### PR TITLE
xds: ensure server interceptors are created in a sync context

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsServerBuilder.java
+++ b/xds/src/main/java/io/grpc/xds/XdsServerBuilder.java
@@ -31,6 +31,7 @@ import io.grpc.Internal;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.ServerCredentials;
+import io.grpc.SynchronizationContext;
 import io.grpc.netty.InternalNettyServerBuilder;
 import io.grpc.netty.InternalNettyServerCredentials;
 import io.grpc.netty.InternalProtocolNegotiator;
@@ -55,6 +56,7 @@ public final class XdsServerBuilder extends ForwardingServerBuilder<XdsServerBui
   private final FilterRegistry filterRegistry = FilterRegistry.getDefaultRegistry();
   private XdsClientPoolFactory xdsClientPoolFactory =
           SharedXdsClientPoolProvider.getDefaultProvider();
+  private SynchronizationContext syncContext = null;
   private long drainGraceTime = 10;
   private TimeUnit drainGraceTimeUnit = TimeUnit.MINUTES;
 
@@ -127,12 +129,18 @@ public final class XdsServerBuilder extends ForwardingServerBuilder<XdsServerBui
     }
     InternalNettyServerBuilder.eagAttributes(delegate, builder.build());
     return new XdsServerWrapper("0.0.0.0:" + port, delegate, xdsServingStatusListener,
-            filterChainSelectorManager, xdsClientPoolFactory, filterRegistry);
+            filterChainSelectorManager, xdsClientPoolFactory, filterRegistry, syncContext);
   }
 
   @VisibleForTesting
   XdsServerBuilder xdsClientPoolFactory(XdsClientPoolFactory xdsClientPoolFactory) {
     this.xdsClientPoolFactory = checkNotNull(xdsClientPoolFactory, "xdsClientPoolFactory");
+    return this;
+  }
+
+  @VisibleForTesting
+  XdsServerBuilder syncContext(SynchronizationContext syncContext) {
+    this.syncContext = checkNotNull(syncContext, "syncContext");
     return this;
   }
 

--- a/xds/src/test/java/io/grpc/xds/XdsClientWrapperForServerSdsTestMisc.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientWrapperForServerSdsTestMisc.java
@@ -37,8 +37,6 @@ import io.grpc.ServerBuilder;
 import io.grpc.Status;
 import io.grpc.SynchronizationContext;
 import io.grpc.inprocess.InProcessSocketAddress;
-import io.grpc.internal.GrpcUtil;
-import io.grpc.internal.SharedResourceHolder;
 import io.grpc.internal.TestUtils.NoopChannelLogger;
 import io.grpc.netty.GrpcHttp2ConnectionHandler;
 import io.grpc.netty.InternalProtocolNegotiationEvent;
@@ -126,7 +124,7 @@ public class XdsClientWrapperForServerSdsTestMisc {
     when(mockServer.isShutdown()).thenReturn(false);
     xdsServerWrapper = new XdsServerWrapper("0.0.0.0:" + PORT, mockBuilder, listener,
         selectorManager, new FakeXdsClientPoolFactory(xdsClient), FilterRegistry.newRegistry(),
-        syncContext, SharedResourceHolder.get(GrpcUtil.TIMER_SERVICE));
+        syncContext);
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/XdsServerTestHelper.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerTestHelper.java
@@ -183,12 +183,6 @@ public class XdsServerTestHelper {
     final Map<String, ResourceWatcher<RdsUpdate>> rdsWatchers = new HashMap<>();
     private final SynchronizationContext syncContext;
 
-    FakeXdsClient() {
-      this(new SynchronizationContext((t, e) -> {
-        throw new AssertionError(e);
-      }));
-    }
-
     FakeXdsClient(SynchronizationContext syncContext) {
       this.syncContext = syncContext;
     }


### PR DESCRIPTION
`XdsServerWrapper#generatePerRouteInterceptors` was always intended to be executed within a sync context. This PR ensures that by calling `syncContext.throwIfNotInThisSynchronizationContext()`.

To achieve this, this PR refactors `XdsServerWrapper` and `XdsServerWrapper` to allow for `SynchronizationContext` dependency injection so that tests can supply the syncContext object.

This change is needed for upcoming xDS filter state retention because the new tests in XdsServerWrapperTest flake with this NPE:

> `Cannot invoke "io.grpc.xds.client.XdsClient$ResourceWatcher.onChanged(io.grpc.xds.client.XdsClient$ResourceUpdate)" because "this.ldsWatcher" is null`