### PR TITLE
Use acceptResolvedAddresses() in easy cases

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProvider.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProvider.java
@@ -116,6 +116,13 @@ public class RpcBehaviorLoadBalancerProvider extends LoadBalancerProvider {
           ((RpcBehaviorConfig) resolvedAddresses.getLoadBalancingPolicyConfig()).rpcBehavior);
       delegateLb.handleResolvedAddresses(resolvedAddresses);
     }
+
+    @Override
+    public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+      helper.setRpcBehavior(
+          ((RpcBehaviorConfig) resolvedAddresses.getLoadBalancingPolicyConfig()).rpcBehavior);
+      return delegateLb.acceptResolvedAddresses(resolvedAddresses);
+    }
   }
 
   /**

--- a/interop-testing/src/test/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProviderTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/RpcBehaviorLoadBalancerProviderTest.java
@@ -88,6 +88,15 @@ public class RpcBehaviorLoadBalancerProviderTest {
   }
 
   @Test
+  public void acceptResolvedAddressesDelegated() {
+    RpcBehaviorLoadBalancer lb = new RpcBehaviorLoadBalancer(new RpcBehaviorHelper(mockHelper),
+        mockDelegateLb);
+    ResolvedAddresses resolvedAddresses = buildResolvedAddresses(buildConfig());
+    lb.acceptResolvedAddresses(resolvedAddresses);
+    verify(mockDelegateLb).acceptResolvedAddresses(resolvedAddresses);
+  }
+
+  @Test
   public void helperWrapsPicker() {
     RpcBehaviorHelper helper = new RpcBehaviorHelper(mockHelper);
     helper.setRpcBehavior("error-code-15");

--- a/services/src/main/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactory.java
+++ b/services/src/main/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactory.java
@@ -194,7 +194,18 @@ final class HealthCheckingLoadBalancerFactory extends LoadBalancer.Factory {
               .get(LoadBalancer.ATTR_HEALTH_CHECKING_CONFIG);
       String serviceName = ServiceConfigUtil.getHealthCheckedServiceName(healthCheckingConfig);
       helper.setHealthCheckedService(serviceName);
-      super.handleResolvedAddresses(resolvedAddresses);
+      delegate.handleResolvedAddresses(resolvedAddresses);
+    }
+
+    @Override
+    public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+      Map<String, ?> healthCheckingConfig =
+          resolvedAddresses
+              .getAttributes()
+              .get(LoadBalancer.ATTR_HEALTH_CHECKING_CONFIG);
+      String serviceName = ServiceConfigUtil.getHealthCheckedServiceName(healthCheckingConfig);
+      helper.setHealthCheckedService(serviceName);
+      return delegate.acceptResolvedAddresses(resolvedAddresses);
     }
 
     @Override

--- a/services/src/test/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactoryTest.java
+++ b/services/src/test/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactoryTest.java
@@ -206,15 +206,16 @@ public class HealthCheckingLoadBalancerFactoryTest {
         boolean shutdown;
 
         @Override
-        public void handleResolvedAddresses(final ResolvedAddresses resolvedAddresses) {
+        public Status acceptResolvedAddresses(final ResolvedAddresses resolvedAddresses) {
           syncContext.execute(new Runnable() {
               @Override
               public void run() {
                 if (!shutdown) {
-                  hcLb.handleResolvedAddresses(resolvedAddresses);
+                  hcLb.acceptResolvedAddresses(resolvedAddresses);
                 }
               }
             });
+          return Status.OK;
         }
 
         @Override
@@ -264,9 +265,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result);
+    hcLbEventDelivery.acceptResolvedAddresses(result);
 
-    verify(origLb).handleResolvedAddresses(result);
+    verify(origLb).acceptResolvedAddresses(result);
     verify(origHelper, atLeast(0)).getSynchronizationContext();
     verify(origHelper, atLeast(0)).getScheduledExecutorService();
     verifyNoMoreInteractions(origHelper);
@@ -404,9 +405,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result);
+    hcLbEventDelivery.acceptResolvedAddresses(result);
 
-    verify(origLb).handleResolvedAddresses(result);
+    verify(origLb).acceptResolvedAddresses(result);
     verifyNoMoreInteractions(origLb);
 
     // We create 2 Subchannels. One of them connects to a server that doesn't implement health check
@@ -489,9 +490,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result);
+    hcLbEventDelivery.acceptResolvedAddresses(result);
 
-    verify(origLb).handleResolvedAddresses(result);
+    verify(origLb).acceptResolvedAddresses(result);
     verifyNoMoreInteractions(origLb);
 
     SubchannelStateListener mockHealthListener = mockHealthListeners[0];
@@ -567,9 +568,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result);
+    hcLbEventDelivery.acceptResolvedAddresses(result);
 
-    verify(origLb).handleResolvedAddresses(result);
+    verify(origLb).acceptResolvedAddresses(result);
     verifyNoMoreInteractions(origLb);
 
     SubchannelStateListener mockStateListener = mockStateListeners[0];
@@ -667,9 +668,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(Attributes.EMPTY)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result1);
+    hcLbEventDelivery.acceptResolvedAddresses(result1);
 
-    verify(origLb).handleResolvedAddresses(result1);
+    verify(origLb).acceptResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     // First, create Subchannels 0
@@ -688,8 +689,8 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result2);
-    verify(origLb).handleResolvedAddresses(result2);
+    hcLbEventDelivery.acceptResolvedAddresses(result2);
+    verify(origLb).acceptResolvedAddresses(result2);
 
     // Health check started on existing Subchannel
     assertThat(healthImpls[0].calls).hasSize(1);
@@ -711,9 +712,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result1);
+    hcLbEventDelivery.acceptResolvedAddresses(result1);
 
-    verify(origLb).handleResolvedAddresses(result1);
+    verify(origLb).acceptResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY, maybeGetMockListener());
@@ -738,7 +739,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(Attributes.EMPTY)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result2);
+    hcLbEventDelivery.acceptResolvedAddresses(result2);
 
     // Health check RPC cancelled.
     assertThat(serverCall.cancelled).isTrue();
@@ -746,7 +747,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
     inOrder.verify(getMockListener()).onSubchannelState(
         eq(ConnectivityStateInfo.forNonError(READY)));
 
-    inOrder.verify(origLb).handleResolvedAddresses(result2);
+    inOrder.verify(origLb).acceptResolvedAddresses(result2);
 
     verifyNoMoreInteractions(origLb, mockStateListeners[0]);
     assertThat(healthImpl.calls).isEmpty();
@@ -759,9 +760,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result);
+    hcLbEventDelivery.acceptResolvedAddresses(result);
 
-    verify(origLb).handleResolvedAddresses(result);
+    verify(origLb).acceptResolvedAddresses(result);
     verifyNoMoreInteractions(origLb);
 
     SubchannelStateListener mockHealthListener = mockHealthListeners[0];
@@ -793,7 +794,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(Attributes.EMPTY)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result2);
+    hcLbEventDelivery.acceptResolvedAddresses(result2);
 
     // Retry timer is cancelled
     assertThat(clock.getPendingTasks()).isEmpty();
@@ -805,7 +806,7 @@ public class HealthCheckingLoadBalancerFactoryTest {
     inOrder.verify(getMockListener()).onSubchannelState(
         eq(ConnectivityStateInfo.forNonError(READY)));
 
-    inOrder.verify(origLb).handleResolvedAddresses(result2);
+    inOrder.verify(origLb).acceptResolvedAddresses(result2);
 
     verifyNoMoreInteractions(origLb, mockStateListeners[0]);
   }
@@ -817,9 +818,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result1);
+    hcLbEventDelivery.acceptResolvedAddresses(result1);
 
-    verify(origLb).handleResolvedAddresses(result1);
+    verify(origLb).acceptResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY, maybeGetMockListener());
@@ -842,9 +843,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(Attributes.EMPTY)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result2);
+    hcLbEventDelivery.acceptResolvedAddresses(result2);
 
-    inOrder.verify(origLb).handleResolvedAddresses(result2);
+    inOrder.verify(origLb).acceptResolvedAddresses(result2);
 
     // Underlying subchannel is now ready
     deliverSubchannelState(0, ConnectivityStateInfo.forNonError(READY));
@@ -870,9 +871,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result1);
+    hcLbEventDelivery.acceptResolvedAddresses(result1);
 
-    verify(origLb).handleResolvedAddresses(result1);
+    verify(origLb).acceptResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     SubchannelStateListener mockHealthListener = mockHealthListeners[0];
@@ -900,9 +901,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         eq(ConnectivityStateInfo.forNonError(READY)));
 
     // Service config returns with the same health check name.
-    hcLbEventDelivery.handleResolvedAddresses(result1);
+    hcLbEventDelivery.acceptResolvedAddresses(result1);
     // It's delivered to origLb, but nothing else happens
-    inOrder.verify(origLb).handleResolvedAddresses(result1);
+    inOrder.verify(origLb).acceptResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb, mockListener);
 
     // Service config returns a different health check name.
@@ -911,8 +912,8 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result2);
-    inOrder.verify(origLb).handleResolvedAddresses(result2);
+    hcLbEventDelivery.acceptResolvedAddresses(result2);
+    inOrder.verify(origLb).acceptResolvedAddresses(result2);
 
     // Current health check RPC cancelled.
     assertThat(serverCall.cancelled).isTrue();
@@ -934,9 +935,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result1);
+    hcLbEventDelivery.acceptResolvedAddresses(result1);
 
-    verify(origLb).handleResolvedAddresses(result1);
+    verify(origLb).acceptResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     SubchannelStateListener mockHealthListener = mockHealthListeners[0];
@@ -969,9 +970,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
 
     // Service config returns with the same health check name.
 
-    hcLbEventDelivery.handleResolvedAddresses(result1);
+    hcLbEventDelivery.acceptResolvedAddresses(result1);
     // It's delivered to origLb, but nothing else happens
-    inOrder.verify(origLb).handleResolvedAddresses(result1);
+    inOrder.verify(origLb).acceptResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb, mockListener);
     assertThat(clock.getPendingTasks()).hasSize(1);
     assertThat(healthImpl.calls).isEmpty();
@@ -982,12 +983,12 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result2);
+    hcLbEventDelivery.acceptResolvedAddresses(result2);
     // Concluded CONNECTING state
     inOrder.verify(getMockListener()).onSubchannelState(
         eq(ConnectivityStateInfo.forNonError(CONNECTING)));
 
-    inOrder.verify(origLb).handleResolvedAddresses(result2);
+    inOrder.verify(origLb).acceptResolvedAddresses(result2);
 
     // Current retry timer cancelled
     assertThat(clock.getPendingTasks()).isEmpty();
@@ -1008,9 +1009,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result1);
+    hcLbEventDelivery.acceptResolvedAddresses(result1);
 
-    verify(origLb).handleResolvedAddresses(result1);
+    verify(origLb).acceptResolvedAddresses(result1);
     verifyNoMoreInteractions(origLb);
 
     Subchannel subchannel = createSubchannel(0, Attributes.EMPTY, maybeGetMockListener());
@@ -1031,9 +1032,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
     inOrder.verifyNoMoreInteractions();
 
     // Service config returns with the same health check name.
-    hcLbEventDelivery.handleResolvedAddresses(result1);
+    hcLbEventDelivery.acceptResolvedAddresses(result1);
     // It's delivered to origLb, but nothing else happens
-    inOrder.verify(origLb).handleResolvedAddresses(result1);
+    inOrder.verify(origLb).acceptResolvedAddresses(result1);
     assertThat(healthImpl.calls).isEmpty();
     verifyNoMoreInteractions(origLb);
 
@@ -1043,9 +1044,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result2);
+    hcLbEventDelivery.acceptResolvedAddresses(result2);
 
-    inOrder.verify(origLb).handleResolvedAddresses(result2);
+    inOrder.verify(origLb).acceptResolvedAddresses(result2);
 
     // Underlying subchannel is now ready
     deliverSubchannelState(0, ConnectivityStateInfo.forNonError(READY));
@@ -1092,9 +1093,9 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result);
+    hcLbEventDelivery.acceptResolvedAddresses(result);
 
-    verify(origLb).handleResolvedAddresses(result);
+    verify(origLb).acceptResolvedAddresses(result);
     verifyNoMoreInteractions(origLb);
     ServerSideCall[] serverCalls = new ServerSideCall[NUM_SUBCHANNELS];
 
@@ -1172,8 +1173,8 @@ public class HealthCheckingLoadBalancerFactoryTest {
         .setAddresses(resolvedAddressList)
         .setAttributes(resolutionAttrs)
         .build();
-    hcLbEventDelivery.handleResolvedAddresses(result);
-    verify(origLb).handleResolvedAddresses(result);
+    hcLbEventDelivery.acceptResolvedAddresses(result);
+    verify(origLb).acceptResolvedAddresses(result);
     createSubchannel(0, Attributes.EMPTY);
     assertThat(healthImpls[0].calls).isEmpty();
     deliverSubchannelState(0, ConnectivityStateInfo.forNonError(READY));

--- a/util/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
@@ -171,9 +171,8 @@ public final class OutlierDetectionLoadBalancer extends LoadBalancer {
       endpointTrackerMap.cancelTracking();
     }
 
-    switchLb.handleResolvedAddresses(
+    return switchLb.acceptResolvedAddresses(
         resolvedAddresses.toBuilder().setLoadBalancingPolicyConfig(config.childConfig).build());
-    return Status.OK;
   }
 
   @Override

--- a/util/src/test/java/io/grpc/util/OutlierDetectionLoadBalancerTest.java
+++ b/util/src/test/java/io/grpc/util/OutlierDetectionLoadBalancerTest.java
@@ -280,7 +280,7 @@ public class OutlierDetectionLoadBalancerTest {
     loadBalancer.acceptResolvedAddresses(resolvedAddresses);
 
     // Handling of resolved addresses is delegated
-    verify(mockChildLb).handleResolvedAddresses(
+    verify(mockChildLb).acceptResolvedAddresses(
         resolvedAddresses.toBuilder().setLoadBalancingPolicyConfig(childConfig).build());
 
     // There is a single pending task to run the outlier detection algorithm

--- a/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WrrLocalityLoadBalancer.java
@@ -113,12 +113,10 @@ final class WrrLocalityLoadBalancer extends LoadBalancer {
     Object switchConfig = GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(
         lbRegistry.getProvider(WEIGHTED_TARGET_POLICY_NAME),
         new WeightedTargetConfig(weightedPolicySelections));
-    switchLb.handleResolvedAddresses(
+    return switchLb.acceptResolvedAddresses(
         resolvedAddresses.toBuilder()
             .setLoadBalancingPolicyConfig(switchConfig)
             .build());
-
-    return Status.OK;
   }
 
   @Override

--- a/xds/src/main/java/io/grpc/xds/orca/OrcaOobUtil.java
+++ b/xds/src/main/java/io/grpc/xds/orca/OrcaOobUtil.java
@@ -83,7 +83,7 @@ public final class OrcaOobUtil {
    *       class WrrLoadbalancer extends LoadBalancer {
    *         private final Helper originHelper;  // the original Helper
    *
-   *         public void handleResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+   *         public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
    *           // listener implements the logic for WRR's usage of backend metrics.
    *           OrcaReportingHelper orcaHelper =
    *               OrcaOobUtil.newOrcaReportingHelper(originHelper);

--- a/xds/src/test/java/io/grpc/xds/ClusterManagerLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterManagerLoadBalancerTest.java
@@ -118,7 +118,7 @@ public class ClusterManagerLoadBalancerTest {
   }
 
   @Test
-  public void handleResolvedAddressesUpdatesChannelPicker() {
+  public void acceptResolvedAddressesUpdatesChannelPicker() {
     deliverResolvedAddresses(ImmutableMap.of("childA", "policy_a", "childB", "policy_b"));
 
     verify(helper, atLeastOnce()).updateBalancingState(

--- a/xds/src/test/java/io/grpc/xds/MetadataLoadBalancerProvider.java
+++ b/xds/src/test/java/io/grpc/xds/MetadataLoadBalancerProvider.java
@@ -114,6 +114,14 @@ public class MetadataLoadBalancerProvider extends LoadBalancerProvider {
       helper.setMetadata(config.metadataKey, config.metadataValue);
       delegateLb.handleResolvedAddresses(resolvedAddresses);
     }
+
+    @Override
+    public Status acceptResolvedAddresses(ResolvedAddresses resolvedAddresses) {
+      MetadataLoadBalancerConfig config
+          = (MetadataLoadBalancerConfig) resolvedAddresses.getLoadBalancingPolicyConfig();
+      helper.setMetadata(config.metadataKey, config.metadataValue);
+      return delegateLb.acceptResolvedAddresses(resolvedAddresses);
+    }
   }
 
   /**

--- a/xds/src/test/java/io/grpc/xds/WrrLocalityLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WrrLocalityLoadBalancerTest.java
@@ -108,7 +108,7 @@ public class WrrLocalityLoadBalancerTest {
   }
 
   @Test
-  public void handleResolvedAddresses() {
+  public void acceptResolvedAddresses() {
     // A two locality cluster with a mock child LB policy.
     String localityOne = "localityOne";
     String localityTwo = "localityTwo";
@@ -124,7 +124,7 @@ public class WrrLocalityLoadBalancerTest {
 
     // Assert that the child policy and the locality weights were correctly mapped to a
     // WeightedTargetConfig.
-    verify(mockWeightedTargetLb).handleResolvedAddresses(resolvedAddressesCaptor.capture());
+    verify(mockWeightedTargetLb).acceptResolvedAddresses(resolvedAddressesCaptor.capture());
     Object config = resolvedAddressesCaptor.getValue().getLoadBalancingPolicyConfig();
     assertThat(config).isInstanceOf(WeightedTargetConfig.class);
     WeightedTargetConfig wtConfig = (WeightedTargetConfig) config;
@@ -136,7 +136,7 @@ public class WrrLocalityLoadBalancerTest {
   }
 
   @Test
-  public void handleResolvedAddresses_noLocalityWeights() {
+  public void acceptResolvedAddresses_noLocalityWeights() {
     // A two locality cluster with a mock child LB policy.
     Object childPolicy = newChildConfig(mockChildProvider, null);
 
@@ -182,7 +182,7 @@ public class WrrLocalityLoadBalancerTest {
 
     // Assert that the child policy and the locality weights were correctly mapped to a
     // WeightedTargetConfig.
-    verify(mockWeightedTargetLb).handleResolvedAddresses(resolvedAddressesCaptor.capture());
+    verify(mockWeightedTargetLb).acceptResolvedAddresses(resolvedAddressesCaptor.capture());
 
     //assertThat(resolvedAddressesCaptor.getValue().getAttributes()
     //    .get(XdsAttributes.ATTR_LOCALITY_WEIGHTS)).isNull();
@@ -213,7 +213,7 @@ public class WrrLocalityLoadBalancerTest {
   }
 
   private void deliverAddresses(WrrLocalityConfig config, List<EquivalentAddressGroup> addresses) {
-    loadBalancer.handleResolvedAddresses(
+    loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(addresses).setLoadBalancingPolicyConfig(config)
             .build());
   }


### PR DESCRIPTION
We want to move away from handleResolvedAddresses(). These are "easy" in that they need no logic. LBs extending ForwardingLoadBalancer had the method duplicated from handleResolvedAddresses() and swapped away from `super` because ForwardingLoadBalancer only forwards handleResolvedAddresses() reliably today. Duplicating small methods was less bug-prone than dealing with ForwardingLoadBalancer.

CC @SreeramdasLavanya