### PR TITLE
Adds Grpc.newManagedChannel(String, ChannelCredentials, NameResolverR…

### DIFF
--- a/api/src/main/java/io/grpc/Grpc.java
+++ b/api/src/main/java/io/grpc/Grpc.java
@@ -102,6 +102,15 @@ public final class Grpc {
   }
 
   /**
+   * Creates a channel builder with a target string, credentials and nameResolverRegistry.
+   */
+  public static ManagedChannelBuilder<?> newChannelBuilderForNameResolverRegistry(String target,
+      ChannelCredentials creds, NameResolverRegistry nameResolverRegistry) {
+    return ManagedChannelRegistry.getDefaultRegistry().newChannelBuilder(nameResolverRegistry,
+      target, creds);
+  }
+
+  /**
    * Creates a channel builder from a host, port, and credentials. The host and port are combined to
    * form an authority string and then passed to {@link #newChannelBuilder(String,
    * ChannelCredentials)}. IPv6 addresses are properly surrounded by square brackets ("[]").

--- a/api/src/main/java/io/grpc/Grpc.java
+++ b/api/src/main/java/io/grpc/Grpc.java
@@ -104,7 +104,7 @@ public final class Grpc {
   /**
    * Creates a channel builder with a target string, credentials and nameResolverRegistry.
    */
-  public static ManagedChannelBuilder<?> newChannelBuilderForNameResolverRegistry(String target,
+  public static ManagedChannelBuilder<?> newChannelBuilder(String target,
       ChannelCredentials creds, NameResolverRegistry nameResolverRegistry) {
     return ManagedChannelRegistry.getDefaultRegistry().newChannelBuilder(nameResolverRegistry,
       target, creds);

--- a/api/src/main/java/io/grpc/Grpc.java
+++ b/api/src/main/java/io/grpc/Grpc.java
@@ -102,12 +102,32 @@ public final class Grpc {
   }
 
   /**
-   * Creates a channel builder with a target string, credentials and nameResolverRegistry.
+   * Creates a channel builder with a target string, credentials, and a specific
+   * name resolver registry.
+   *
+   * <p>This method uses the {@link ManagedChannelRegistry#getDefaultRegistry()} to
+   * find an appropriate underlying transport provider based on the target and credentials.
+   * The provided {@code nameResolverRegistry} is used to resolve the target address
+   * into physical addresses (e.g., DNS or custom schemes).
+   *
+   * @param target the target URI for the channel, such as {@code "localhost:8080"}
+   *     or {@code "dns:///example.com"}
+   * @param creds the channel credentials to use for secure communication
+   * @param nameResolverRegistry the registry used to look up {@link NameResolver}
+   *     providers for the target
+   * @return a {@link ManagedChannelBuilder} instance configured with the given parameters
+   * @throws IllegalArgumentException if no provider is available for the given target
+   *     or credentials
+   * @since 1.79.0
    */
-  public static ManagedChannelBuilder<?> newChannelBuilder(String target,
-      ChannelCredentials creds, NameResolverRegistry nameResolverRegistry) {
-    return ManagedChannelRegistry.getDefaultRegistry().newChannelBuilder(nameResolverRegistry,
-      target, creds);
+  public static ManagedChannelBuilder<?> newChannelBuilder(
+      String target,
+      ChannelCredentials creds,
+      NameResolverRegistry nameResolverRegistry) {
+    return ManagedChannelRegistry.getDefaultRegistry().newChannelBuilder(
+        nameResolverRegistry,
+        target,
+        creds);
   }
 
   /**

--- a/api/src/main/java/io/grpc/Grpc.java
+++ b/api/src/main/java/io/grpc/Grpc.java
@@ -105,9 +105,7 @@ public final class Grpc {
    * Creates a channel builder with a target string, credentials, and a specific
    * name resolver registry.
    *
-   * <p>This method uses the {@link ManagedChannelRegistry#getDefaultRegistry()} to
-   * find an appropriate underlying transport provider based on the target and credentials.
-   * The provided {@code nameResolverRegistry} is used to resolve the target address
+   * <p>The provided {@code nameResolverRegistry} is used to resolve the target address
    * into physical addresses (e.g., DNS or custom schemes).
    *
    * @param target the target URI for the channel, such as {@code "localhost:8080"}
@@ -118,8 +116,9 @@ public final class Grpc {
    * @return a {@link ManagedChannelBuilder} instance configured with the given parameters
    * @throws IllegalArgumentException if no provider is available for the given target
    *     or credentials
-   * @since 1.79.0
+   * @since 1.81.0
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/12694")
   public static ManagedChannelBuilder<?> newChannelBuilder(
       String target,
       ChannelCredentials creds,

--- a/api/src/main/java/io/grpc/Grpc.java
+++ b/api/src/main/java/io/grpc/Grpc.java
@@ -116,7 +116,7 @@ public final class Grpc {
    * @return a {@link ManagedChannelBuilder} instance configured with the given parameters
    * @throws IllegalArgumentException if no provider is available for the given target
    *     or credentials
-   * @since 1.81.0
+   * @since 1.83.0
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/12694")
   public static ManagedChannelBuilder<?> newChannelBuilder(

--- a/api/src/main/java/io/grpc/ManagedChannelProvider.java
+++ b/api/src/main/java/io/grpc/ManagedChannelProvider.java
@@ -82,8 +82,9 @@ public abstract class ManagedChannelProvider {
   }
 
   /**
-   * Creates a channel builder with a target string, credentials, NameResolverRegistry adn NameResolverProvider.
-   * Returns an error-string result if unable to understand the credentials.
+   * Creates a channel builder with a target string, credentials, NameResolverRegistry
+   * and NameResolverProvider. Returns an error-string result if unable to
+   * understand the credentials.
    */
   protected NewChannelBuilderResult newChannelBuilder(String target, ChannelCredentials creds,
                                                       NameResolverRegistry nameResolverRegistry,

--- a/api/src/main/java/io/grpc/ManagedChannelProvider.java
+++ b/api/src/main/java/io/grpc/ManagedChannelProvider.java
@@ -103,7 +103,6 @@ public abstract class ManagedChannelProvider {
   protected NewChannelBuilderResult newChannelBuilder(String target, ChannelCredentials creds,
                                                       NameResolverRegistry nameResolverRegistry,
                                                       NameResolverProvider nameResolverProvider) {
-    // Implementation note: Currently delegates to the simplified version
     return newChannelBuilder(target, creds);
   }
 

--- a/api/src/main/java/io/grpc/ManagedChannelProvider.java
+++ b/api/src/main/java/io/grpc/ManagedChannelProvider.java
@@ -82,13 +82,28 @@ public abstract class ManagedChannelProvider {
   }
 
   /**
-   * Creates a channel builder with a target string, credentials, NameResolverRegistry
-   * and NameResolverProvider. Returns an error-string result if unable to
-   * understand the credentials.
+   * Creates a channel builder using the provided target, credentials, and resolution
+   * components.
+   *
+   * <p>This method allows for fine-grained control over name resolution by providing
+   * both a {@link NameResolverRegistry} and a specific {@link NameResolverProvider}.
+   * Unlike the public factory methods, this returns a {@link NewChannelBuilderResult},
+   * which may contain an error string if the provided credentials or target are
+   * not supported by this provider.
+   *
+   * @param target the target URI for the channel
+   * @param creds the channel credentials to use
+   * @param nameResolverRegistry the registry used for looking up name resolvers
+   * @param nameResolverProvider a specific provider to use, or {@code null} to
+   *     search the registry
+   * @return a {@link NewChannelBuilderResult} containing either the builder or an
+   *     error description
+   * @since 1.79.0
    */
   protected NewChannelBuilderResult newChannelBuilder(String target, ChannelCredentials creds,
                                                       NameResolverRegistry nameResolverRegistry,
                                                       NameResolverProvider nameResolverProvider) {
+    // Implementation note: Currently delegates to the simplified version
     return newChannelBuilder(target, creds);
   }
 

--- a/api/src/main/java/io/grpc/ManagedChannelProvider.java
+++ b/api/src/main/java/io/grpc/ManagedChannelProvider.java
@@ -82,6 +82,16 @@ public abstract class ManagedChannelProvider {
   }
 
   /**
+   * Creates a channel builder with a target string, credentials, NameResolverRegistry adn NameResolverProvider.
+   * Returns an error-string result if unable to understand the credentials.
+   */
+  protected NewChannelBuilderResult newChannelBuilder(String target, ChannelCredentials creds,
+                                                      NameResolverRegistry nameResolverRegistry,
+                                                      NameResolverProvider nameResolverProvider) {
+    return newChannelBuilder(target, creds);
+  }
+
+  /**
    * Returns the {@link SocketAddress} types this ManagedChannelProvider supports.
    */
   protected abstract Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes();

--- a/api/src/main/java/io/grpc/ManagedChannelProvider.java
+++ b/api/src/main/java/io/grpc/ManagedChannelProvider.java
@@ -87,7 +87,7 @@ public abstract class ManagedChannelProvider {
    *
    * <p>This method allows for fine-grained control over name resolution by providing
    * both a {@link NameResolverRegistry} and a specific {@link NameResolverProvider}.
-   * Unlike the public factory methods, this returns a {@link NewChannelBuilderResult},
+   * This returns a {@link NewChannelBuilderResult},
    * which may contain an error string if the provided credentials or target are
    * not supported by this provider.
    *

--- a/api/src/main/java/io/grpc/ManagedChannelProvider.java
+++ b/api/src/main/java/io/grpc/ManagedChannelProvider.java
@@ -98,7 +98,7 @@ public abstract class ManagedChannelProvider {
    *     search the registry
    * @return a {@link NewChannelBuilderResult} containing either the builder or an
    *     error description
-   * @since 1.79.0
+   * @since 1.81.0
    */
   protected NewChannelBuilderResult newChannelBuilder(String target, ChannelCredentials creds,
                                                       NameResolverRegistry nameResolverRegistry,

--- a/api/src/main/java/io/grpc/ManagedChannelProvider.java
+++ b/api/src/main/java/io/grpc/ManagedChannelProvider.java
@@ -98,7 +98,7 @@ public abstract class ManagedChannelProvider {
    *     search the registry
    * @return a {@link NewChannelBuilderResult} containing either the builder or an
    *     error description
-   * @since 1.81.0
+   * @since 1.83.0
    */
   protected NewChannelBuilderResult newChannelBuilder(String target, ChannelCredentials creds,
                                                       NameResolverRegistry nameResolverRegistry,

--- a/api/src/main/java/io/grpc/ManagedChannelRegistry.java
+++ b/api/src/main/java/io/grpc/ManagedChannelRegistry.java
@@ -197,7 +197,7 @@ public final class ManagedChannelRegistry {
         continue;
       }
       ManagedChannelProvider.NewChannelBuilderResult result
-          = provider.newChannelBuilder(target, creds);
+          = provider.newChannelBuilder(target, creds, nameResolverRegistry, nameResolverProvider);
       if (result.getChannelBuilder() != null) {
         return result.getChannelBuilder();
       }

--- a/api/src/main/java/io/grpc/ManagedChannelRegistry.java
+++ b/api/src/main/java/io/grpc/ManagedChannelRegistry.java
@@ -158,7 +158,6 @@ public final class ManagedChannelRegistry {
     return newChannelBuilder(NameResolverRegistry.getDefaultRegistry(), target, creds);
   }
 
-  @VisibleForTesting
   ManagedChannelBuilder<?> newChannelBuilder(NameResolverRegistry nameResolverRegistry,
       String target, ChannelCredentials creds) {
     NameResolverProvider nameResolverProvider = null;

--- a/api/src/main/java/io/grpc/NameResolver.java
+++ b/api/src/main/java/io/grpc/NameResolver.java
@@ -191,7 +191,7 @@ public abstract class NameResolver {
      */
     public NameResolver newNameResolver(Uri targetUri, final Args args) {
       // Not every io.grpc.Uri can be converted but in the ordinary ManagedChannel creation flow,
-      // any IllegalArgumentException thrown here would happened anyway, just earlier. That's
+      // any IllegalArgumentException thrown here would have happened anyway, just earlier. That's
       // because parse/toString is transparent so java.net.URI#create here sees the original target
       // string just like it did before the io.grpc.Uri migration.
       //

--- a/api/src/main/java/io/grpc/NameResolverProvider.java
+++ b/api/src/main/java/io/grpc/NameResolverProvider.java
@@ -65,7 +65,7 @@ public abstract class NameResolverProvider extends NameResolver.Factory {
    *
    * @since 1.40.0
    * */
-  protected String getScheme() {
+  public String getScheme() {
     return getDefaultScheme();
   }
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -310,6 +310,49 @@ public final class ManagedChannelImplBuilder
   }
 
   /**
+   * Creates a new managed channel builder with a target string, which can be
+   * either a valid {@link io.grpc.NameResolver}-compliant URI, or an authority
+   * string. Transport
+   * implementors must provide client transport factory builder, and may set
+   * custom channel default
+   * port provider.
+   *
+   * @param channelCreds         The ChannelCredentials provided by the user.
+   *                             These may be used when
+   *                             creating derivative channels.
+   * @param nameResolverRegistry the registry used to look up name resolvers.
+   * @param nameResolverProvider the provider used to look up name resolvers.
+   */
+  public ManagedChannelImplBuilder(
+      String target, @Nullable ChannelCredentials channelCreds, @Nullable CallCredentials callCreds,
+      ClientTransportFactoryBuilder clientTransportFactoryBuilder,
+      @Nullable ChannelBuilderDefaultPortProvider channelBuilderDefaultPortProvider,
+      @Nullable NameResolverRegistry nameResolverRegistry,
+      @Nullable NameResolverProvider nameResolverProvider) {
+    this.target = checkNotNull(target, "target");
+    this.channelCredentials = channelCreds;
+    this.callCredentials = callCreds;
+    this.clientTransportFactoryBuilder = checkNotNull(clientTransportFactoryBuilder,
+        "clientTransportFactoryBuilder");
+    this.directServerAddress = null;
+
+    if (channelBuilderDefaultPortProvider != null) {
+      this.channelBuilderDefaultPortProvider = channelBuilderDefaultPortProvider;
+    } else {
+      this.channelBuilderDefaultPortProvider = new ManagedChannelDefaultPortProvider();
+    }
+    if (nameResolverRegistry != null) {
+      this.nameResolverRegistry = nameResolverRegistry;
+    }
+    if (nameResolverProvider != null) {
+      this.nameResolverProvider = nameResolverProvider;
+    }
+
+    // TODO(dnvindhya): Move configurator to all the individual builders
+    InternalConfiguratorRegistry.configureChannelBuilder(this);
+  }
+
+  /**
    * Returns a target string for the SocketAddress. It is only used as a placeholder, because
    * DirectAddressNameResolverProvider will not actually try to use it. However, it must be a valid
    * URI.
@@ -438,13 +481,8 @@ public final class ManagedChannelImplBuilder
     return this;
   }
 
-  public ManagedChannelImplBuilder nameResolverRegistry(NameResolverRegistry resolverRegistry) {
+  ManagedChannelImplBuilder nameResolverRegistry(NameResolverRegistry resolverRegistry) {
     this.nameResolverRegistry = resolverRegistry;
-    return this;
-  }
-
-  public ManagedChannelImplBuilder nameResolverProvider(NameResolverProvider provider) {
-    this.nameResolverProvider = provider;
     return this;
   }
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -155,7 +155,7 @@ public final class ManagedChannelImplBuilder
 
   private final List<ClientInterceptor> interceptors = new ArrayList<>();
   NameResolverRegistry nameResolverRegistry = NameResolverRegistry.getDefaultRegistry();
-  boolean registryProvided;
+
   @Nullable
   NameResolverProvider nameResolverProvider;
 
@@ -344,7 +344,6 @@ public final class ManagedChannelImplBuilder
     }
     if (nameResolverRegistry != null) {
       this.nameResolverRegistry = nameResolverRegistry;
-      this.registryProvided = true;
     }
     if (nameResolverProvider != null) {
       this.nameResolverProvider = nameResolverProvider;
@@ -469,8 +468,7 @@ public final class ManagedChannelImplBuilder
     Preconditions.checkState(directServerAddress == null,
         "directServerAddress is set (%s), which forbids the use of NameResolverFactory",
         directServerAddress);
-    Preconditions.checkState(!registryProvided,
-        "nameResolverRegistry is already set, which forbids the use of NameResolverFactory");
+
     if (resolverFactory != null) {
       NameResolverRegistry reg = new NameResolverRegistry();
       if (resolverFactory instanceof NameResolverProvider) {
@@ -487,7 +485,6 @@ public final class ManagedChannelImplBuilder
 
   ManagedChannelImplBuilder nameResolverRegistry(NameResolverRegistry resolverRegistry) {
     this.nameResolverRegistry = resolverRegistry;
-    this.registryProvided = true;
     return this;
   }
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -294,20 +294,14 @@ public final class ManagedChannelImplBuilder
       String target, @Nullable ChannelCredentials channelCreds, @Nullable CallCredentials callCreds,
       ClientTransportFactoryBuilder clientTransportFactoryBuilder,
       @Nullable ChannelBuilderDefaultPortProvider channelBuilderDefaultPortProvider) {
-    this.target = checkNotNull(target, "target");
-    this.channelCredentials = channelCreds;
-    this.callCredentials = callCreds;
-    this.clientTransportFactoryBuilder = checkNotNull(clientTransportFactoryBuilder,
-        "clientTransportFactoryBuilder");
-    this.directServerAddress = null;
-
-    if (channelBuilderDefaultPortProvider != null) {
-      this.channelBuilderDefaultPortProvider = channelBuilderDefaultPortProvider;
-    } else {
-      this.channelBuilderDefaultPortProvider = new ManagedChannelDefaultPortProvider();
-    }
-    // TODO(dnvindhya): Move configurator to all the individual builders
-    InternalConfiguratorRegistry.configureChannelBuilder(this);
+    this(
+        target,
+        channelCreds,
+        callCreds,
+        clientTransportFactoryBuilder,
+        channelBuilderDefaultPortProvider,
+        null,
+        null);
   }
 
   /**
@@ -337,17 +331,15 @@ public final class ManagedChannelImplBuilder
         "clientTransportFactoryBuilder");
     this.directServerAddress = null;
 
-    if (channelBuilderDefaultPortProvider != null) {
-      this.channelBuilderDefaultPortProvider = channelBuilderDefaultPortProvider;
-    } else {
-      this.channelBuilderDefaultPortProvider = new ManagedChannelDefaultPortProvider();
-    }
-    if (nameResolverRegistry != null) {
-      this.nameResolverRegistry = nameResolverRegistry;
-    }
-    if (nameResolverProvider != null) {
-      this.nameResolverProvider = nameResolverProvider;
-    }
+    this.channelBuilderDefaultPortProvider =
+        channelBuilderDefaultPortProvider != null
+            ? channelBuilderDefaultPortProvider
+            : new ManagedChannelDefaultPortProvider();
+    this.nameResolverRegistry =
+        nameResolverRegistry != null
+            ? nameResolverRegistry
+            : NameResolverRegistry.getDefaultRegistry();
+    this.nameResolverProvider = nameResolverProvider;
 
     // TODO(dnvindhya): Move configurator to all the individual builders
     InternalConfiguratorRegistry.configureChannelBuilder(this);
@@ -908,33 +900,32 @@ public final class ManagedChannelImplBuilder
     if (targetUri != null) {
       // For "localhost:8080" this would likely cause provider to be null, because "localhost" is
       // parsed as the scheme. Will hit the next case and try "dns:///localhost:8080".
-      provider = nameResolverProvider;
-      if (provider == null) {
+      // Use the explicit provider if its scheme matches the target URI.
+      if (nameResolverProvider != null
+          && targetUri.getScheme().equals(nameResolverProvider.getDefaultScheme())) {
+        provider = nameResolverProvider;
+      } else {
         provider = nameResolverRegistry.getProviderForScheme(targetUri.getScheme());
       }
     }
 
-    if (!URI_PATTERN.matcher(target).matches()) {
+    if (provider == null && !URI_PATTERN.matcher(target).matches()) {
       // It doesn't look like a URI target. Maybe it's an authority string. Try with
       // the default scheme from the registry (if provider is not specified) or
       // the provider's default scheme (if provider is specified).
-      String scheme = (provider != null)
-          ? provider.getDefaultScheme()
-          : (nameResolverProvider != null
-              ? nameResolverProvider.getDefaultScheme()
-              : nameResolverRegistry.getDefaultScheme());
+      String scheme = nameResolverProvider != null
+          ? nameResolverProvider.getDefaultScheme()
+          : nameResolverRegistry.getDefaultScheme();
       try {
         targetUri = new URI(scheme, "", "/" + target, null);
       } catch (URISyntaxException e) {
-        // Should not happen because we just validated the URI.
+        // Should not be possible
         throw new IllegalArgumentException(e);
       }
-      if (provider == null) {
-        if (nameResolverProvider != null) {
-          provider = nameResolverProvider;
-        } else {
-          provider = nameResolverRegistry.getProviderForScheme(targetUri.getScheme());
-        }
+      if (nameResolverProvider != null) {
+        provider = nameResolverProvider;
+      } else {
+        provider = nameResolverRegistry.getProviderForScheme(targetUri.getScheme());
       }
     }
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -762,7 +762,7 @@ public final class ManagedChannelImplBuilder
         clientTransportFactoryBuilder.buildClientTransportFactory();
     ResolvedNameResolver resolvedResolver =
         InternalFeatureFlags.getRfc3986UrisEnabled()
-            ? getNameResolverProviderRfc3986(target, nameResolverRegistry)
+            ? getNameResolverProviderRfc3986(target, nameResolverRegistry, nameResolverProvider)
             : getNameResolverProvider(target, nameResolverRegistry, nameResolverProvider);
     resolvedResolver.checkAddressTypes(clientTransportFactory.getSupportedSocketAddressTypes());
     return new ManagedChannelOrphanWrapper(new ManagedChannelImpl(
@@ -902,7 +902,7 @@ public final class ManagedChannelImplBuilder
       // parsed as the scheme. Will hit the next case and try "dns:///localhost:8080".
       // Use the explicit provider if its scheme matches the target URI.
       if (nameResolverProvider != null
-          && targetUri.getScheme().equals(nameResolverProvider.getDefaultScheme())) {
+          && targetUri.getScheme().equals(nameResolverProvider.getScheme())) {
         provider = nameResolverProvider;
       } else {
         provider = nameResolverRegistry.getProviderForScheme(targetUri.getScheme());
@@ -914,7 +914,7 @@ public final class ManagedChannelImplBuilder
       // the default scheme from the registry (if provider is not specified) or
       // the provider's default scheme (if provider is specified).
       String scheme = nameResolverProvider != null
-          ? nameResolverProvider.getDefaultScheme()
+          ? nameResolverProvider.getScheme()
           : nameResolverRegistry.getDefaultScheme();
       try {
         targetUri = new URI(scheme, "", "/" + target, null);
@@ -940,7 +940,8 @@ public final class ManagedChannelImplBuilder
 
   @VisibleForTesting
   static ResolvedNameResolver getNameResolverProviderRfc3986(
-      String target, NameResolverRegistry nameResolverRegistry) {
+      String target, NameResolverRegistry nameResolverRegistry,
+      NameResolverProvider nameResolverProvider) {
     // Finding a NameResolver. Try using the target string as the URI. If that fails, try prepending
     // "dns:///".
     NameResolverProvider provider = null;
@@ -955,15 +956,25 @@ public final class ManagedChannelImplBuilder
     if (targetUri != null) {
       // For "localhost:8080" this would likely cause provider to be null, because "localhost" is
       // parsed as the scheme. Will hit the next case and try "dns:///localhost:8080".
-      provider = nameResolverRegistry.getProviderForScheme(targetUri.getScheme());
+      // Use the explicit provider if its scheme matches the target URI.
+      if (nameResolverProvider != null
+          && targetUri.getScheme().equals(nameResolverProvider.getScheme())) {
+        provider = nameResolverProvider;
+      } else {
+        provider = nameResolverRegistry.getProviderForScheme(targetUri.getScheme());
+      }
     }
 
     if (provider == null && !URI_PATTERN.matcher(target).matches()) {
-      // It doesn't look like a URI target. Maybe it's an authority string. Try with the default
-      // scheme from the registry.
+      // It doesn't look like a URI target. Maybe it's an authority string. Try with
+      // the default scheme from the registry (if provider is not specified) or
+      // the provider's default scheme (if provider is specified).
+      String scheme = nameResolverProvider != null
+          ? nameResolverProvider.getScheme()
+          : nameResolverRegistry.getDefaultScheme();
       targetUri =
           Uri.newBuilder()
-              .setScheme(nameResolverRegistry.getDefaultScheme())
+              .setScheme(scheme)
               .setHost("")
               .setPath("/" + target)
               .build();

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
@@ -54,6 +54,7 @@ import io.grpc.StaticTestingClassLoader;
 import io.grpc.internal.ManagedChannelImplBuilder.ChannelBuilderDefaultPortProvider;
 import io.grpc.internal.ManagedChannelImplBuilder.ClientTransportFactoryBuilder;
 import io.grpc.internal.ManagedChannelImplBuilder.FixedPortProvider;
+import io.grpc.internal.ManagedChannelImplBuilder.ResolvedNameResolver;
 import io.grpc.internal.ManagedChannelImplBuilder.UnsupportedClientTransportFactoryBuilder;
 import io.grpc.testing.GrpcCleanupRule;
 import java.net.InetSocketAddress;
@@ -386,7 +387,7 @@ public class ManagedChannelImplBuilderTest {
     builder = new ManagedChannelImplBuilder(DUMMY_AUTHORITY_VALID,
         mockClientTransportFactoryBuilder, new FixedPortProvider(DUMMY_PORT));
     try {
-      ManagedChannel unused = grpcCleanupRule.register(builder.build());
+      grpcCleanupRule.register(builder.build());
       fail("Should fail");
     } catch (IllegalArgumentException e) {
       assertThat(e)
@@ -409,7 +410,7 @@ public class ManagedChannelImplBuilderTest {
     builder = new ManagedChannelImplBuilder(DUMMY_AUTHORITY_VALID,
         mockClientTransportFactoryBuilder, new FixedPortProvider(DUMMY_PORT));
     // should not fail
-    ManagedChannel unused = grpcCleanupRule.register(builder.build());
+    grpcCleanupRule.register(builder.build());
   }
 
   @Test
@@ -803,6 +804,7 @@ public class ManagedChannelImplBuilderTest {
   private static class CustomSocketAddress extends SocketAddress {}
 
   @Test
+  @SuppressWarnings("deprecation")
   public void nameResolverFactory_notAllowedAfterRegistry() {
     NameResolverRegistry registry = new NameResolverRegistry();
     builder.nameResolverRegistry(registry);
@@ -870,7 +872,7 @@ public class ManagedChannelImplBuilderTest {
       }
     };
 
-    ManagedChannelImplBuilder.ResolvedNameResolver resolved = ManagedChannelImplBuilder.getNameResolverProvider(
+    ResolvedNameResolver resolved = ManagedChannelImplBuilder.getNameResolverProvider(
         target, registry, explicitProvider);
 
     // Should prefer explicit provider if scheme matches?
@@ -913,7 +915,7 @@ public class ManagedChannelImplBuilderTest {
     NameResolverRegistry registry = new NameResolverRegistry();
     registry.register(registryProvider);
 
-    ManagedChannelImplBuilder.ResolvedNameResolver resolved = ManagedChannelImplBuilder.getNameResolverProvider(
+    ResolvedNameResolver resolved = ManagedChannelImplBuilder.getNameResolverProvider(
         target, registry, null);
 
     assertThat(resolved.provider).isSameInstanceAs(registryProvider);

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
@@ -804,19 +804,6 @@ public class ManagedChannelImplBuilderTest {
   private static class CustomSocketAddress extends SocketAddress {}
 
   @Test
-  @SuppressWarnings("deprecation")
-  public void nameResolverFactory_notAllowedAfterRegistry() {
-    NameResolverRegistry registry = new NameResolverRegistry();
-    builder.nameResolverRegistry(registry);
-    try {
-      builder.nameResolverFactory(mock(NameResolver.Factory.class));
-      fail("Should throw");
-    } catch (IllegalStateException e) {
-      assertThat(e).hasMessageThat().contains("nameResolverRegistry is already set");
-    }
-  }
-
-  @Test
   public void getNameResolverProvider_explicitProviderWithIpTarget() {
     String target = "127.0.0.1:8080";
     NameResolverRegistry registry = new NameResolverRegistry();

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
@@ -808,6 +808,7 @@ public class ManagedChannelImplBuilderTest {
     String target = "127.0.0.1:8080";
     NameResolverRegistry registry = new NameResolverRegistry();
     NameResolverProvider explicitProvider = mock(NameResolverProvider.class);
+    when(explicitProvider.getScheme()).thenReturn("dns");
     when(explicitProvider.getDefaultScheme()).thenReturn("dns");
 
     ManagedChannelImplBuilder.ResolvedNameResolver resolved;
@@ -823,6 +824,7 @@ public class ManagedChannelImplBuilderTest {
     String target = "::1";
     NameResolverRegistry registry = new NameResolverRegistry();
     NameResolverProvider explicitProvider = mock(NameResolverProvider.class);
+    when(explicitProvider.getScheme()).thenReturn("dns");
     when(explicitProvider.getDefaultScheme()).thenReturn("dns");
 
     ManagedChannelImplBuilder.ResolvedNameResolver resolved;
@@ -906,5 +908,44 @@ public class ManagedChannelImplBuilderTest {
         target, registry, null);
 
     assertThat(resolved.provider).isSameInstanceAs(registryProvider);
+  }
+
+  @Test
+  public void getNameResolverProviderRfc3986_explicitProviderWithAuthorityTarget() {
+    String target = "authority-target";
+    NameResolverRegistry registry = new NameResolverRegistry();
+    NameResolverProvider explicitProvider = new NameResolverProvider() {
+      @Override
+      public NameResolver newNameResolver(URI targetUri, NameResolver.Args args) {
+        return null;
+      }
+
+      @Override
+      public String getScheme() {
+        return "customscheme";
+      }
+
+      @Override
+      public String getDefaultScheme() {
+        return "customscheme";
+      }
+
+      @Override
+      protected boolean isAvailable() {
+        return true;
+      }
+
+      @Override
+      protected int priority() {
+        return 5;
+      }
+    };
+    registry.register(explicitProvider);
+
+    ManagedChannelImplBuilder.ResolvedNameResolver resolved = ManagedChannelImplBuilder
+        .getNameResolverProviderRfc3986(target, registry, explicitProvider);
+
+    assertThat(resolved.provider).isSameInstanceAs(explicitProvider);
+    assertThat(resolved.targetUri.toString()).isEqualTo("customscheme:///authority-target");
   }
 }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverRfc3986Test.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverRfc3986Test.java
@@ -136,7 +136,7 @@ public class ManagedChannelImplGetNameResolverRfc3986Test {
     NameResolverRegistry nameResolverRegistry = new NameResolverRegistry();
     try {
       ManagedChannelImplBuilder.getNameResolverProviderRfc3986(
-          "foo.googleapis.com:8080", nameResolverRegistry);
+          "foo.googleapis.com:8080", nameResolverRegistry, null);
       fail("Should fail");
     } catch (IllegalArgumentException e) {
       // expected
@@ -148,7 +148,7 @@ public class ManagedChannelImplGetNameResolverRfc3986Test {
     NameResolverRegistry nameResolverRegistry = getTestRegistry("testscheme");
     try {
       ManagedChannelImplBuilder.getNameResolverProviderRfc3986(
-              "testscheme:///foo.googleapis.com:8080", nameResolverRegistry)
+              "testscheme:///foo.googleapis.com:8080", nameResolverRegistry, null)
           .checkAddressTypes(Collections.singleton(CustomSocketAddress.class));
       fail("Should fail");
     } catch (IllegalArgumentException e) {
@@ -163,7 +163,8 @@ public class ManagedChannelImplGetNameResolverRfc3986Test {
   private void testValidTarget(String target, String expectedUriString, Uri expectedUri) {
     NameResolverRegistry nameResolverRegistry = getTestRegistry(expectedUri.getScheme());
     ManagedChannelImplBuilder.ResolvedNameResolver resolved =
-        ManagedChannelImplBuilder.getNameResolverProviderRfc3986(target, nameResolverRegistry);
+        ManagedChannelImplBuilder.getNameResolverProviderRfc3986(target, nameResolverRegistry,
+            null);
     assertThat(resolved.provider).isInstanceOf(FakeNameResolverProvider.class);
     assertThat(resolved.targetUri).isEqualTo(wrap(expectedUri));
     assertThat(resolved.targetUri.toString()).isEqualTo(expectedUriString);
@@ -174,7 +175,8 @@ public class ManagedChannelImplGetNameResolverRfc3986Test {
 
     try {
       ManagedChannelImplBuilder.ResolvedNameResolver resolved =
-          ManagedChannelImplBuilder.getNameResolverProviderRfc3986(target, nameResolverRegistry);
+          ManagedChannelImplBuilder.getNameResolverProviderRfc3986(target, nameResolverRegistry,
+              null);
       FakeNameResolverProvider nameResolverProvider = (FakeNameResolverProvider) resolved.provider;
       fail("Should have failed, but got resolver provider " + nameResolverProvider);
     } catch (IllegalArgumentException e) {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplGetNameResolverTest.java
@@ -118,7 +118,8 @@ public class ManagedChannelImplGetNameResolverTest {
     NameResolverRegistry nameResolverRegistry = new NameResolverRegistry();
     try {
       ManagedChannelImplBuilder.getNameResolverProvider(
-          "foo.googleapis.com:8080", nameResolverRegistry);
+          "foo.googleapis.com:8080", nameResolverRegistry,
+          null);
       fail("Should fail");
     } catch (IllegalArgumentException e) {
       // expected
@@ -130,7 +131,7 @@ public class ManagedChannelImplGetNameResolverTest {
     NameResolverRegistry nameResolverRegistry = getTestRegistry("testscheme");
     try {
       ManagedChannelImplBuilder.getNameResolverProvider(
-              "testscheme:///foo.googleapis.com:8080", nameResolverRegistry)
+              "testscheme:///foo.googleapis.com:8080", nameResolverRegistry, null)
           .checkAddressTypes(Collections.singleton(CustomSocketAddress.class));
       fail("Should fail");
     } catch (IllegalArgumentException e) {
@@ -143,7 +144,7 @@ public class ManagedChannelImplGetNameResolverTest {
   private void testValidTarget(String target, String expectedUriString, URI expectedUri) {
     NameResolverRegistry nameResolverRegistry = getTestRegistry(expectedUri.getScheme());
     ManagedChannelImplBuilder.ResolvedNameResolver resolved =
-        ManagedChannelImplBuilder.getNameResolverProvider(target, nameResolverRegistry);
+        ManagedChannelImplBuilder.getNameResolverProvider(target, nameResolverRegistry, null);
     assertThat(resolved.provider).isInstanceOf(FakeNameResolverProvider.class);
     assertThat(resolved.targetUri).isEqualTo(wrap(expectedUri));
     assertThat(resolved.targetUri.toString()).isEqualTo(expectedUriString);
@@ -154,7 +155,7 @@ public class ManagedChannelImplGetNameResolverTest {
 
     try {
       ManagedChannelImplBuilder.ResolvedNameResolver resolved =
-          ManagedChannelImplBuilder.getNameResolverProvider(target, nameResolverRegistry);
+          ManagedChannelImplBuilder.getNameResolverProvider(target, nameResolverRegistry, null);
       FakeNameResolverProvider nameResolverProvider = (FakeNameResolverProvider) resolved.provider;
       fail("Should have failed, but got resolver provider " + nameResolverProvider);
     } catch (IllegalArgumentException e) {

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -209,10 +209,20 @@ public final class NettyChannelBuilder extends ForwardingChannelBuilder2<NettyCh
   NettyChannelBuilder(
       String target, ChannelCredentials channelCreds, CallCredentials callCreds,
       ProtocolNegotiator.ClientFactory negotiator) {
+    this(target, channelCreds, callCreds, negotiator, null, null);
+  }
+
+  NettyChannelBuilder(
+      String target, ChannelCredentials channelCreds, CallCredentials callCreds,
+      ProtocolNegotiator.ClientFactory negotiator,
+      NameResolverRegistry nameResolverRegistry,
+      NameResolverProvider nameResolverProvider) {
     managedChannelImplBuilder = new ManagedChannelImplBuilder(
         target, channelCreds, callCreds,
         new NettyChannelTransportFactoryBuilder(),
-        new NettyChannelDefaultPortProvider());
+        new NettyChannelDefaultPortProvider(),
+        nameResolverRegistry,
+        nameResolverProvider);
     this.protocolNegotiatorFactory = checkNotNull(negotiator, "negotiator");
     this.freezeProtocolNegotiatorFactory = true;
   }
@@ -710,23 +720,7 @@ public final class NettyChannelBuilder extends ForwardingChannelBuilder2<NettyCh
     return this;
   }
 
-  /**
-   * Sets the registry used for looking up name resolvers.
-   */
-  @CanIgnoreReturnValue
-  public NettyChannelBuilder nameResolverRegistry(NameResolverRegistry registry) {
-    managedChannelImplBuilder.nameResolverRegistry(registry);
-    return this;
-  }
 
-  /**
-   * Sets the {@link io.grpc.NameResolverProvider} to use.
-   */
-  @CanIgnoreReturnValue
-  public NettyChannelBuilder nameResolverProvider(NameResolverProvider provider) {
-    managedChannelImplBuilder.nameResolverProvider(provider);
-    return this;
-  }
 
   static Collection<Class<? extends SocketAddress>> getSupportedSocketAddressTypes() {
     return Collections.singleton(InetSocketAddress.class);

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -38,6 +38,8 @@ import io.grpc.ForwardingChannelBuilder2;
 import io.grpc.HttpConnectProxiedSocketAddress;
 import io.grpc.Internal;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.NameResolverProvider;
+import io.grpc.NameResolverRegistry;
 import io.grpc.internal.AtomicBackoff;
 import io.grpc.internal.ClientTransportFactory;
 import io.grpc.internal.ConnectionClientTransport;
@@ -705,6 +707,24 @@ public final class NettyChannelBuilder extends ForwardingChannelBuilder2<NettyCh
   @VisibleForTesting
   NettyChannelBuilder setTransportTracerFactory(TransportTracer.Factory transportTracerFactory) {
     this.transportTracerFactory = transportTracerFactory;
+    return this;
+  }
+
+  /**
+   * Sets the registry used for looking up name resolvers.
+   */
+  @CanIgnoreReturnValue
+  public NettyChannelBuilder nameResolverRegistry(NameResolverRegistry registry) {
+    managedChannelImplBuilder.nameResolverRegistry(registry);
+    return this;
+  }
+
+  /**
+   * Sets the {@link io.grpc.NameResolverProvider} to use.
+   */
+  @CanIgnoreReturnValue
+  public NettyChannelBuilder nameResolverProvider(NameResolverProvider provider) {
+    managedChannelImplBuilder.nameResolverProvider(provider);
     return this;
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyChannelProvider.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelProvider.java
@@ -19,6 +19,8 @@ package io.grpc.netty;
 import io.grpc.ChannelCredentials;
 import io.grpc.Internal;
 import io.grpc.ManagedChannelProvider;
+import io.grpc.NameResolverProvider;
+import io.grpc.NameResolverRegistry;
 import java.net.SocketAddress;
 import java.util.Collection;
 
@@ -53,6 +55,25 @@ public final class NettyChannelProvider extends ManagedChannelProvider {
     }
     return NewChannelBuilderResult.channelBuilder(
         new NettyChannelBuilder(target, creds, result.callCredentials, result.negotiator));
+  }
+
+  @Override
+  public NewChannelBuilderResult newChannelBuilder(String target, ChannelCredentials creds,
+                                                   NameResolverRegistry nameResolverRegistry,
+                                                   NameResolverProvider nameResolverProvider) {
+    ProtocolNegotiators.FromChannelCredentialsResult result = ProtocolNegotiators.from(creds);
+    if (result.error != null) {
+      return NewChannelBuilderResult.error(result.error);
+    }
+    NettyChannelBuilder builder = new NettyChannelBuilder(target, creds,
+        result.callCredentials, result.negotiator);
+    if (nameResolverRegistry != null) {
+      builder.nameResolverRegistry(nameResolverRegistry);
+    }
+    if (nameResolverProvider != null) {
+      builder.nameResolverProvider(nameResolverProvider);
+    }
+    return NewChannelBuilderResult.channelBuilder(builder);
   }
 
   @Override

--- a/netty/src/main/java/io/grpc/netty/NettyChannelProvider.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelProvider.java
@@ -66,13 +66,7 @@ public final class NettyChannelProvider extends ManagedChannelProvider {
       return NewChannelBuilderResult.error(result.error);
     }
     NettyChannelBuilder builder = new NettyChannelBuilder(target, creds,
-        result.callCredentials, result.negotiator);
-    if (nameResolverRegistry != null) {
-      builder.nameResolverRegistry(nameResolverRegistry);
-    }
-    if (nameResolverProvider != null) {
-      builder.nameResolverProvider(nameResolverProvider);
-    }
+        result.callCredentials, result.negotiator, nameResolverRegistry, nameResolverProvider);
     return NewChannelBuilderResult.channelBuilder(builder);
   }
 

--- a/netty/src/main/java/io/grpc/netty/UdsNettyChannelProvider.java
+++ b/netty/src/main/java/io/grpc/netty/UdsNettyChannelProvider.java
@@ -20,6 +20,8 @@ import com.google.common.base.Preconditions;
 import io.grpc.ChannelCredentials;
 import io.grpc.Internal;
 import io.grpc.ManagedChannelProvider;
+import io.grpc.NameResolverProvider;
+import io.grpc.NameResolverRegistry;
 import io.grpc.internal.SharedResourcePool;
 import io.netty.channel.unix.DomainSocketAddress;
 import java.net.SocketAddress;
@@ -54,6 +56,21 @@ public final class UdsNettyChannelProvider extends ManagedChannelProvider {
   public NewChannelBuilderResult newChannelBuilder(String target, ChannelCredentials creds) {
     Preconditions.checkState(isAvailable());
     NewChannelBuilderResult result = new NettyChannelProvider().newChannelBuilder(target, creds);
+    if (result.getChannelBuilder() != null) {
+      ((NettyChannelBuilder) result.getChannelBuilder())
+          .eventLoopGroupPool(SharedResourcePool.forResource(Utils.DEFAULT_WORKER_EVENT_LOOP_GROUP))
+          .channelType(Utils.EPOLL_DOMAIN_CLIENT_CHANNEL_TYPE, DomainSocketAddress.class);
+    }
+    return result;
+  }
+
+  @Override
+  public NewChannelBuilderResult newChannelBuilder(String target, ChannelCredentials creds,
+                                                   NameResolverRegistry nameResolverRegistry,
+                                                   NameResolverProvider nameResolverProvider) {
+    Preconditions.checkState(isAvailable());
+    NewChannelBuilderResult result = new NettyChannelProvider().newChannelBuilder(
+        target, creds, nameResolverRegistry, nameResolverProvider);
     if (result.getChannelBuilder() != null) {
       ((NettyChannelBuilder) result.getChannelBuilder())
           .eventLoopGroupPool(SharedResourcePool.forResource(Utils.DEFAULT_WORKER_EVENT_LOOP_GROUP))

--- a/netty/src/test/java/io/grpc/netty/UdsNettyChannelProviderTest.java
+++ b/netty/src/test/java/io/grpc/netty/UdsNettyChannelProviderTest.java
@@ -30,6 +30,7 @@ import io.grpc.ManagedChannelProvider.NewChannelBuilderResult;
 import io.grpc.ManagedChannelRegistryAccessor;
 import io.grpc.NameResolverRegistry;
 import io.grpc.TlsChannelCredentials;
+import io.grpc.internal.testing.FakeNameResolverProvider;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
 import io.grpc.testing.protobuf.SimpleRequest;
@@ -124,9 +125,14 @@ public class UdsNettyChannelProviderTest {
   @Test
   public void managedChannelRegistry_newChannelBuilderForNameResolverRegistry() {
     Assume.assumeTrue(Utils.isEpollAvailable());
+    NameResolverRegistry nameResolverRegistry = new NameResolverRegistry();
+    DomainSocketAddress socketAddress = new DomainSocketAddress("test-server");
+    FakeNameResolverProvider fakeNameResolverProvider = new FakeNameResolverProvider(
+            "unix:///sock.sock", socketAddress);
+    nameResolverRegistry.register(fakeNameResolverProvider);
     ManagedChannelBuilder<?> managedChannelBuilder
-            = Grpc.newChannelBuilderForNameResolverRegistry("unix:///sock.sock",
-             InsecureChannelCredentials.create(), NameResolverRegistry.getDefaultRegistry());
+            = Grpc.newChannelBuilder("unix:///sock.sock",
+            InsecureChannelCredentials.create(), nameResolverRegistry);
     assertThat(managedChannelBuilder).isNotNull();
     ManagedChannel channel = managedChannelBuilder.build();
     assertThat(channel).isNotNull();

--- a/netty/src/test/java/io/grpc/netty/UdsNettyChannelProviderTest.java
+++ b/netty/src/test/java/io/grpc/netty/UdsNettyChannelProviderTest.java
@@ -28,6 +28,7 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.ManagedChannelProvider;
 import io.grpc.ManagedChannelProvider.NewChannelBuilderResult;
 import io.grpc.ManagedChannelRegistryAccessor;
+import io.grpc.NameResolverRegistry;
 import io.grpc.TlsChannelCredentials;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
@@ -113,6 +114,19 @@ public class UdsNettyChannelProviderTest {
     Assume.assumeTrue(Utils.isEpollAvailable());
     ManagedChannelBuilder<?> managedChannelBuilder
             = Grpc.newChannelBuilder("unix:///sock.sock", InsecureChannelCredentials.create());
+    assertThat(managedChannelBuilder).isNotNull();
+    ManagedChannel channel = managedChannelBuilder.build();
+    assertThat(channel).isNotNull();
+    assertThat(channel.authority()).isEqualTo("/sock.sock");
+    channel.shutdownNow();
+  }
+
+  @Test
+  public void managedChannelRegistry_newChannelBuilderForNameResolverRegistry() {
+    Assume.assumeTrue(Utils.isEpollAvailable());
+    ManagedChannelBuilder<?> managedChannelBuilder
+            = Grpc.newChannelBuilderForNameResolverRegistry("unix:///sock.sock",
+             InsecureChannelCredentials.create(), NameResolverRegistry.getDefaultRegistry());
     assertThat(managedChannelBuilder).isNotNull();
     ManagedChannel channel = managedChannelBuilder.build();
     assertThat(channel).isNotNull();

--- a/netty/src/test/java/io/grpc/netty/UdsNettyChannelProviderTest.java
+++ b/netty/src/test/java/io/grpc/netty/UdsNettyChannelProviderTest.java
@@ -109,6 +109,16 @@ public class UdsNettyChannelProviderTest {
   }
 
   @Test
+  public void newChannelBuilder_withRegistry_success() {
+    Assume.assumeTrue(Utils.isEpollAvailable());
+    NewChannelBuilderResult result = provider.newChannelBuilder("unix:sock.sock",
+        TlsChannelCredentials.create(),
+        io.grpc.NameResolverRegistry.getDefaultRegistry(),
+        new io.grpc.internal.DnsNameResolverProvider());
+    assertThat(result.getChannelBuilder()).isInstanceOf(NettyChannelBuilder.class);
+  }
+
+  @Test
   public void managedChannelRegistry_newChannelBuilder() {
     Assume.assumeTrue(Utils.isEpollAvailable());
     ManagedChannelBuilder<?> managedChannelBuilder

--- a/netty/src/test/java/io/grpc/netty/UdsNettyChannelProviderTest.java
+++ b/netty/src/test/java/io/grpc/netty/UdsNettyChannelProviderTest.java
@@ -28,9 +28,7 @@ import io.grpc.ManagedChannelBuilder;
 import io.grpc.ManagedChannelProvider;
 import io.grpc.ManagedChannelProvider.NewChannelBuilderResult;
 import io.grpc.ManagedChannelRegistryAccessor;
-import io.grpc.NameResolverRegistry;
 import io.grpc.TlsChannelCredentials;
-import io.grpc.internal.testing.FakeNameResolverProvider;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
 import io.grpc.testing.protobuf.SimpleRequest;
@@ -115,24 +113,6 @@ public class UdsNettyChannelProviderTest {
     Assume.assumeTrue(Utils.isEpollAvailable());
     ManagedChannelBuilder<?> managedChannelBuilder
             = Grpc.newChannelBuilder("unix:///sock.sock", InsecureChannelCredentials.create());
-    assertThat(managedChannelBuilder).isNotNull();
-    ManagedChannel channel = managedChannelBuilder.build();
-    assertThat(channel).isNotNull();
-    assertThat(channel.authority()).isEqualTo("/sock.sock");
-    channel.shutdownNow();
-  }
-
-  @Test
-  public void managedChannelRegistry_newChannelBuilderForNameResolverRegistry() {
-    Assume.assumeTrue(Utils.isEpollAvailable());
-    NameResolverRegistry nameResolverRegistry = new NameResolverRegistry();
-    DomainSocketAddress socketAddress = new DomainSocketAddress("test-server");
-    FakeNameResolverProvider fakeNameResolverProvider = new FakeNameResolverProvider(
-            "unix:///sock.sock", socketAddress);
-    nameResolverRegistry.register(fakeNameResolverProvider);
-    ManagedChannelBuilder<?> managedChannelBuilder
-            = Grpc.newChannelBuilder("unix:///sock.sock",
-            InsecureChannelCredentials.create(), nameResolverRegistry);
     assertThat(managedChannelBuilder).isNotNull();
     ManagedChannel channel = managedChannelBuilder.build();
     assertThat(channel).isNotNull();

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -35,6 +35,8 @@ import io.grpc.ForwardingChannelBuilder2;
 import io.grpc.InsecureChannelCredentials;
 import io.grpc.Internal;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.NameResolverProvider;
+import io.grpc.NameResolverRegistry;
 import io.grpc.TlsChannelCredentials;
 import io.grpc.internal.AtomicBackoff;
 import io.grpc.internal.ClientTransportFactory;
@@ -586,6 +588,22 @@ public final class OkHttpChannelBuilder extends ForwardingChannelBuilder2<OkHttp
       default:
         throw new RuntimeException("Unknown negotiation type: " + negotiationType);
     }
+  }
+
+  /**
+   * Sets the registry used for looking up name resolvers.
+   */
+  public OkHttpChannelBuilder nameResolverRegistry(NameResolverRegistry registry) {
+    managedChannelImplBuilder.nameResolverRegistry(registry);
+    return this;
+  }
+
+  /**
+   * Sets the {@link NameResolverProvider} to use.
+   */
+  public OkHttpChannelBuilder nameResolverProvider(NameResolverProvider provider) {
+    managedChannelImplBuilder.nameResolverProvider(provider);
+    return this;
   }
 
   private static final EnumSet<TlsChannelCredentials.Feature> understoodTlsFeatures =

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -216,10 +216,20 @@ public final class OkHttpChannelBuilder extends ForwardingChannelBuilder2<OkHttp
   OkHttpChannelBuilder(
       String target, ChannelCredentials channelCreds, CallCredentials callCreds,
       SSLSocketFactory factory) {
+    this(target, channelCreds, callCreds, factory, null, null);
+  }
+
+  OkHttpChannelBuilder(
+      String target, ChannelCredentials channelCreds, CallCredentials callCreds,
+      SSLSocketFactory factory,
+      NameResolverRegistry nameResolverRegistry,
+      NameResolverProvider nameResolverProvider) {
     managedChannelImplBuilder = new ManagedChannelImplBuilder(
         target, channelCreds, callCreds,
         new OkHttpChannelTransportFactoryBuilder(),
-        new OkHttpChannelDefaultPortProvider());
+        new OkHttpChannelDefaultPortProvider(),
+        nameResolverRegistry,
+        nameResolverProvider);
     this.sslSocketFactory = factory;
     this.negotiationType = factory == null ? NegotiationType.PLAINTEXT : NegotiationType.TLS;
     this.freezeSecurityConfiguration = true;
@@ -590,21 +600,7 @@ public final class OkHttpChannelBuilder extends ForwardingChannelBuilder2<OkHttp
     }
   }
 
-  /**
-   * Sets the registry used for looking up name resolvers.
-   */
-  public OkHttpChannelBuilder nameResolverRegistry(NameResolverRegistry registry) {
-    managedChannelImplBuilder.nameResolverRegistry(registry);
-    return this;
-  }
 
-  /**
-   * Sets the {@link NameResolverProvider} to use.
-   */
-  public OkHttpChannelBuilder nameResolverProvider(NameResolverProvider provider) {
-    managedChannelImplBuilder.nameResolverProvider(provider);
-    return this;
-  }
 
   private static final EnumSet<TlsChannelCredentials.Feature> understoodTlsFeatures =
       EnumSet.of(

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelProvider.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelProvider.java
@@ -72,13 +72,8 @@ public final class OkHttpChannelProvider extends ManagedChannelProvider {
       return NewChannelBuilderResult.error(result.error);
     }
     OkHttpChannelBuilder builder = new OkHttpChannelBuilder(
-        target, creds, result.callCredentials, result.factory);
-    if (nameResolverRegistry != null) {
-      builder.nameResolverRegistry(nameResolverRegistry);
-    }
-    if (nameResolverProvider != null) {
-      builder.nameResolverProvider(nameResolverProvider);
-    }
+        target, creds, result.callCredentials, result.factory,
+        nameResolverRegistry, nameResolverProvider);
     return NewChannelBuilderResult.channelBuilder(builder);
   }
 

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelProvider.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelProvider.java
@@ -20,6 +20,8 @@ import io.grpc.ChannelCredentials;
 import io.grpc.Internal;
 import io.grpc.InternalServiceProviders;
 import io.grpc.ManagedChannelProvider;
+import io.grpc.NameResolverProvider;
+import io.grpc.NameResolverRegistry;
 import java.net.SocketAddress;
 import java.util.Collection;
 
@@ -58,6 +60,26 @@ public final class OkHttpChannelProvider extends ManagedChannelProvider {
     }
     return NewChannelBuilderResult.channelBuilder(new OkHttpChannelBuilder(
         target, creds, result.callCredentials, result.factory));
+  }
+
+  @Override
+  public NewChannelBuilderResult newChannelBuilder(String target, ChannelCredentials creds,
+                                                   NameResolverRegistry nameResolverRegistry,
+                                                   NameResolverProvider nameResolverProvider) {
+    OkHttpChannelBuilder.SslSocketFactoryResult result =
+        OkHttpChannelBuilder.sslSocketFactoryFrom(creds);
+    if (result.error != null) {
+      return NewChannelBuilderResult.error(result.error);
+    }
+    OkHttpChannelBuilder builder = new OkHttpChannelBuilder(
+        target, creds, result.callCredentials, result.factory);
+    if (nameResolverRegistry != null) {
+      builder.nameResolverRegistry(nameResolverRegistry);
+    }
+    if (nameResolverProvider != null) {
+      builder.nameResolverProvider(nameResolverProvider);
+    }
+    return NewChannelBuilderResult.channelBuilder(builder);
   }
 
   @Override

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelProviderTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpChannelProviderTest.java
@@ -85,4 +85,13 @@ public class OkHttpChannelProviderTest {
         TlsChannelCredentials.newBuilder().requireFakeFeature().build());
     assertThat(result.getError()).contains("FAKE");
   }
+
+  @Test
+  public void newChannelBuilder_withRegistry_success() {
+    NewChannelBuilderResult result = provider.newChannelBuilder("localhost:443",
+        TlsChannelCredentials.create(),
+        io.grpc.NameResolverRegistry.getDefaultRegistry(),
+        new io.grpc.internal.DnsNameResolverProvider());
+    assertThat(result.getChannelBuilder()).isInstanceOf(OkHttpChannelBuilder.class);
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-java/issues/11055
Exposes a new method for channel creation which accepts NameResolverRegistry