### PR TITLE
services: fix HealthService notifyWatchers

### DIFF
--- a/services/src/main/java/io/grpc/protobuf/services/HealthServiceImpl.java
+++ b/services/src/main/java/io/grpc/protobuf/services/HealthServiceImpl.java
@@ -176,7 +176,11 @@ final class HealthServiceImpl extends HealthGrpc.HealthImplBase {
         watchers.get(service);
     if (serviceWatchers != null) {
       for (StreamObserver<HealthCheckResponse> responseObserver : serviceWatchers.keySet()) {
-        responseObserver.onNext(response);
+        try {
+          responseObserver.onNext(response);
+        } catch (Exception e) {
+          logger.log(Level.WARNING, String.format("Exception notify service %s", service), e);
+        }
       }
     }
   }

--- a/services/src/main/java/io/grpc/protobuf/services/HealthServiceImpl.java
+++ b/services/src/main/java/io/grpc/protobuf/services/HealthServiceImpl.java
@@ -28,9 +28,11 @@ import io.grpc.health.v1.HealthCheckResponse;
 import io.grpc.health.v1.HealthCheckResponse.ServingStatus;
 import io.grpc.health.v1.HealthGrpc;
 import io.grpc.stub.StreamObserver;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -166,6 +168,18 @@ final class HealthServiceImpl extends HealthGrpc.HealthImplBase {
         return 0;
       }
       return serviceWatchers.size();
+    }
+  }
+
+  @VisibleForTesting
+  Set<StreamObserver<HealthCheckResponse>> watchersForTest(String service) {
+    synchronized (watchLock) {
+      IdentityHashMap<StreamObserver<HealthCheckResponse>, Boolean> serviceWatchers =
+              watchers.get(service);
+      if (serviceWatchers == null) {
+        return Collections.emptySet();
+      }
+      return serviceWatchers.keySet();
     }
   }
 


### PR DESCRIPTION
fix #11853 

Use ServerCallStreamObserver.setOnCancelHandler() to disable this exception
