### PR TITLE
xds: ensure server interceptors are created in a sync context

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsServerWrapper.java
+++ b/xds/src/main/java/io/grpc/xds/XdsServerWrapper.java
@@ -524,9 +524,7 @@ final class XdsServerWrapper extends Server {
 
     private ImmutableMap<Route, ServerInterceptor> generatePerRouteInterceptors(
         @Nullable List<NamedFilterConfig> filterConfigs, List<VirtualHost> virtualHosts) {
-      // This should always be called from the sync context.
-      // Ideally we'd want to throw otherwise, but this breaks the tests now.
-      // syncContext.throwIfNotInThisSynchronizationContext();
+      syncContext.throwIfNotInThisSynchronizationContext();
 
       ImmutableMap.Builder<Route, ServerInterceptor> perRouteInterceptors =
           new ImmutableMap.Builder<>();

--- a/xds/src/test/java/io/grpc/xds/XdsServerWrapperTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerWrapperTest.java
@@ -251,7 +251,7 @@ public class XdsServerWrapperTest {
     FilterChain f0 = createFilterChain("filter-chain-0", hcm_virtual);
     FilterChain f1 = createFilterChain("filter-chain-1", createRds("rds"));
     xdsClient.deliverLdsUpdate(Collections.singletonList(f0), f1);
-    xdsClient.awaitRds();
+    xdsClient.awaitRds(FakeXdsClient.DEFAULT_TIMEOUT);
     xdsClient.deliverRdsUpdate("rds",
             Collections.singletonList(createVirtualHost("virtual-host-1")));
     verify(listener, timeout(5000)).onServing();
@@ -366,7 +366,7 @@ public class XdsServerWrapperTest {
     FilterChain filterChain = createFilterChain("filter-chain-1", createRds("rds"));
     SslContextProviderSupplier sslSupplier = filterChain.sslContextProviderSupplier();
     xdsClient.deliverLdsUpdate(Collections.singletonList(filterChain), null);
-    xdsClient.awaitRds();
+    xdsClient.awaitRds(FakeXdsClient.DEFAULT_TIMEOUT);
     xdsClient.deliverRdsUpdate("rds",
             Collections.singletonList(createVirtualHost("virtual-host-1")));
     try {
@@ -433,7 +433,7 @@ public class XdsServerWrapperTest {
     xdsClient.ldsResource.get(5, TimeUnit.SECONDS);
     FilterChain filterChain = createFilterChain("filter-chain-1", createRds("rds"));
     xdsClient.deliverLdsUpdate(Collections.singletonList(filterChain), null);
-    xdsClient.awaitRds();
+    xdsClient.awaitRds(FakeXdsClient.DEFAULT_TIMEOUT);
     xdsClient.deliverRdsUpdate("rds",
             Collections.singletonList(createVirtualHost("virtual-host-1")));
     try {
@@ -555,7 +555,7 @@ public class XdsServerWrapperTest {
     xdsClient.deliverLdsUpdate(Arrays.asList(f0, f2), f3);
     verify(mockServer, never()).start();
     verify(listener, never()).onServing();
-    xdsClient.awaitRds();
+    xdsClient.awaitRds(FakeXdsClient.DEFAULT_TIMEOUT);
 
     xdsClient.deliverRdsUpdate("r1",
             Collections.singletonList(createVirtualHost("virtual-host-1")));
@@ -605,7 +605,7 @@ public class XdsServerWrapperTest {
     assertThat(start.isDone()).isFalse();
     assertThat(selectorManager.getSelectorToUpdateSelector()).isNull();
 
-    xdsClient.awaitRds();
+    xdsClient.awaitRds(FakeXdsClient.DEFAULT_TIMEOUT);
     xdsClient.deliverRdsUpdate("r0",
             Collections.singletonList(createVirtualHost("virtual-host-0")));
     start.get(5000, TimeUnit.MILLISECONDS);
@@ -633,7 +633,7 @@ public class XdsServerWrapperTest {
     EnvoyServerProtoData.FilterChain f5 = createFilterChain("filter-chain-4", createRds("r1"));
     xdsClient.setExpectedRdsCount(1);
     xdsClient.deliverLdsUpdate(Arrays.asList(f5, f3), f4);
-    xdsClient.awaitRds();
+    xdsClient.awaitRds(FakeXdsClient.DEFAULT_TIMEOUT);
     xdsClient.deliverRdsUpdate("r1",
             Collections.singletonList(createVirtualHost("virtual-host-1")));
     xdsClient.deliverRdsUpdate("r0",
@@ -686,7 +686,7 @@ public class XdsServerWrapperTest {
     EnvoyServerProtoData.FilterChain f0 = createFilterChain("filter-chain-0", hcmVirtual);
     EnvoyServerProtoData.FilterChain f1 = createFilterChain("filter-chain-1", createRds("r0"));
     xdsClient.deliverLdsUpdate(Arrays.asList(f0, f1), null);
-    xdsClient.awaitRds();
+    xdsClient.awaitRds(FakeXdsClient.DEFAULT_TIMEOUT);
     xdsClient.rdsWatchers.get("r0").onError(Status.CANCELLED);
     start.get(5000, TimeUnit.MILLISECONDS);
     assertThat(selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().size())
@@ -1233,7 +1233,7 @@ public class XdsServerWrapperTest {
     VirtualHost virtualHost  = VirtualHost.create(
         "v1", Collections.singletonList("foo.google.com"), Arrays.asList(route),
         ImmutableMap.of("filter-config-name-0", f0Override));
-    xdsClient.awaitRds();
+    xdsClient.awaitRds(FakeXdsClient.DEFAULT_TIMEOUT);
     xdsClient.deliverRdsUpdate("r0", Collections.singletonList(virtualHost));
     start.get(5000, TimeUnit.MILLISECONDS);
     verify(mockServer).start();

--- a/xds/src/test/java/io/grpc/xds/XdsServerWrapperTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerWrapperTest.java
@@ -74,7 +74,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -252,7 +251,7 @@ public class XdsServerWrapperTest {
     FilterChain f0 = createFilterChain("filter-chain-0", hcm_virtual);
     FilterChain f1 = createFilterChain("filter-chain-1", createRds("rds"));
     xdsClient.deliverLdsUpdate(Collections.singletonList(f0), f1);
-    xdsClient.rdsCount.await(5, TimeUnit.SECONDS);
+    xdsClient.awaitRds();
     xdsClient.deliverRdsUpdate("rds",
             Collections.singletonList(createVirtualHost("virtual-host-1")));
     verify(listener, timeout(5000)).onServing();
@@ -261,7 +260,7 @@ public class XdsServerWrapperTest {
     xdsServerWrapper.shutdown();
     assertThat(xdsServerWrapper.isShutdown()).isTrue();
     assertThat(xdsClient.ldsResource).isNull();
-    assertThat(xdsClient.shutdown).isTrue();
+    assertThat(xdsClient.isShutDown()).isTrue();
     verify(mockServer).shutdown();
     assertThat(f0.sslContextProviderSupplier().isShutdown()).isTrue();
     assertThat(f1.sslContextProviderSupplier().isShutdown()).isTrue();
@@ -303,7 +302,7 @@ public class XdsServerWrapperTest {
     verify(mockServer, never()).start();
     assertThat(xdsServerWrapper.isShutdown()).isTrue();
     assertThat(xdsClient.ldsResource).isNull();
-    assertThat(xdsClient.shutdown).isTrue();
+    assertThat(xdsClient.isShutDown()).isTrue();
     verify(mockServer).shutdown();
     assertThat(f0.sslContextProviderSupplier().isShutdown()).isTrue();
     assertThat(f1.sslContextProviderSupplier().isShutdown()).isTrue();
@@ -342,7 +341,7 @@ public class XdsServerWrapperTest {
     xdsServerWrapper.shutdown();
     assertThat(xdsServerWrapper.isShutdown()).isTrue();
     assertThat(xdsClient.ldsResource).isNull();
-    assertThat(xdsClient.shutdown).isTrue();
+    assertThat(xdsClient.isShutDown()).isTrue();
     verify(mockBuilder, times(1)).build();
     verify(mockServer, times(1)).shutdown();
     xdsServerWrapper.awaitTermination(1, TimeUnit.SECONDS);
@@ -367,7 +366,7 @@ public class XdsServerWrapperTest {
     FilterChain filterChain = createFilterChain("filter-chain-1", createRds("rds"));
     SslContextProviderSupplier sslSupplier = filterChain.sslContextProviderSupplier();
     xdsClient.deliverLdsUpdate(Collections.singletonList(filterChain), null);
-    xdsClient.rdsCount.await(5, TimeUnit.SECONDS);
+    xdsClient.awaitRds();
     xdsClient.deliverRdsUpdate("rds",
             Collections.singletonList(createVirtualHost("virtual-host-1")));
     try {
@@ -434,7 +433,7 @@ public class XdsServerWrapperTest {
     xdsClient.ldsResource.get(5, TimeUnit.SECONDS);
     FilterChain filterChain = createFilterChain("filter-chain-1", createRds("rds"));
     xdsClient.deliverLdsUpdate(Collections.singletonList(filterChain), null);
-    xdsClient.rdsCount.await(5, TimeUnit.SECONDS);
+    xdsClient.awaitRds();
     xdsClient.deliverRdsUpdate("rds",
             Collections.singletonList(createVirtualHost("virtual-host-1")));
     try {
@@ -544,7 +543,7 @@ public class XdsServerWrapperTest {
             0L, Collections.singletonList(virtualHost), new ArrayList<NamedFilterConfig>());
     EnvoyServerProtoData.FilterChain f0 = createFilterChain("filter-chain-0", hcmVirtual);
     EnvoyServerProtoData.FilterChain f1 = createFilterChain("filter-chain-1", createRds("r0"));
-    xdsClient.rdsCount = new CountDownLatch(3);
+    xdsClient.setExpectedRdsCount(3);
     xdsClient.deliverLdsUpdate(Arrays.asList(f0, f1), null);
     assertThat(start.isDone()).isFalse();
     assertThat(selectorManager.getSelectorToUpdateSelector()).isNull();
@@ -556,7 +555,7 @@ public class XdsServerWrapperTest {
     xdsClient.deliverLdsUpdate(Arrays.asList(f0, f2), f3);
     verify(mockServer, never()).start();
     verify(listener, never()).onServing();
-    xdsClient.rdsCount.await(5, TimeUnit.SECONDS);
+    xdsClient.awaitRds();
 
     xdsClient.deliverRdsUpdate("r1",
             Collections.singletonList(createVirtualHost("virtual-host-1")));
@@ -602,12 +601,11 @@ public class XdsServerWrapperTest {
     EnvoyServerProtoData.FilterChain f1 = createFilterChain("filter-chain-1", createRds("r0"));
     EnvoyServerProtoData.FilterChain f2 = createFilterChain("filter-chain-2", createRds("r0"));
 
-    xdsClient.rdsCount = new CountDownLatch(1);
     xdsClient.deliverLdsUpdate(Arrays.asList(f0, f1), f2);
     assertThat(start.isDone()).isFalse();
     assertThat(selectorManager.getSelectorToUpdateSelector()).isNull();
 
-    xdsClient.rdsCount.await(5, TimeUnit.SECONDS);
+    xdsClient.awaitRds();
     xdsClient.deliverRdsUpdate("r0",
             Collections.singletonList(createVirtualHost("virtual-host-0")));
     start.get(5000, TimeUnit.MILLISECONDS);
@@ -633,9 +631,9 @@ public class XdsServerWrapperTest {
     EnvoyServerProtoData.FilterChain f3 = createFilterChain("filter-chain-3", createRds("r0"));
     EnvoyServerProtoData.FilterChain f4 = createFilterChain("filter-chain-4", createRds("r1"));
     EnvoyServerProtoData.FilterChain f5 = createFilterChain("filter-chain-4", createRds("r1"));
-    xdsClient.rdsCount = new CountDownLatch(1);
+    xdsClient.setExpectedRdsCount(1);
     xdsClient.deliverLdsUpdate(Arrays.asList(f5, f3), f4);
-    xdsClient.rdsCount.await(5, TimeUnit.SECONDS);
+    xdsClient.awaitRds();
     xdsClient.deliverRdsUpdate("r1",
             Collections.singletonList(createVirtualHost("virtual-host-1")));
     xdsClient.deliverRdsUpdate("r0",
@@ -688,7 +686,7 @@ public class XdsServerWrapperTest {
     EnvoyServerProtoData.FilterChain f0 = createFilterChain("filter-chain-0", hcmVirtual);
     EnvoyServerProtoData.FilterChain f1 = createFilterChain("filter-chain-1", createRds("r0"));
     xdsClient.deliverLdsUpdate(Arrays.asList(f0, f1), null);
-    xdsClient.rdsCount.await();
+    xdsClient.awaitRds();
     xdsClient.rdsWatchers.get("r0").onError(Status.CANCELLED);
     start.get(5000, TimeUnit.MILLISECONDS);
     assertThat(selectorManager.getSelectorToUpdateSelector().getRoutingConfigs().size())
@@ -1235,7 +1233,7 @@ public class XdsServerWrapperTest {
     VirtualHost virtualHost  = VirtualHost.create(
         "v1", Collections.singletonList("foo.google.com"), Arrays.asList(route),
         ImmutableMap.of("filter-config-name-0", f0Override));
-    xdsClient.rdsCount.await(5, TimeUnit.SECONDS);
+    xdsClient.awaitRds();
     xdsClient.deliverRdsUpdate("r0", Collections.singletonList(virtualHost));
     start.get(5000, TimeUnit.MILLISECONDS);
     verify(mockServer).start();


### PR DESCRIPTION
`XdsServerWrapper#generatePerRouteInterceptors` was always intended to be executed within a sync context. This PR ensures that by calling `syncContext.throwIfNotInThisSynchronizationContext()`.

This change is needed for upcoming xDS filter state retention because the new tests in XdsServerWrapperTest flake with this NPE:

> `Cannot invoke "io.grpc.xds.client.XdsClient$ResourceWatcher.onChanged(io.grpc.xds.client.XdsClient$ResourceUpdate)" because "this.ldsWatcher" is null`