### PR TITLE
servlet: set description for CANCELLED status

### DIFF
--- a/servlet/src/main/java/io/grpc/servlet/ServletServerStream.java
+++ b/servlet/src/main/java/io/grpc/servlet/ServletServerStream.java
@@ -297,7 +297,7 @@ final class ServletServerStream extends AbstractServerStream {
       }
       transportState.runOnTransportThread(() -> transportState.transportReportStatus(status));
       // There is no way to RST_STREAM with CANCEL code, so write trailers instead
-      close(Status.CANCELLED.withDescription("servlet io exception")
+      close(Status.CANCELLED.withDescription("Servlet stream cancelled")
               .withCause(status.asRuntimeException()),
           new Metadata());
       CountDownLatch countDownLatch = new CountDownLatch(1);

--- a/servlet/src/main/java/io/grpc/servlet/ServletServerStream.java
+++ b/servlet/src/main/java/io/grpc/servlet/ServletServerStream.java
@@ -297,7 +297,9 @@ final class ServletServerStream extends AbstractServerStream {
       }
       transportState.runOnTransportThread(() -> transportState.transportReportStatus(status));
       // There is no way to RST_STREAM with CANCEL code, so write trailers instead
-      close(Status.CANCELLED.withCause(status.asRuntimeException()), new Metadata());
+      close(Status.CANCELLED.withDescription("servlet io exception")
+              .withCause(status.asRuntimeException()),
+          new Metadata());
       CountDownLatch countDownLatch = new CountDownLatch(1);
       transportState.runOnTransportThread(() -> {
         asyncCtx.complete();


### PR DESCRIPTION
It eventually happens from Tomcat when it's behind nginx.
Currently caller gets just `io.grpc.StatusRuntimeException: CANCELLED` which is not very clear.

I guess when this code was originally developed, the assumption was that nobody will received it, but it actually happens, so worth making this status more clear.

if you are curious, the exception which causes that is
```
java.io.IOException: null
	at org.apache.coyote.http2.Stream$StandardStreamInputBuffer.receiveReset(Stream.java:1516)
	at org.apache.coyote.http2.Stream.receiveReset(Stream.java:227)
	at org.apache.coyote.http2.Http2UpgradeHandler.close(Http2UpgradeHandler.java:1302)
	at org.apache.coyote.http2.Http2UpgradeHandler.upgradeDispatch(Http2UpgradeHandler.java:434)
	at org.apache.coyote.http2.Http2AsyncUpgradeHandler.upgradeDispatch(Http2AsyncUpgradeHandler.java:43)
	at org.apache.coyote.http2.Http2AsyncParser$FrameCompletionHandler.failed(Http2AsyncParser.java:337)
	at org.apache.coyote.http2.Http2AsyncParser$FrameCompletionHandler.failed(Http2AsyncParser.java:167)
	at org.apache.tomcat.util.net.SocketWrapperBase$VectoredIOCompletionHandler.failed(SocketWrapperBase.java:1174)
	at org.apache.tomcat.util.net.NioEndpoint$NioSocketWrapper$NioOperationState.run(NioEndpoint.java:1710)
```