### PR TITLE
xds: Support filter state retention

### DIFF
--- a/xds/src/main/java/io/grpc/xds/EnvoyServerProtoData.java
+++ b/xds/src/main/java/io/grpc/xds/EnvoyServerProtoData.java
@@ -207,7 +207,7 @@ public final class EnvoyServerProtoData {
   @AutoValue
   abstract static class FilterChain {
 
-    // possibly empty
+    // Must be unique per server instance (except the default chain).
     abstract String name();
 
     // TODO(sanjaypujare): flatten structure by moving FilterChainMatch class members here.

--- a/xds/src/main/java/io/grpc/xds/Filter.java
+++ b/xds/src/main/java/io/grpc/xds/Filter.java
@@ -20,6 +20,7 @@ import com.google.common.base.MoreObjects;
 import com.google.protobuf.Message;
 import io.grpc.ClientInterceptor;
 import io.grpc.ServerInterceptor;
+import java.io.Closeable;
 import java.util.Objects;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nullable;
@@ -32,7 +33,7 @@ import javax.annotation.Nullable;
  * {@link Provider#isClientFilter()}, {@link Provider#isServerFilter()} to indicate that the filter
  * is capable of working on the client side or server side or both, respectively.
  */
-interface Filter {
+interface Filter extends Closeable {
 
   /** Represents an opaque data structure holding configuration for a filter. */
   interface FilterConfig {
@@ -72,6 +73,21 @@ interface Filter {
      *
      * <p>Returns a filter instance registered with the same typeUrls as the provider,
      * capable of working with the same FilterConfig type returned by provider's parse functions.
+     *
+     * <p>For xDS gRPC clients, new filter instances are created per combination of:
+     * <ol>
+     *   <li><code>XdsNameResolver</code> instance,</li>
+     *   <li>Filter name+typeUrl in HttpConnectionManager (HCM) http_filters.</li>
+     * </ol>
+     *
+     * <p>For xDS-enabled gRPC servers, new filter instances are created per combination of:
+     * <ol>
+     *   <li>Server instance,</li>
+     *   <li>FilterChain name,</li>
+     *   <li>Filter name+typeUrl in FilterChain's HCM.http_filters.</li>
+     * </ol>
+     *
+     * <p>See {@link Filter#close()} for details on filter instance shutdown.
      */
     Filter newInstance();
 
@@ -103,6 +119,36 @@ interface Filter {
     return null;
   }
 
+  /**
+   * Implement to perform cleanup on filter shutdown.
+   *
+   * <p>Stateful filters should implement this method to perform cleanup, f.e. release shared
+   * resources, close remote connections, etc.
+   *
+   * <p>This method is called on the filter instance when an LDS update does not have
+   * the HttpConnectionManager that created the instance, or when HttpConnectionManager that created
+   * the instance no longer contains filter configuration for given name+typeUrl combination. More
+   * specifically:
+   *
+   * <p>Existing client-side filter instances are shutdown:
+   *   - A single a filter instance is shutdown when an LDS update contains HCM that is missing
+   *     filter configuration for name+typeUrl combination of this instance.
+   *   - All filter instances when watched LDS resource is missing from an LDS update.
+   *   - All filter instances name resolver shutdown.
+   *
+   * <p>Existing server-side filter instances are shutdown:
+   *   - A single a filter instance is shutdown when an LDS update contains FilterChain with
+   *     HCM.http_filters that is missing configuration for filter name+typeUrl.
+   *   - All filter instances associated with the FilterChain when an LDS update no longer
+   *     contains FilterChain's name.
+   *   - All filter instances when watched LDS resource is missing from an LDS update.
+   *   - All filter instances on server shutdown.
+   *
+   * <p>See {@link Provider#newInstance()} for details on filter instance creation.
+   */
+  @Override
+  default void close() {}
+
   /** Filter config with instance name. */
   final class NamedFilterConfig {
     // filter instance name
@@ -112,6 +158,10 @@ interface Filter {
     NamedFilterConfig(String name, FilterConfig filterConfig) {
       this.name = name;
       this.filterConfig = filterConfig;
+    }
+
+    String filterStateKey() {
+      return name + "_" + filterConfig.typeUrl();
     }
 
     @Override

--- a/xds/src/main/java/io/grpc/xds/Filter.java
+++ b/xds/src/main/java/io/grpc/xds/Filter.java
@@ -120,9 +120,6 @@ interface Filter extends Closeable {
   /**
    * Releases filter resources like shared resources and remote connections.
    *
-   * <p>Stateful filters should implement this method to perform cleanup, f.e. release shared
-   * resources, close remote connections, etc.
-   *
    * <p>See {@link Provider#newInstance()} for details on filter instance creation.
    */
   @Override

--- a/xds/src/main/java/io/grpc/xds/Filter.java
+++ b/xds/src/main/java/io/grpc/xds/Filter.java
@@ -86,8 +86,6 @@ interface Filter extends Closeable {
      *   <li>FilterChain name,</li>
      *   <li>Filter name+typeUrl in FilterChain's HCM.http_filters.</li>
      * </ol>
-     *
-     * <p>See {@link Filter#close()} for details on filter instance shutdown.
      */
     Filter newInstance();
 
@@ -120,29 +118,10 @@ interface Filter extends Closeable {
   }
 
   /**
-   * Implement to perform cleanup on filter shutdown.
+   * Releases filter resources like shared resources and remote connections.
    *
    * <p>Stateful filters should implement this method to perform cleanup, f.e. release shared
    * resources, close remote connections, etc.
-   *
-   * <p>This method is called on the filter instance when an LDS update does not have
-   * the HttpConnectionManager that created the instance, or when HttpConnectionManager that created
-   * the instance no longer contains filter configuration for given name+typeUrl combination. More
-   * specifically:
-   *
-   * <p>Existing client-side filter instances are shutdown:
-   *   - A single a filter instance is shutdown when an LDS update contains HCM that is missing
-   *     filter configuration for name+typeUrl combination of this instance.
-   *   - All filter instances when watched LDS resource is missing from an LDS update.
-   *   - All filter instances name resolver shutdown.
-   *
-   * <p>Existing server-side filter instances are shutdown:
-   *   - A single a filter instance is shutdown when an LDS update contains FilterChain with
-   *     HCM.http_filters that is missing configuration for filter name+typeUrl.
-   *   - All filter instances associated with the FilterChain when an LDS update no longer
-   *     contains FilterChain's name.
-   *   - All filter instances when watched LDS resource is missing from an LDS update.
-   *   - All filter instances on server shutdown.
    *
    * <p>See {@link Provider#newInstance()} for details on filter instance creation.
    */

--- a/xds/src/main/java/io/grpc/xds/FilterChainMatchingProtocolNegotiators.java
+++ b/xds/src/main/java/io/grpc/xds/FilterChainMatchingProtocolNegotiators.java
@@ -151,6 +151,10 @@ final class FilterChainMatchingProtocolNegotiators {
         this.defaultRoutingConfig = checkNotNull(defaultRoutingConfig, "defaultRoutingConfig");
       }
 
+      FilterChainSelector(Map<FilterChain, AtomicReference<ServerRoutingConfig>> routingConfigs) {
+        this(routingConfigs, null, new AtomicReference<>());
+      }
+
       @VisibleForTesting
       Map<FilterChain, AtomicReference<ServerRoutingConfig>> getRoutingConfigs() {
         return routingConfigs;

--- a/xds/src/main/java/io/grpc/xds/XdsListenerResource.java
+++ b/xds/src/main/java/io/grpc/xds/XdsListenerResource.java
@@ -178,6 +178,7 @@ class XdsListenerResource extends XdsResourceType<LdsUpdate> {
     }
 
     ImmutableList.Builder<FilterChain> filterChains = ImmutableList.builder();
+    Set<String> filterChainNames = new HashSet<>();
     Set<FilterChainMatch> filterChainMatchSet = new HashSet<>();
     int i = 0;
     for (io.envoyproxy.envoy.config.listener.v3.FilterChain fc : proto.getFilterChainsList()) {
@@ -186,6 +187,10 @@ class XdsListenerResource extends XdsResourceType<LdsUpdate> {
       if (filterChainName.isEmpty()) {
         // Generate a name, so we can identify it in the logs.
         filterChainName = "chain_" + i;
+      }
+      if (!filterChainNames.add(filterChainName)) {
+        throw new ResourceInvalidException("Filter chain names must be unique. "
+            + "Found duplicate: " + filterChainName);
       }
       filterChains.add(
           parseFilterChain(fc, filterChainName, tlsContextManager, filterRegistry,

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -127,6 +127,7 @@ final class XdsNameResolver extends NameResolver {
   private final ConfigSelector configSelector = new ConfigSelector();
   private final long randomChannelId;
   private final MetricRecorder metricRecorder;
+  // Must be accessed in syncContext.
   // Filter instances are unique per channel, and per filter (name+typeUrl).
   // NamedFilterConfig.filterStateKey -> filter_instance.
   private final HashMap<String, Filter> activeFilters = new HashMap<>();

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -727,16 +727,16 @@ final class XdsNameResolver extends NameResolver {
         String filterKey = namedFilter.filterStateKey();
 
         Filter.Provider provider = filterRegistry.get(typeUrl);
-        checkNotNull(provider, "provider " + typeUrl);
+        checkNotNull(provider, "provider %s", typeUrl);
         Filter filter = activeFilters.computeIfAbsent(filterKey, k -> provider.newInstance());
-        checkNotNull(filter, "filter " + filterKey);
+        checkNotNull(filter, "filter %s", filterKey);
         filtersToShutdown.remove(filterKey);
       }
 
       // Shutdown filters not present in current HCM.
       for (String filterKey : filtersToShutdown) {
         Filter filterToShutdown = activeFilters.remove(filterKey);
-        checkNotNull(filterToShutdown, "filterToShutdown " + filterKey);
+        checkNotNull(filterToShutdown, "filterToShutdown %s", filterKey);
         filterToShutdown.close();
       }
     }
@@ -874,9 +874,10 @@ final class XdsNameResolver extends NameResolver {
         String name = namedFilter.name;
         FilterConfig config = namedFilter.filterConfig;
         FilterConfig overrideConfig = selectedOverrideConfigs.get(name);
+        String filterKey = namedFilter.filterStateKey();
 
-        Filter filter = activeFilters.get(namedFilter.filterStateKey());
-        checkNotNull(filter, "activeFilters.get(" + namedFilter.filterStateKey() + ")");
+        Filter filter = activeFilters.get(filterKey);
+        checkNotNull(filter, "activeFilters.get(%s)", filterKey);
         ClientInterceptor interceptor =
             filter.buildClientInterceptor(config, overrideConfig, scheduler);
 

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -127,6 +127,9 @@ final class XdsNameResolver extends NameResolver {
   private final ConfigSelector configSelector = new ConfigSelector();
   private final long randomChannelId;
   private final MetricRecorder metricRecorder;
+  // Filter instances are unique per channel, and per filter (name+typeUrl).
+  // NamedFilterConfig.filterStateKey -> filter_instance.
+  private final HashMap<String, Filter> activeFilters = new HashMap<>();
 
   private volatile RoutingConfig routingConfig = RoutingConfig.EMPTY;
   private Listener2 listener;
@@ -658,18 +661,23 @@ final class XdsNameResolver extends NameResolver {
       HttpConnectionManager httpConnectionManager = update.httpConnectionManager();
       List<VirtualHost> virtualHosts = httpConnectionManager.virtualHosts();
       String rdsName = httpConnectionManager.rdsName();
+      ImmutableList<NamedFilterConfig> filterConfigs = httpConnectionManager.httpFilterConfigs();
+      long streamDurationNano = httpConnectionManager.httpMaxStreamDurationNano();
+
+      // Create/update HCM-bound state.
       cleanUpRouteDiscoveryState();
+      updateActiveFilters(filterConfigs);
+
+      // Routes specified directly in LDS.
       if (virtualHosts != null) {
-        updateRoutes(virtualHosts, httpConnectionManager.httpMaxStreamDurationNano(),
-            httpConnectionManager.httpFilterConfigs());
-      } else {
-        routeDiscoveryState = new RouteDiscoveryState(
-            rdsName, httpConnectionManager.httpMaxStreamDurationNano(),
-            httpConnectionManager.httpFilterConfigs());
-        logger.log(XdsLogLevel.INFO, "Start watching RDS resource {0}", rdsName);
-        xdsClient.watchXdsResource(XdsRouteConfigureResource.getInstance(),
-            rdsName, routeDiscoveryState, syncContext);
+        updateRoutes(virtualHosts, streamDurationNano, filterConfigs);
+        return;
       }
+      // Routes provided by RDS.
+      routeDiscoveryState = new RouteDiscoveryState(rdsName, streamDurationNano, filterConfigs);
+      logger.log(XdsLogLevel.INFO, "Start watching RDS resource {0}", rdsName);
+      xdsClient.watchXdsResource(XdsRouteConfigureResource.getInstance(),
+          rdsName, routeDiscoveryState, syncContext);
     }
 
     @Override
@@ -690,6 +698,7 @@ final class XdsNameResolver extends NameResolver {
       String error = "LDS resource does not exist: " + resourceName;
       logger.log(XdsLogLevel.INFO, error);
       cleanUpRouteDiscoveryState();
+      updateActiveFilters(null);
       cleanUpRoutes(error);
     }
 
@@ -703,7 +712,33 @@ final class XdsNameResolver extends NameResolver {
       logger.log(XdsLogLevel.INFO, "Stop watching LDS resource {0}", ldsResourceName);
       stopped = true;
       cleanUpRouteDiscoveryState();
+      updateActiveFilters(null);
       xdsClient.cancelXdsResourceWatch(XdsListenerResource.getInstance(), ldsResourceName, this);
+    }
+
+    // called in syncContext
+    private void updateActiveFilters(@Nullable List<NamedFilterConfig> filterConfigs) {
+      if (filterConfigs == null) {
+        filterConfigs = ImmutableList.of();
+      }
+      Set<String> filtersToShutdown = new HashSet<>(activeFilters.keySet());
+      for (NamedFilterConfig namedFilter : filterConfigs) {
+        String typeUrl = namedFilter.filterConfig.typeUrl();
+        String filterKey = namedFilter.filterStateKey();
+
+        Filter.Provider provider = filterRegistry.get(typeUrl);
+        checkNotNull(provider, "provider " + typeUrl);
+        Filter filter = activeFilters.computeIfAbsent(filterKey, k -> provider.newInstance());
+        checkNotNull(filter, "filter " + filterKey);
+        filtersToShutdown.remove(filterKey);
+      }
+
+      // Shutdown filters not present in current HCM.
+      for (String filterKey : filtersToShutdown) {
+        Filter filterToShutdown = activeFilters.remove(filterKey);
+        checkNotNull(filterToShutdown, "filterToShutdown " + filterKey);
+        filterToShutdown.close();
+      }
     }
 
     // called in syncContext
@@ -836,19 +871,15 @@ final class XdsNameResolver extends NameResolver {
 
       ImmutableList.Builder<ClientInterceptor> filterInterceptors = ImmutableList.builder();
       for (NamedFilterConfig namedFilter : filterConfigs) {
-        FilterConfig config = namedFilter.filterConfig;
         String name = namedFilter.name;
-        String typeUrl = config.typeUrl();
+        FilterConfig config = namedFilter.filterConfig;
+        FilterConfig overrideConfig = selectedOverrideConfigs.get(name);
 
-        Filter.Provider provider = filterRegistry.get(typeUrl);
-        if (provider == null || !provider.isClientFilter()) {
-          continue;
-        }
-
-        Filter filter = provider.newInstance();
-
+        Filter filter = activeFilters.get(namedFilter.filterStateKey());
+        checkNotNull(filter, "activeFilters.get(" + namedFilter.filterStateKey() + ")");
         ClientInterceptor interceptor =
-            filter.buildClientInterceptor(config, selectedOverrideConfigs.get(name), scheduler);
+            filter.buildClientInterceptor(config, overrideConfig, scheduler);
+
         if (interceptor != null) {
           filterInterceptors.add(interceptor);
         }

--- a/xds/src/main/java/io/grpc/xds/XdsServerWrapper.java
+++ b/xds/src/main/java/io/grpc/xds/XdsServerWrapper.java
@@ -523,7 +523,7 @@ final class XdsServerWrapper extends Server {
       // Shutdown all filters of chains missing from the LDS.
       for (String chainToShutdown : removedChains) {
         HashMap<String, Filter> filtersToShutdown = activeFilters.get(chainToShutdown);
-        checkNotNull(filtersToShutdown, "filtersToShutdown of " + chainToShutdown);
+        checkNotNull(filtersToShutdown, "filtersToShutdown of chain %s", chainToShutdown);
         updateActiveFiltersForChain(filtersToShutdown, null);
         activeFilters.remove(chainToShutdown);
       }
@@ -559,16 +559,16 @@ final class XdsServerWrapper extends Server {
         String filterKey = namedFilter.filterStateKey();
 
         Filter.Provider provider = filterRegistry.get(typeUrl);
-        checkNotNull(provider, "provider " + typeUrl);
+        checkNotNull(provider, "provider %s", typeUrl);
         Filter filter = chainFilters.computeIfAbsent(filterKey, k -> provider.newInstance());
-        checkNotNull(filter, "filter " + filterKey);
+        checkNotNull(filter, "filter %s", filterKey);
         filtersToShutdown.remove(filterKey);
       }
 
       // Shutdown filters not present in current HCM.
       for (String filterKey : filtersToShutdown) {
         Filter filterToShutdown = chainFilters.remove(filterKey);
-        checkNotNull(filterToShutdown, "filterToShutdown " + filterKey);
+        checkNotNull(filterToShutdown, "filterToShutdown %s", filterKey);
         filterToShutdown.close();
       }
     }
@@ -632,9 +632,10 @@ final class XdsServerWrapper extends Server {
             String name = namedFilter.name;
             FilterConfig config = namedFilter.filterConfig;
             FilterConfig overrideConfig = perRouteOverrides.get(name);
+            String filterKey = namedFilter.filterStateKey();
 
-            Filter filter = chainFilters.get(namedFilter.filterStateKey());
-            checkNotNull(filter, "chainFilters.get(" + namedFilter.filterStateKey() + ")");
+            Filter filter = chainFilters.get(filterKey);
+            checkNotNull(filter, "chainFilters.get(%s)", filterKey);
             ServerInterceptor interceptor = filter.buildServerInterceptor(config, overrideConfig);
 
             if (interceptor != null) {

--- a/xds/src/main/java/io/grpc/xds/XdsServerWrapper.java
+++ b/xds/src/main/java/io/grpc/xds/XdsServerWrapper.java
@@ -113,6 +113,14 @@ final class XdsServerWrapper extends Server {
   private DiscoveryState discoveryState;
   private volatile Server delegate;
 
+  // Must be updated in the sync context.
+  // Filter instances are unique per Server, per FilterChain, and per filter's name+typeUrl.
+  // FilterChain.name -> <NamedFilterConfig.filterStateKey -> filter_instance>.
+  private final HashMap<String, HashMap<String, Filter>> activeFilters = new HashMap<>();
+  // Default filter chain Filter instances are unique per Server, and per filter's name+typeUrl.
+  // NamedFilterConfig.filterStateKey -> filter_instance.
+  private final HashMap<String, Filter> activeFiltersDefaultChain = new HashMap<>();
+
   XdsServerWrapper(
       String listenerAddress,
       ServerBuilder<?> delegateBuilder,
@@ -382,13 +390,18 @@ final class XdsServerWrapper extends Server {
         releaseSuppliersInFlight();
         pendingRds.clear();
       }
+
       filterChains = update.listener().filterChains();
       defaultFilterChain = update.listener().defaultFilterChain();
+      // Filters are loaded even if the server isn't serving yet.
+      updateActiveFilters();
+
       List<FilterChain> allFilterChains = filterChains;
       if (defaultFilterChain != null) {
         allFilterChains = new ArrayList<>(filterChains);
         allFilterChains.add(defaultFilterChain);
       }
+
       Set<String> allRds = new HashSet<>();
       for (FilterChain filterChain : allFilterChains) {
         HttpConnectionManager hcm = filterChain.httpConnectionManager();
@@ -406,6 +419,7 @@ final class XdsServerWrapper extends Server {
           allRds.add(hcm.rdsName());
         }
       }
+
       for (Map.Entry<String, RouteDiscoveryState> entry: routeDiscoveryStates.entrySet()) {
         if (!allRds.contains(entry.getKey())) {
           xdsClient.cancelXdsResourceWatch(XdsRouteConfigureResource.getInstance(),
@@ -448,6 +462,7 @@ final class XdsServerWrapper extends Server {
       cleanUpRouteDiscoveryStates();
       logger.log(Level.FINE, "Stop watching LDS resource {0}", resourceName);
       xdsClient.cancelXdsResourceWatch(XdsListenerResource.getInstance(), resourceName, this);
+      shutdownActiveFilters();
       List<SslContextProviderSupplier> toRelease = getSuppliersInUse();
       filterChainSelectorManager.updateSelector(FilterChainSelector.NO_FILTER_CHAIN);
       for (SslContextProviderSupplier s: toRelease) {
@@ -464,7 +479,8 @@ final class XdsServerWrapper extends Server {
       ImmutableMap.Builder<FilterChain, AtomicReference<ServerRoutingConfig>> routingConfigs =
           ImmutableMap.builder();
       for (FilterChain filterChain: filterChains) {
-        routingConfigs.put(filterChain, generateRoutingConfig(filterChain));
+        HashMap<String, Filter> chainFilters = activeFilters.get(filterChain.name());
+        routingConfigs.put(filterChain, generateRoutingConfig(filterChain, chainFilters));
       }
 
       // Prepare the new selector.
@@ -473,9 +489,9 @@ final class XdsServerWrapper extends Server {
         selector = new FilterChainSelector(
             routingConfigs.build(),
             defaultFilterChain.sslContextProviderSupplier(),
-            generateRoutingConfig(defaultFilterChain));
+            generateRoutingConfig(defaultFilterChain, activeFiltersDefaultChain));
       } else {
-        selector = new FilterChainSelector(routingConfigs.build(), null, new AtomicReference<>());
+        selector = new FilterChainSelector(routingConfigs.build());
       }
 
       // Prepare the list of current selector's resources to close later.
@@ -494,38 +510,105 @@ final class XdsServerWrapper extends Server {
       startDelegateServer();
     }
 
-    private AtomicReference<ServerRoutingConfig> generateRoutingConfig(FilterChain filterChain) {
+    // called in syncContext
+    private void updateActiveFilters() {
+      Set<String> removedChains = new HashSet<>(activeFilters.keySet());
+      for (FilterChain filterChain: filterChains) {
+        removedChains.remove(filterChain.name());
+        updateActiveFiltersForChain(
+            activeFilters.computeIfAbsent(filterChain.name(), k -> new HashMap<>()),
+            filterChain.httpConnectionManager().httpFilterConfigs());
+      }
+
+      // Shutdown all filters of chains missing from the LDS.
+      for (String chainToShutdown : removedChains) {
+        HashMap<String, Filter> filtersToShutdown = activeFilters.get(chainToShutdown);
+        checkNotNull(filtersToShutdown, "filtersToShutdown of " + chainToShutdown);
+        updateActiveFiltersForChain(filtersToShutdown, null);
+        activeFilters.remove(chainToShutdown);
+      }
+
+      // Default chain.
+      ImmutableList<NamedFilterConfig> defaultChainConfigs = null;
+      if (defaultFilterChain != null) {
+        defaultChainConfigs = defaultFilterChain.httpConnectionManager().httpFilterConfigs();
+      }
+      updateActiveFiltersForChain(activeFiltersDefaultChain, defaultChainConfigs);
+    }
+
+    // called in syncContext
+    private void shutdownActiveFilters() {
+      for (HashMap<String, Filter> chainFilters : activeFilters.values()) {
+        checkNotNull(chainFilters, "chainFilters");
+        updateActiveFiltersForChain(chainFilters, null);
+      }
+      activeFilters.clear();
+      updateActiveFiltersForChain(activeFiltersDefaultChain, null);
+    }
+
+    // called in syncContext
+    private void updateActiveFiltersForChain(
+        Map<String, Filter> chainFilters, @Nullable List<NamedFilterConfig> filterConfigs) {
+      if (filterConfigs == null) {
+        filterConfigs = ImmutableList.of();
+      }
+
+      Set<String> filtersToShutdown = new HashSet<>(chainFilters.keySet());
+      for (NamedFilterConfig namedFilter : filterConfigs) {
+        String typeUrl = namedFilter.filterConfig.typeUrl();
+        String filterKey = namedFilter.filterStateKey();
+
+        Filter.Provider provider = filterRegistry.get(typeUrl);
+        checkNotNull(provider, "provider " + typeUrl);
+        Filter filter = chainFilters.computeIfAbsent(filterKey, k -> provider.newInstance());
+        checkNotNull(filter, "filter " + filterKey);
+        filtersToShutdown.remove(filterKey);
+      }
+
+      // Shutdown filters not present in current HCM.
+      for (String filterKey : filtersToShutdown) {
+        Filter filterToShutdown = chainFilters.remove(filterKey);
+        checkNotNull(filterToShutdown, "filterToShutdown " + filterKey);
+        filterToShutdown.close();
+      }
+    }
+
+    private AtomicReference<ServerRoutingConfig> generateRoutingConfig(
+        FilterChain filterChain, Map<String, Filter> chainFilters) {
       HttpConnectionManager hcm = filterChain.httpConnectionManager();
-      ImmutableMap<Route, ServerInterceptor> interceptors;
+      ServerRoutingConfig routingConfig;
 
       // Inlined routes.
-      if (hcm.virtualHosts() != null) {
-        interceptors = generatePerRouteInterceptors(hcm.httpFilterConfigs(), hcm.virtualHosts());
-        return new AtomicReference<>(ServerRoutingConfig.create(hcm.virtualHosts(), interceptors));
+      ImmutableList<VirtualHost> vhosts = hcm.virtualHosts();
+      if (vhosts != null) {
+        routingConfig = ServerRoutingConfig.create(vhosts,
+            generatePerRouteInterceptors(hcm.httpFilterConfigs(), vhosts, chainFilters));
+        return new AtomicReference<>(routingConfig);
       }
 
       // Routes from RDS.
       RouteDiscoveryState rds = routeDiscoveryStates.get(hcm.rdsName());
       checkNotNull(rds, "rds");
 
-      ServerRoutingConfig routingConfig;
       ImmutableList<VirtualHost> savedVhosts = rds.savedVirtualHosts;
       if (savedVhosts != null) {
-        interceptors = generatePerRouteInterceptors(hcm.httpFilterConfigs(), savedVhosts);
-        routingConfig = ServerRoutingConfig.create(savedVhosts, interceptors);
+        routingConfig = ServerRoutingConfig.create(savedVhosts,
+            generatePerRouteInterceptors(hcm.httpFilterConfigs(), savedVhosts, chainFilters));
       } else {
         routingConfig = ServerRoutingConfig.FAILING_ROUTING_CONFIG;
       }
-
       AtomicReference<ServerRoutingConfig> routingConfigRef = new AtomicReference<>(routingConfig);
       savedRdsRoutingConfigRef.put(filterChain, routingConfigRef);
       return routingConfigRef;
     }
 
     private ImmutableMap<Route, ServerInterceptor> generatePerRouteInterceptors(
-        @Nullable List<NamedFilterConfig> filterConfigs, List<VirtualHost> virtualHosts) {
+        @Nullable List<NamedFilterConfig> filterConfigs,
+        List<VirtualHost> virtualHosts,
+        Map<String, Filter> chainFilters) {
       syncContext.throwIfNotInThisSynchronizationContext();
 
+      checkNotNull(chainFilters, "chainFilters");
       ImmutableMap.Builder<Route, ServerInterceptor> perRouteInterceptors =
           new ImmutableMap.Builder<>();
 
@@ -545,21 +628,15 @@ final class XdsServerWrapper extends Server {
 
           // Interceptors for this vhost/route combo.
           List<ServerInterceptor> interceptors = new ArrayList<>(filterConfigs.size());
-
           for (NamedFilterConfig namedFilter : filterConfigs) {
-            FilterConfig config = namedFilter.filterConfig;
             String name = namedFilter.name;
-            String typeUrl = config.typeUrl();
+            FilterConfig config = namedFilter.filterConfig;
+            FilterConfig overrideConfig = perRouteOverrides.get(name);
 
-            Filter.Provider provider = filterRegistry.get(typeUrl);
-            if (provider == null || !provider.isServerFilter()) {
-              logger.warning("HttpFilter[" + name + "]: not supported on server-side: " + typeUrl);
-              continue;
-            }
+            Filter filter = chainFilters.get(namedFilter.filterStateKey());
+            checkNotNull(filter, "chainFilters.get(" + namedFilter.filterStateKey() + ")");
+            ServerInterceptor interceptor = filter.buildServerInterceptor(config, overrideConfig);
 
-            Filter filter = provider.newInstance();
-            ServerInterceptor interceptor =
-                filter.buildServerInterceptor(config, perRouteOverrides.get(name));
             if (interceptor != null) {
               interceptors.add(interceptor);
             }
@@ -597,6 +674,7 @@ final class XdsServerWrapper extends Server {
 
     private void handleConfigNotFound(StatusException exception) {
       cleanUpRouteDiscoveryStates();
+      shutdownActiveFilters();
       List<SslContextProviderSupplier> toRelease = getSuppliersInUse();
       filterChainSelectorManager.updateSelector(FilterChainSelector.NO_FILTER_CHAIN);
       for (SslContextProviderSupplier s: toRelease) {
@@ -718,22 +796,24 @@ final class XdsServerWrapper extends Server {
 
       private void updateRdsRoutingConfig() {
         for (FilterChain filterChain : savedRdsRoutingConfigRef.keySet()) {
-          if (resourceName.equals(filterChain.httpConnectionManager().rdsName())) {
-            ServerRoutingConfig updatedRoutingConfig;
-            if (savedVirtualHosts == null) {
-              updatedRoutingConfig = ServerRoutingConfig.FAILING_ROUTING_CONFIG;
-            } else {
-              ImmutableMap<Route, ServerInterceptor> updatedInterceptors =
-                  generatePerRouteInterceptors(
-                      filterChain.httpConnectionManager().httpFilterConfigs(),
-                      savedVirtualHosts);
-              updatedRoutingConfig = ServerRoutingConfig.create(savedVirtualHosts,
-                  updatedInterceptors);
-            }
-            logger.log(Level.FINEST, "Updating filter chain {0} rds routing config: {1}",
-                new Object[]{filterChain.name(), updatedRoutingConfig});
-            savedRdsRoutingConfigRef.get(filterChain).set(updatedRoutingConfig);
+          HttpConnectionManager hcm = filterChain.httpConnectionManager();
+          if (!resourceName.equals(hcm.rdsName())) {
+            continue;
           }
+
+          ServerRoutingConfig updatedRoutingConfig;
+          if (savedVirtualHosts == null) {
+            updatedRoutingConfig = ServerRoutingConfig.FAILING_ROUTING_CONFIG;
+          } else {
+            HashMap<String, Filter> chainFilters = activeFilters.get(filterChain.name());
+            ImmutableMap<Route, ServerInterceptor> interceptors = generatePerRouteInterceptors(
+                hcm.httpFilterConfigs(), savedVirtualHosts, chainFilters);
+            updatedRoutingConfig = ServerRoutingConfig.create(savedVirtualHosts, interceptors);
+          }
+
+          logger.log(Level.FINEST, "Updating filter chain {0} rds routing config: {1}",
+              new Object[]{filterChain.name(), updatedRoutingConfig});
+          savedRdsRoutingConfigRef.get(filterChain).set(updatedRoutingConfig);
         }
       }
 

--- a/xds/src/main/java/io/grpc/xds/XdsServerWrapper.java
+++ b/xds/src/main/java/io/grpc/xds/XdsServerWrapper.java
@@ -113,7 +113,7 @@ final class XdsServerWrapper extends Server {
   private DiscoveryState discoveryState;
   private volatile Server delegate;
 
-  // Must be updated in the sync context.
+  // Must be accessed in syncContext.
   // Filter instances are unique per Server, per FilterChain, and per filter's name+typeUrl.
   // FilterChain.name -> <NamedFilterConfig.filterStateKey -> filter_instance>.
   private final HashMap<String, HashMap<String, Filter>> activeFilters = new HashMap<>();

--- a/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplDataTest.java
@@ -2829,6 +2829,45 @@ public class GrpcXdsClientImplDataTest {
   }
 
   @Test
+  public void parseFilterChain_duplicateName() throws ResourceInvalidException {
+    FilterChain filterChain0 =
+        FilterChain.newBuilder()
+            .setName("filter_chain")
+            .setFilterChainMatch(FilterChainMatch.getDefaultInstance())
+            .addFilters(buildHttpConnectionManagerFilter(
+                HttpFilter.newBuilder()
+                    .setName("http-filter-foo")
+                    .setIsOptional(true)
+                    .setTypedConfig(Any.pack(Router.newBuilder().build()))
+                    .build()))
+            .build();
+
+    FilterChain filterChain1 =
+        FilterChain.newBuilder()
+            .setName("filter_chain")
+            .setFilterChainMatch(
+                FilterChainMatch.newBuilder().addAllSourcePorts(Arrays.asList(443, 8080)))
+            .addFilters(buildHttpConnectionManagerFilter(
+                HttpFilter.newBuilder()
+                    .setName("http-filter-bar")
+                    .setTypedConfig(Any.pack(Router.newBuilder().build()))
+                    .setIsOptional(true)
+                    .build()))
+            .build();
+
+    Listener listenerProto =
+        Listener.newBuilder()
+            .setName("listener1")
+            .setTrafficDirection(TrafficDirection.INBOUND)
+            .addAllFilterChains(Arrays.asList(filterChain0, filterChain1))
+            .build();
+    thrown.expect(ResourceInvalidException.class);
+    thrown.expectMessage("Filter chain names must be unique. Found duplicate: filter_chain");
+    XdsListenerResource.parseServerSideListener(
+        listenerProto, null, filterRegistry, null, getXdsResourceTypeArgs(true));
+  }
+
+  @Test
   public void validateCommonTlsContext_tlsParams() throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
             .setTlsParams(TlsParameters.getDefaultInstance())

--- a/xds/src/test/java/io/grpc/xds/StatefulFilter.java
+++ b/xds/src/test/java/io/grpc/xds/StatefulFilter.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2025 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+import com.google.common.collect.ImmutableList;
+import com.google.protobuf.Message;
+import io.grpc.ServerInterceptor;
+import java.util.ConcurrentModificationException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.IntStream;
+import javax.annotation.Nullable;
+
+/**
+ * Unlike most singleton-based filters, each StatefulFilter object has a distinct identity.
+ */
+class StatefulFilter implements Filter {
+
+  static final String DEFAULT_TYPE_URL = "type.googleapis.com/grpc.test.StatefulFilter";
+  private final AtomicBoolean shutdown = new AtomicBoolean();
+
+  final int idx;
+  @Nullable volatile String lastCfg = null;
+
+  public StatefulFilter(int idx) {
+    this.idx = idx;
+  }
+
+  public boolean isShutdown() {
+    return shutdown.get();
+  }
+
+  @Override
+  public void close() {
+    if (!shutdown.compareAndSet(false, true)) {
+      throw new ConcurrentModificationException(
+          "Unexpected: StatefulFilter#close called multiple times");
+    }
+  }
+
+  @Nullable
+  @Override
+  public ServerInterceptor buildServerInterceptor(
+      FilterConfig config,
+      @Nullable FilterConfig overrideConfig) {
+    Config cfg = (Config) config;
+    // TODO(sergiitk): to be replaced when name argument passed to the constructor.
+    lastCfg = cfg.getConfig();
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder().append("StatefulFilter{")
+        .append("idx=").append(idx);
+    if (lastCfg != null) {
+      sb.append(", name=").append(lastCfg);
+    }
+    return sb.append("}").toString();
+  }
+
+  static final class Provider implements Filter.Provider {
+
+    private final String typeUrl;
+    private final ConcurrentMap<Integer, StatefulFilter> instances = new ConcurrentHashMap<>();
+
+    volatile int counter;
+
+    Provider() {
+      this(DEFAULT_TYPE_URL);
+    }
+
+    Provider(String typeUrl) {
+      this.typeUrl = typeUrl;
+    }
+
+    @Override
+    public String[] typeUrls() {
+      return new String[]{ typeUrl };
+    }
+
+    @Override
+    public boolean isClientFilter() {
+      return true;
+    }
+
+    @Override
+    public boolean isServerFilter() {
+      return true;
+    }
+
+    @Override
+    public synchronized StatefulFilter newInstance() {
+      StatefulFilter filter = new StatefulFilter(counter++);
+      instances.put(filter.idx, filter);
+      return filter;
+    }
+
+    public synchronized StatefulFilter getInstance(int idx) {
+      return instances.get(idx);
+    }
+
+    public synchronized ImmutableList<StatefulFilter> getAllInstances() {
+      return IntStream.range(0, counter).mapToObj(this::getInstance).collect(toImmutableList());
+    }
+
+    @SuppressWarnings("UnusedMethod")
+    public synchronized int getCount() {
+      return counter;
+    }
+
+    @Override
+    public ConfigOrError<Config> parseFilterConfig(Message rawProtoMessage) {
+      return ConfigOrError.fromConfig(Config.fromProto(rawProtoMessage, typeUrl));
+    }
+
+    @Override
+    public ConfigOrError<Config> parseFilterConfigOverride(Message rawProtoMessage) {
+      return ConfigOrError.fromConfig(Config.fromProto(rawProtoMessage, typeUrl));
+    }
+  }
+
+
+  static final class Config implements FilterConfig {
+
+    private final String typeUrl;
+    private final String config;
+
+    public Config(String config, String typeUrl) {
+      this.config = config;
+      this.typeUrl = typeUrl;
+    }
+
+    public Config(String config) {
+      this(config, DEFAULT_TYPE_URL);
+    }
+
+    public Config() {
+      this("<BLANK>", DEFAULT_TYPE_URL);
+    }
+
+    public static Config fromProto(Message rawProtoMessage, String typeUrl) {
+      checkNotNull(rawProtoMessage, "rawProtoMessage");
+      return new Config(rawProtoMessage.toString(), typeUrl);
+    }
+
+    public String getConfig() {
+      return config;
+    }
+
+    @Override
+    public String typeUrl() {
+      return typeUrl;
+    }
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/XdsServerWrapperTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerWrapperTest.java
@@ -18,6 +18,7 @@
 package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static io.grpc.xds.XdsServerWrapper.ATTR_SERVER_ROUTING_CONFIG;
 import static io.grpc.xds.XdsServerWrapper.RETRY_DELAY_NANOS;
 import static org.junit.Assert.fail;
@@ -49,10 +50,13 @@ import io.grpc.StatusException;
 import io.grpc.SynchronizationContext;
 import io.grpc.internal.FakeClock;
 import io.grpc.testing.TestMethodDescriptors;
+import io.grpc.xds.EnvoyServerProtoData.CidrRange;
 import io.grpc.xds.EnvoyServerProtoData.FilterChain;
+import io.grpc.xds.EnvoyServerProtoData.FilterChainMatch;
 import io.grpc.xds.Filter.FilterConfig;
 import io.grpc.xds.Filter.NamedFilterConfig;
 import io.grpc.xds.FilterChainMatchingProtocolNegotiators.FilterChainMatchingHandler.FilterChainSelector;
+import io.grpc.xds.StatefulFilter.Config;
 import io.grpc.xds.VirtualHost.Route;
 import io.grpc.xds.VirtualHost.Route.RouteMatch;
 import io.grpc.xds.VirtualHost.Route.RouteMatch.PathMatcher;
@@ -70,10 +74,12 @@ import io.grpc.xds.internal.Matchers.HeaderMatcher;
 import io.grpc.xds.internal.security.CommonTlsContextTestsUtil;
 import io.grpc.xds.internal.security.SslContextProviderSupplier;
 import java.io.IOException;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -93,6 +99,14 @@ import org.mockito.junit.MockitoRule;
 @RunWith(JUnit4.class)
 public class XdsServerWrapperTest {
   private static final int START_WAIT_AFTER_LISTENER_MILLIS = 100;
+  private static final String ROUTER_FILTER_INSTANCE_NAME = "envoy.router";
+  private static final RouterFilter.Provider ROUTER_FILTER_PROVIDER = new RouterFilter.Provider();
+
+  // Readability: makes it simpler to distinguish resource parameters.
+  private static final ImmutableMap<String, FilterConfig> NO_FILTER_OVERRIDES = ImmutableMap.of();
+
+  private static final String STATEFUL_1 = "stateful_1";
+  private static final String STATEFUL_2 = "stateful_2";
 
   @Rule
   public final MockitoRule mocks = MockitoJUnit.rule();
@@ -1268,9 +1282,507 @@ public class XdsServerWrapperTest {
         .get(filterChain).get()).isEqualTo(noopConfig);
   }
 
+  // Begin filter state tests.
+
+  @Test
+  public void filterState_survivesLds() {
+    StatefulFilter.Provider statefulFilterProvider = new StatefulFilter.Provider();
+    FilterRegistry filterRegistry = filterStateTestFilterRegistry(statefulFilterProvider);
+    SettableFuture<Server> serverStart = filterStateTestStartServer(filterRegistry);
+
+    VirtualHost vhost = filterStateTestVhost();
+
+    // LDS 1.
+    FilterChain lds1FilterChain = createFilterChain("chain_0",
+        createHcm(vhost, filterStateTestConfigs(STATEFUL_1, STATEFUL_2)));
+    xdsClient.deliverLdsUpdate(lds1FilterChain, null);
+    verifyServerStarted(serverStart);
+    ImmutableList<StatefulFilter> lds1Snapshot = statefulFilterProvider.getAllInstances();
+    // Verify that StatefulFilter with different filter names result in different Filter instances.
+    assertWithMessage("LDS 1: expected to create filter instances").that(lds1Snapshot).hasSize(2);
+    // Naming: lds<LDS#>Filter<name#>
+    StatefulFilter lds1Filter1 = lds1Snapshot.get(0);
+    StatefulFilter lds1Filter2 = lds1Snapshot.get(1);
+    assertThat(lds1Filter1).isNotSameInstanceAs(lds1Filter2);
+    // Redundant check just in case StatefulFilter synchronization is broken.
+    assertThat(lds1Filter1.idx).isEqualTo(0);
+    assertThat(lds1Filter2.idx).isEqualTo(1);
+
+    // LDS 2: filter configs with the same names.
+    FilterChain lds2FilterChain = createFilterChain("chain_0",
+        createHcm(vhost, filterStateTestConfigs(STATEFUL_1, STATEFUL_2)));
+    xdsClient.deliverLdsUpdate(lds2FilterChain, null);
+    ImmutableList<StatefulFilter> lds2Snapshot = statefulFilterProvider.getAllInstances();
+    // Filter names hasn't changed, so expecting no new StatefulFilter instances.
+    assertWithMessage("LDS 2: Expected Filter instances to be reused across LDS updates")
+        .that(lds2Snapshot).isEqualTo(lds1Snapshot);
+
+    // LDS 3: Filter "STATEFUL_2" removed.
+    FilterChain lds3FilterChain = createFilterChain("chain_0",
+        createHcm(vhost, filterStateTestConfigs(STATEFUL_1)));
+    xdsClient.deliverLdsUpdate(lds3FilterChain, null);
+    ImmutableList<StatefulFilter> lds3Snapshot = statefulFilterProvider.getAllInstances();
+    // Again, no new StatefulFilter instances should be created.
+    assertWithMessage("LDS 3: Expected Filter instances to be reused across LDS updates")
+        .that(lds3Snapshot).isEqualTo(lds1Snapshot);
+    // Verify the shutdown state.
+    assertThat(lds1Filter1.isShutdown()).isFalse();
+    assertWithMessage("LDS 3: Expected %s to be shut down", lds1Filter2)
+        .that(lds1Filter2.isShutdown()).isTrue();
+
+    // LDS 4: Filter "STATEFUL_2" added back.
+    FilterChain lds4FilterChain = createFilterChain("chain_0",
+        createHcm(vhost, filterStateTestConfigs(STATEFUL_1, STATEFUL_2)));
+    xdsClient.deliverLdsUpdate(lds4FilterChain, null);
+    ImmutableList<StatefulFilter> lds4Snapshot = statefulFilterProvider.getAllInstances();
+    // Filter "STATEFUL_2" should be treated as any other new filter name in an LDS update:
+    // a new instance should be created.
+    assertWithMessage("LDS 4: Expected a new filter instance for %s", STATEFUL_2)
+        .that(lds4Snapshot).hasSize(3);
+    StatefulFilter lds4Filter2 = lds4Snapshot.get(2);
+    assertThat(lds4Filter2.idx).isEqualTo(2);
+    assertThat(lds4Filter2).isNotSameInstanceAs(lds1Filter2);
+    assertThat(lds4Snapshot).containsAtLeastElementsIn(lds1Snapshot);
+    // Verify the shutdown state.
+    assertThat(lds1Filter1.isShutdown()).isFalse();
+    assertThat(lds1Filter2.isShutdown()).isTrue();
+    assertThat(lds4Filter2.isShutdown()).isFalse();
+  }
+
+  @Test
+  public void filterState_survivesRds() throws Exception {
+    StatefulFilter.Provider statefulFilterProvider = new StatefulFilter.Provider();
+    FilterRegistry filterRegistry = filterStateTestFilterRegistry(statefulFilterProvider);
+    SettableFuture<Server> serverStart = filterStateTestStartServer(filterRegistry);
+
+    String rdsName = "rds.example.com";
+
+    // LDS 1.
+    FilterChain fc1 = createFilterChain("fc1",
+        createHcmForRds(rdsName, filterStateTestConfigs(STATEFUL_1, STATEFUL_2)));
+    xdsClient.deliverLdsUpdate(fc1, null);
+    xdsClient.awaitRds(FakeXdsClient.DEFAULT_TIMEOUT);
+    verify(listener, never()).onServing();
+    // Server didn't start, but filter instances should have already been created.
+    ImmutableList<StatefulFilter> lds1Snapshot = statefulFilterProvider.getAllInstances();
+    assertWithMessage("LDS 1: expected to create filter instances").that(lds1Snapshot).hasSize(2);
+    // Naming: lds<LDS#>Filter<name#>
+    StatefulFilter lds1Filter1 = lds1Snapshot.get(0);
+    StatefulFilter lds1Filter2 = lds1Snapshot.get(1);
+    assertThat(lds1Filter1).isNotSameInstanceAs(lds1Filter2);
+
+    // RDS 1.
+    VirtualHost vhost1 = filterStateTestVhost();
+    xdsClient.deliverRdsUpdate(rdsName, vhost1);
+    verifyServerStarted(serverStart);
+    assertThat(getSelectorRoutingConfigs()).hasSize(1);
+    assertThat(getSelectorVhosts(fc1)).containsExactly(vhost1);
+    // Initial RDS update should not generate Filter instances.
+    ImmutableList<StatefulFilter> rds1Snapshot = statefulFilterProvider.getAllInstances();
+    assertWithMessage("RDS 1: Expected Filter instances to be reused across RDS route updates")
+        .that(rds1Snapshot).isEqualTo(lds1Snapshot);
+
+    // RDS 2: exactly the same as RDS 1.
+    xdsClient.deliverRdsUpdate(rdsName, vhost1);
+    assertThat(getSelectorRoutingConfigs()).hasSize(1);
+    assertThat(getSelectorVhosts(fc1)).containsExactly(vhost1);
+    ImmutableList<StatefulFilter> rds2Snapshot = statefulFilterProvider.getAllInstances();
+    // Neither should any subsequent RDS updates.
+    assertWithMessage("RDS 2: Expected Filter instances to be reused across RDS route updates")
+        .that(rds2Snapshot).isEqualTo(lds1Snapshot);
+
+    // RDS 3: Contains a per-route override for STATEFUL_1.
+    VirtualHost vhost3 = filterStateTestVhost(vhost1.name(), ImmutableMap.of(
+        STATEFUL_1, new Config("RDS3")
+    ));
+    xdsClient.deliverRdsUpdate(rdsName, vhost3);
+    assertThat(getSelectorRoutingConfigs()).hasSize(1);
+    assertThat(getSelectorVhosts(fc1)).containsExactly(vhost3);
+    ImmutableList<StatefulFilter> rds3Snapshot = statefulFilterProvider.getAllInstances();
+    // As with any other Route update, typed_per_filter_config overrides should not result in
+    // creating new filter instances.
+    assertWithMessage("RDS 3: Expected Filter instances to be reused on per-route filter overrides")
+        .that(rds3Snapshot).isEqualTo(lds1Snapshot);
+  }
+
+  @Test
+  public void filterState_uniquePerFilterChain() {
+    StatefulFilter.Provider statefulFilterProvider = new StatefulFilter.Provider();
+    FilterRegistry filterRegistry = filterStateTestFilterRegistry(statefulFilterProvider);
+    SettableFuture<Server> serverStart = filterStateTestStartServer(filterRegistry);
+
+    // Prepare multiple filter chains matchers for testing.
+    FilterChainMatch matcherA = createMatchSrcIp("3fff:a::/32");
+    FilterChainMatch matcherB = createMatchSrcIp("3fff:b::/32");
+
+    // Vhosts won't change too.
+    VirtualHost vhostA = filterStateTestVhost("stateful_vhost_a");
+    VirtualHost vhostB = filterStateTestVhost("stateful_vhost_b");
+
+    // LDS 1.
+    FilterChain lds1ChainA = createFilterChain("chain_a",
+        createHcm(vhostA, filterStateTestConfigs(STATEFUL_1, STATEFUL_2)),
+        matcherA);
+    FilterChain lds1ChainB = createFilterChain("chain_b",
+        createHcm(vhostB, filterStateTestConfigs(STATEFUL_2)),
+        matcherB);
+
+    xdsClient.deliverLdsUpdate(ImmutableList.of(lds1ChainA, lds1ChainB), null);
+    verifyServerStarted(serverStart);
+    ImmutableList<StatefulFilter> lds1Snapshot = statefulFilterProvider.getAllInstances();
+    // Verify that filter with name STATEFUL_2 produced separate instances unique per filter chain.
+    assertWithMessage("LDS 1: expected to create filter instances").that(lds1Snapshot).hasSize(3);
+    // Naming: lds<LDS#>Chain<name>Filter<name#>
+    StatefulFilter lds1ChainAFilter1 = lds1Snapshot.get(0);
+    StatefulFilter lds1ChainAFilter2 = lds1Snapshot.get(1);
+    StatefulFilter lds1ChainBFilter2 = lds1Snapshot.get(2);
+    assertThat(lds1ChainAFilter2).isNotSameInstanceAs(lds1ChainBFilter2);
+
+    // LDS 2: In chain B filter with name STATEFUL_1 is replaced STATEFUL_2.
+    FilterChain lds2ChainA = createFilterChain("chain_a",
+        createHcm(vhostA, filterStateTestConfigs(STATEFUL_1, STATEFUL_2)),
+        matcherA);
+    FilterChain lds2ChainB = createFilterChain("chain_b",
+        createHcm(vhostB, filterStateTestConfigs(STATEFUL_1)),
+        matcherB);
+
+    xdsClient.deliverLdsUpdate(ImmutableList.of(lds2ChainA, lds2ChainB), null);
+    ImmutableList<StatefulFilter> lds2Snapshot = statefulFilterProvider.getAllInstances();
+    assertWithMessage("LDS 2: expected a distinct instance of filter %s for Chain B", STATEFUL_1)
+        .that(lds2Snapshot).hasSize(4);
+    StatefulFilter lds2ChainBFilter1 = lds2Snapshot.get(3);
+    assertThat(lds2ChainBFilter1).isNotSameInstanceAs(lds1ChainAFilter1);
+    // Confirm correct STATEFUL_2 has been shut down.
+    assertThat(lds1ChainBFilter2.isShutdown()).isTrue();
+    assertThat(lds1ChainAFilter2.isShutdown()).isFalse();
+
+    // LDS 3: Add default chain
+    // Default filter chain is an exception from the uniqueness rule, and we need to make sure
+    // that this is accounted for when we're tracking active filters per unique FilterChain.
+    FilterChain lds3ChainDefault = createFilterChain("chain_default",
+        createHcm(vhostA, filterStateTestConfigs(STATEFUL_1, STATEFUL_2)),
+        matcherA);
+    xdsClient.deliverLdsUpdate(ImmutableList.of(lds2ChainA, lds2ChainB), lds3ChainDefault);
+    ImmutableList<StatefulFilter> lds3Snapshot = statefulFilterProvider.getAllInstances();
+    assertWithMessage("LDS 3: Expected two new distinct filter instances for default chain")
+        .that(lds3Snapshot).hasSize(6);
+    StatefulFilter lds3ChainDefaultFilter1 = lds3Snapshot.get(4);
+    StatefulFilter lds3ChainDefaultFilter2 = lds3Snapshot.get(5);
+    // STATEFUL_1 in default chain not the same STATEFUL_1 in chain A or B
+    assertThat(lds3ChainDefaultFilter1).isNotSameInstanceAs(lds1ChainAFilter1);
+    assertThat(lds3ChainDefaultFilter1).isNotSameInstanceAs(lds2ChainBFilter1);
+    // STATEFUL_2 in default chain not the same STATEFUL_1 in chain A
+    assertThat(lds3ChainDefaultFilter2).isNotSameInstanceAs(lds1ChainAFilter2);
+  }
+
+  /**
+   * Verifies a special case where an existing filter is has a different typeUrl in a subsequent
+   * LDS update.
+   *
+   * <p>Expectations:
+   *   1. The old filter instance must be shutdown.
+   *   2. A new filter instance must be created for the new filter with different typeUrl.
+   */
+  @Test
+  public void filterState_specialCase_sameNameDifferentTypeUrl() {
+    // Setup the server with filter containing StatefulFilter.Provider for two distict type URLs.
+    StatefulFilter.Provider statefulFilterProvider = new StatefulFilter.Provider();
+    String altTypeUrl = "type.googleapis.com/grpc.test.AltStatefulFilter";
+    StatefulFilter.Provider altStatefulFilterProvider = new StatefulFilter.Provider(altTypeUrl);
+    FilterRegistry filterRegistry = FilterRegistry.newRegistry()
+        .register(statefulFilterProvider, altStatefulFilterProvider, ROUTER_FILTER_PROVIDER);
+    SettableFuture<Server> serverStart = filterStateTestStartServer(filterRegistry);
+
+    // Test a normal chain and the default chain, as it's handled separately.
+    VirtualHost vhost = filterStateTestVhost();
+
+    // LDS 1.
+    ImmutableList<NamedFilterConfig> lds1Confgs = filterStateTestConfigs(STATEFUL_1, STATEFUL_2);
+    FilterChain lds1ChainA = createFilterChain("chain_a", createHcm(vhost, lds1Confgs));
+    FilterChain lds1ChainDefault = createFilterChain("chain_default", createHcm(vhost, lds1Confgs));
+    xdsClient.deliverLdsUpdate(lds1ChainA, lds1ChainDefault);
+    verifyServerStarted(serverStart);
+    ImmutableList<StatefulFilter> lds1Snapshot = statefulFilterProvider.getAllInstances();
+    assertWithMessage("LDS 1: expected to create filter instances").that(lds1Snapshot).hasSize(4);
+    // Naming: lds<LDS#>Chain<name>Filter<name#>
+    StatefulFilter lds1ChainAFilter1 = lds1Snapshot.get(0);
+    StatefulFilter lds1ChainAFilter2 = lds1Snapshot.get(1);
+    StatefulFilter lds1ChainDefaultFilter1 = lds1Snapshot.get(2);
+    StatefulFilter lds1ChainDefaultFilter2 = lds1Snapshot.get(3);
+
+    // LDS 2: Filter STATEFUL_2 present, but with a different typeUrl: altTypeUrl.
+    ImmutableList<NamedFilterConfig> lds2Confgs = ImmutableList.of(
+        new NamedFilterConfig(STATEFUL_1, new StatefulFilter.Config(STATEFUL_1)),
+        new NamedFilterConfig(STATEFUL_2, new StatefulFilter.Config(STATEFUL_2, altTypeUrl)),
+        new NamedFilterConfig(ROUTER_FILTER_INSTANCE_NAME, RouterFilter.ROUTER_CONFIG)
+    );
+    FilterChain lds2ChainA = createFilterChain("chain_a", createHcm(vhost, lds2Confgs));
+    FilterChain lds2ChainDefault = createFilterChain("chain_default", createHcm(vhost, lds2Confgs));
+    xdsClient.deliverLdsUpdate(lds2ChainA, lds2ChainDefault);
+    ImmutableList<StatefulFilter> lds2Snapshot = statefulFilterProvider.getAllInstances();
+    ImmutableList<StatefulFilter> lds2SnapshotAlt = altStatefulFilterProvider.getAllInstances();
+    // Filter "STATEFUL_2" has different typeUrl, and should be treated as a new filter.
+    // No changes in the snapshot of normal stateful filters.
+    assertThat(lds2Snapshot).isEqualTo(lds1Snapshot);
+    // Two new filter instances is created by altStatefulFilterProvider for chainA and chainDefault.
+    assertWithMessage("LDS 2: expected new filter instances for type %s", altTypeUrl)
+        .that(lds2SnapshotAlt).hasSize(2);
+    StatefulFilter lds2ChainAFilter2Alt = lds2SnapshotAlt.get(0);
+    StatefulFilter lds2ChainADefault2Alt = lds2SnapshotAlt.get(1);
+    // Confirm two new distict instances of STATEFUL_2 were created.
+    assertThat(lds2ChainAFilter2Alt).isNotSameInstanceAs(lds1ChainAFilter2);
+    assertThat(lds2ChainADefault2Alt).isNotSameInstanceAs(lds1ChainDefaultFilter2);
+    assertThat(lds2ChainAFilter2Alt).isNotSameInstanceAs(lds2ChainADefault2Alt);
+    // Verify the instance of STATEFUL_2 of the old type are shutdown.
+    assertThat(lds1ChainAFilter2.isShutdown()).isTrue();
+    assertThat(lds1ChainDefaultFilter2.isShutdown()).isTrue();
+    // Verify the new instances of STATEFUL_2 and the old instances of STATEFUL_1 are running.
+    assertThat(lds2ChainAFilter2Alt.isShutdown()).isFalse();
+    assertThat(lds2ChainADefault2Alt.isShutdown()).isFalse();
+    assertThat(lds1ChainAFilter1.isShutdown()).isFalse();
+    assertThat(lds1ChainDefaultFilter1.isShutdown()).isFalse();
+  }
+
+  /**
+   * Verifies that all filter instances are shutdown (closed) on LDS resource not found.
+   */
+  @Test
+  public void filterState_shutdown_onLdsNotFound() {
+    StatefulFilter.Provider statefulFilterProvider = new StatefulFilter.Provider();
+    FilterRegistry filterRegistry = filterStateTestFilterRegistry(statefulFilterProvider);
+    SettableFuture<Server> serverStart = filterStateTestStartServer(filterRegistry);
+
+    // Test a normal chain and the default chain, as it's handled separately.
+    VirtualHost vhost = filterStateTestVhost();
+    FilterChain chainA = createFilterChain("chain_a",
+        createHcm(vhost, filterStateTestConfigs(STATEFUL_1)));
+    FilterChain chainDefault = createFilterChain("chain_default",
+        createHcm(vhost, filterStateTestConfigs(STATEFUL_2)));
+
+    // LDS 1.
+    xdsClient.deliverLdsUpdate(chainA, chainDefault);
+    verifyServerStarted(serverStart);
+    ImmutableList<StatefulFilter> lds1Snapshot = statefulFilterProvider.getAllInstances();
+    assertWithMessage("LDS 1: expected to create filter instances").that(lds1Snapshot).hasSize(2);
+    // Naming: lds<LDS#>Chain<name>Filter<name#>
+    StatefulFilter lds1ChainAFilter1 = lds1Snapshot.get(0);
+    StatefulFilter lds1ChainDefaultFilter2 = lds1Snapshot.get(1);
+
+    // LDS 2: resource not found.
+    xdsClient.deliverLdsResourceNotFound();
+    // Verify shutdown.
+    assertThat(lds1ChainAFilter1.isShutdown()).isTrue();
+    assertThat(lds1ChainDefaultFilter2.isShutdown()).isTrue();
+  }
+
+  /**
+   * Verifies that all filter instances of a filter chain are shutdown when said chain is removed.
+   */
+  @Test
+  public void filterState_shutdown_onChainRemoved() {
+    StatefulFilter.Provider statefulFilterProvider = new StatefulFilter.Provider();
+    FilterRegistry filterRegistry = filterStateTestFilterRegistry(statefulFilterProvider);
+    SettableFuture<Server> serverStart = filterStateTestStartServer(filterRegistry);
+
+    ImmutableList<NamedFilterConfig> configs = filterStateTestConfigs(STATEFUL_1, STATEFUL_2);
+    FilterChain chainA = createFilterChain("chain_a",
+        createHcm(filterStateTestVhost("stateful_vhost_a"), configs),
+        createMatchSrcIp("3fff:a::/32"));
+    FilterChain chainB = createFilterChain("chain_b",
+        createHcm(filterStateTestVhost("stateful_vhost_b"), configs),
+        createMatchSrcIp("3fff:b::/32"));
+    FilterChain chainDefault = createFilterChain("chain_default",
+        createHcm(filterStateTestVhost("stateful_vhost_default"), configs),
+        createMatchSrcIp("3fff:defa::/32"));
+
+    // LDS 1.
+    xdsClient.deliverLdsUpdate(ImmutableList.of(chainA, chainB), chainDefault);
+    verifyServerStarted(serverStart);
+    ImmutableList<StatefulFilter> lds1Snapshot = statefulFilterProvider.getAllInstances();
+    assertWithMessage("LDS 1: expected to create filter instances").that(lds1Snapshot).hasSize(6);
+    StatefulFilter chainAFilter1 = lds1Snapshot.get(0);
+    StatefulFilter chainAFilter2 = lds1Snapshot.get(1);
+    StatefulFilter chainBFilter1 = lds1Snapshot.get(2);
+    StatefulFilter chainBFilter2 = lds1Snapshot.get(3);
+    StatefulFilter chainDefaultFilter1 = lds1Snapshot.get(4);
+    StatefulFilter chainDefaultFilter2 = lds1Snapshot.get(5);
+
+    // LDS 2: ChainB and ChainDefault are gone.
+    xdsClient.deliverLdsUpdate(chainA, null);
+    assertThat(statefulFilterProvider.getAllInstances()).isEqualTo(lds1Snapshot);
+    // ChainA filters not shutdown (just in case).
+    assertThat(chainAFilter1.isShutdown()).isFalse();
+    assertThat(chainAFilter2.isShutdown()).isFalse();
+    // ChainB and ChainDefault filters shutdown.
+    assertWithMessage("chainBFilter1").that(chainBFilter1.isShutdown()).isTrue();
+    assertWithMessage("chainBFilter2").that(chainBFilter2.isShutdown()).isTrue();
+    assertWithMessage("chainDefaultFilter1").that(chainDefaultFilter1.isShutdown()).isTrue();
+    assertWithMessage("chainDefaultFilter2").that(chainDefaultFilter2.isShutdown()).isTrue();
+  }
+
+  /**
+   * Verifies that all filter instances are shutdown (closed) on LDS ResourceWatcher shutdown.
+   */
+  @Test
+  public void filterState_shutdown_onServerShutdown() {
+    StatefulFilter.Provider statefulFilterProvider = new StatefulFilter.Provider();
+    FilterRegistry filterRegistry = filterStateTestFilterRegistry(statefulFilterProvider);
+    SettableFuture<Server> serverStart = filterStateTestStartServer(filterRegistry);
+
+    // Test a normal chain and the default chain, as it's handled separately.
+    VirtualHost vhost = filterStateTestVhost();
+    FilterChain chainA = createFilterChain("chain_a",
+        createHcm(vhost, filterStateTestConfigs(STATEFUL_1)));
+    FilterChain chainDefault = createFilterChain("chain_default",
+        createHcm(vhost, filterStateTestConfigs(STATEFUL_2)));
+
+    // LDS 1.
+    xdsClient.deliverLdsUpdate(chainA, chainDefault);
+    verifyServerStarted(serverStart);
+    ImmutableList<StatefulFilter> lds1Snapshot = statefulFilterProvider.getAllInstances();
+    assertWithMessage("LDS 1: expected to create filter instances").that(lds1Snapshot).hasSize(2);
+    // Naming: lds<LDS#>Chain<name>Filter<name#>
+    StatefulFilter lds1ChainAFilter1 = lds1Snapshot.get(0);
+    StatefulFilter lds1ChainDefaultFilter2 = lds1Snapshot.get(1);
+
+    // Shutdown.
+    xdsServerWrapper.shutdown();
+    assertThat(xdsServerWrapper.isShutdown()).isTrue();
+    assertThat(xdsClient.isShutDown()).isTrue();
+    // Verify shutdown.
+    assertThat(lds1ChainAFilter1.isShutdown()).isTrue();
+    assertThat(lds1ChainDefaultFilter2.isShutdown()).isTrue();
+  }
+
+  /**
+   * Verifies that filter instances are NOT shutdown on RDS_RESOURCE_NAME not found.
+   */
+  @Test
+  public void filterState_shutdown_noShutdownOnRdsNotFound() throws Exception {
+    StatefulFilter.Provider statefulFilterProvider = new StatefulFilter.Provider();
+    FilterRegistry filterRegistry = filterStateTestFilterRegistry(statefulFilterProvider);
+    SettableFuture<Server> serverStart = filterStateTestStartServer(filterRegistry);
+
+    String rdsName = "rds.example.com";
+    // Test a normal chain and the default chain, as it's handled separately.
+    FilterChain chainA = createFilterChain("chain_a",
+        createHcmForRds(rdsName, filterStateTestConfigs(STATEFUL_1)));
+    FilterChain chainDefault = createFilterChain("chain_default",
+        createHcmForRds(rdsName, filterStateTestConfigs(STATEFUL_2)));
+
+    xdsClient.deliverLdsUpdate(chainA, chainDefault);
+    xdsClient.awaitRds(FakeXdsClient.DEFAULT_TIMEOUT);
+    verify(listener, never()).onServing();
+    // Server didn't start, but filter instances should have already been created.
+    ImmutableList<StatefulFilter> lds1Snapshot = statefulFilterProvider.getAllInstances();
+    assertWithMessage("LDS 1: expected to create filter instances").that(lds1Snapshot).hasSize(2);
+    // Naming: lds<LDS#>Chain<name>Filter<name#>
+    StatefulFilter lds1ChainAFilter1 = lds1Snapshot.get(0);
+    StatefulFilter lds1ChainDefaultFilter2 = lds1Snapshot.get(1);
+
+    // RDS 1: Standard vhost with a route.
+    xdsClient.deliverRdsUpdate(rdsName, filterStateTestVhost());
+    verifyServerStarted(serverStart);
+    assertThat(statefulFilterProvider.getAllInstances()).isEqualTo(lds1Snapshot);
+
+    // RDS 2: RDS_RESOURCE_NAME not found.
+    xdsClient.deliverRdsResourceNotFound(rdsName);
+    assertThat(lds1ChainAFilter1.isShutdown()).isFalse();
+    assertThat(lds1ChainDefaultFilter2.isShutdown()).isFalse();
+  }
+
+  private FilterRegistry filterStateTestFilterRegistry(
+      StatefulFilter.Provider statefulFilterProvider) {
+    return FilterRegistry.newRegistry().register(statefulFilterProvider, ROUTER_FILTER_PROVIDER);
+  }
+
+  private SettableFuture<Server> filterStateTestStartServer(FilterRegistry filterRegistry) {
+    xdsServerWrapper = new XdsServerWrapper("0.0.0.0:1", mockBuilder, listener,
+        selectorManager, new FakeXdsClientPoolFactory(xdsClient), filterRegistry);
+    SettableFuture<Server> serverStart = SettableFuture.create();
+    scheduleServerStart(xdsServerWrapper, serverStart);
+    return serverStart;
+  }
+
+  private static ImmutableList<NamedFilterConfig> filterStateTestConfigs(String... names) {
+    ImmutableList.Builder<NamedFilterConfig> result = ImmutableList.builder();
+    for (String name : names) {
+      result.add(new NamedFilterConfig(name, new StatefulFilter.Config(name)));
+    }
+    result.add(new NamedFilterConfig(ROUTER_FILTER_INSTANCE_NAME, RouterFilter.ROUTER_CONFIG));
+    return result.build();
+  }
+
+  private static Route filterStateTestRoute(ImmutableMap<String, FilterConfig> perRouteOverrides) {
+    // Standard basic route for filterState tests.
+    return Route.forAction(
+        RouteMatch.withPathExactOnly("/grpc.test.HelloService/SayHello"), null, perRouteOverrides);
+  }
+
+  private static VirtualHost filterStateTestVhost() {
+    return filterStateTestVhost("stateful-vhost", NO_FILTER_OVERRIDES);
+  }
+
+  private static VirtualHost filterStateTestVhost(String name) {
+    return filterStateTestVhost(name, NO_FILTER_OVERRIDES);
+  }
+
+  private static VirtualHost filterStateTestVhost(
+      String name, ImmutableMap<String, FilterConfig> perRouteOverrides) {
+    return VirtualHost.create(
+        name,
+        ImmutableList.of("stateful.test.example.com"),
+        ImmutableList.of(filterStateTestRoute(perRouteOverrides)),
+        NO_FILTER_OVERRIDES);
+  }
+
+  // End filter state tests.
+
+  private void verifyServerStarted(SettableFuture<Server> serverStart) {
+    try {
+      serverStart.get(5, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new AssertionError("serverStart future failed to resolve within the timeout", e);
+    }
+    verify(listener).onServing();
+    try {
+      verify(mockServer).start();
+    } catch (IOException e) {
+      throw new AssertionError("mockServer.start() shouldn't throw", e);
+    }
+  }
+
+  private Map<FilterChain, AtomicReference<ServerRoutingConfig>> getSelectorRoutingConfigs() {
+    return selectorManager.getSelectorToUpdateSelector().getRoutingConfigs();
+  }
+
+  private ServerRoutingConfig getSelectorRoutingConfig(FilterChain fc) {
+    return getSelectorRoutingConfigs().get(fc).get();
+  }
+
+  private ImmutableList<VirtualHost> getSelectorVhosts(FilterChain fc) {
+    return getSelectorRoutingConfig(fc).virtualHosts();
+  }
+
+  public static void scheduleServerStart(
+      XdsServerWrapper xdsServerWrapper, SettableFuture<Server> serverStart) {
+    Executors.newSingleThreadExecutor().execute(() -> {
+      try {
+        serverStart.set(xdsServerWrapper.start());
+      } catch (Exception e) {
+        serverStart.setException(e);
+      }
+    });
+  }
+
   private static FilterChain createFilterChain(String name, HttpConnectionManager hcm) {
-    return EnvoyServerProtoData.FilterChain.create(name, createMatch(),
-            hcm, createTls(), mock(TlsContextManager.class));
+    return createFilterChain(name, hcm, createMatch());
+  }
+
+  private static FilterChain createFilterChain(
+      String name, HttpConnectionManager hcm, FilterChainMatch filterChainMatch) {
+    TlsContextManager tlsContextManager = mock(TlsContextManager.class);
+    return FilterChain.create(name, filterChainMatch, hcm, createTls(), tlsContextManager);
   }
 
   private static VirtualHost createVirtualHost(String name) {
@@ -1279,21 +1791,52 @@ public class XdsServerWrapperTest {
             ImmutableMap.<String, FilterConfig>of());
   }
 
+  private static HttpConnectionManager createHcm(
+      VirtualHost vhost, List<NamedFilterConfig> filterConfigs) {
+    return HttpConnectionManager.forVirtualHosts(0L, ImmutableList.of(vhost), filterConfigs);
+  }
+
+  private static HttpConnectionManager createHcmForRds(
+      String name, List<NamedFilterConfig> filterConfigs) {
+    return HttpConnectionManager.forRdsName(0L, name, filterConfigs);
+  }
+
   private static HttpConnectionManager createRds(String name) {
-    return createRds(name, null);
+    NamedFilterConfig config =
+        new NamedFilterConfig(ROUTER_FILTER_INSTANCE_NAME, RouterFilter.ROUTER_CONFIG);
+    return createHcmForRds(name, ImmutableList.of(config));
   }
 
-  private static HttpConnectionManager createRds(String name, FilterConfig filterConfig) {
-    return HttpConnectionManager.forRdsName(0L, name,
-        Arrays.asList(new NamedFilterConfig("named-config-" + name, filterConfig)));
-  }
-
-  private static EnvoyServerProtoData.FilterChainMatch createMatch() {
-    return EnvoyServerProtoData.FilterChainMatch.create(
+  /**
+   * Returns the least-specific match-all Filter Chain Match.
+   */
+  private static FilterChainMatch createMatch() {
+    return FilterChainMatch.create(
         0,
         ImmutableList.of(),
         ImmutableList.of(),
         ImmutableList.of(),
+        EnvoyServerProtoData.ConnectionSourceType.ANY,
+        ImmutableList.of(),
+        ImmutableList.of(),
+        "");
+  }
+
+  private static FilterChainMatch createMatchSrcIp(String srcCidr) {
+    String[] srcParts = srcCidr.split("/", 2);
+    CidrRange srcIpRange = null;
+    try {
+      srcIpRange = CidrRange.create(srcParts[0], Integer.valueOf(srcParts[1], 10));
+    } catch (UnknownHostException e) {
+      // see https://github.com/grpc/grpc-java/issues/11926
+      throw new IllegalArgumentException("This just seems wrong", e);
+    }
+
+    return FilterChainMatch.create(
+        0,
+        ImmutableList.of(),
+        ImmutableList.of(),
+        ImmutableList.of(srcIpRange),
         EnvoyServerProtoData.ConnectionSourceType.ANY,
         ImmutableList.of(),
         ImmutableList.of(),

--- a/xds/src/test/java/io/grpc/xds/XdsServerWrapperTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsServerWrapperTest.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.net.InetAddresses;
 import com.google.common.util.concurrent.SettableFuture;
 import io.grpc.Attributes;
 import io.grpc.InsecureChannelCredentials;
@@ -74,7 +75,7 @@ import io.grpc.xds.internal.Matchers.HeaderMatcher;
 import io.grpc.xds.internal.security.CommonTlsContextTestsUtil;
 import io.grpc.xds.internal.security.SslContextProviderSupplier;
 import java.io.IOException;
-import java.net.UnknownHostException;
+import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1824,19 +1825,13 @@ public class XdsServerWrapperTest {
 
   private static FilterChainMatch createMatchSrcIp(String srcCidr) {
     String[] srcParts = srcCidr.split("/", 2);
-    CidrRange srcIpRange = null;
-    try {
-      srcIpRange = CidrRange.create(srcParts[0], Integer.valueOf(srcParts[1], 10));
-    } catch (UnknownHostException e) {
-      // see https://github.com/grpc/grpc-java/issues/11926
-      throw new IllegalArgumentException("This just seems wrong", e);
-    }
-
+    InetAddress ip = InetAddresses.forString(srcParts[0]);
+    Integer subnetMask = Integer.valueOf(srcParts[1], 10);
     return FilterChainMatch.create(
         0,
         ImmutableList.of(),
         ImmutableList.of(),
-        ImmutableList.of(srcIpRange),
+        ImmutableList.of(CidrRange.create(ip, subnetMask)),
         EnvoyServerProtoData.ConnectionSourceType.ANY,
         ImmutableList.of(),
         ImmutableList.of(),


### PR DESCRIPTION
This PR adds support filter state retention in Java. The mechanism will be similar to the one described in [A83](https://github.com/grpc/proposal/blob/master/A83-xds-gcp-authn-filter.md#filter-call-credentials-cache) for C-core, and will serve the same purpose. However, the implementation details are very different due to the different nature of xDS HTTP filter support in C-core and Java.

### Filter instance lifecycle
#### xDS gRPC clients
New filter instances are created per combination of:
1. `XdsNameResolver` instance,
2. Filter name+typeUrl as configured in HttpConnectionManager (HCM) http_filters.

Existing client-side filter instances are shutdown:
- A single a filter instance is shutdown when an LDS update contains HCM that is missing filter configuration for name+typeUrl  combination of this instance.
- All filter instances when watched LDS resource is missing from an LDS update.
- All filter instances name resolver shutdown.

#### xDS-enabled gRPC servers
New filter instances are created per combination of:
1. Server instance,
2. FilterChain name,
3. Filter name+typeUrl as configured in FilterChain's HCM.http_filters.

Filter instances of Default Filter Chain is tracked separately per:
1. Server instance,
2. Filter name+typeUrl in default_filter_chain's HCM.http_filters.

Existing server-side filter instances are shutdown:
- A single a filter instance is shutdown when an LDS update contains FilterChain with HCM.http_filters that is missing configuration for filter name+typeUrl.
- All filter instances associated with the FilterChain when an LDS update no longer contains FilterChain's name.
- All filter instances when watched LDS resource is missing from an LDS update.
- All filter instances on server shutdown.

### Related
- Part 1: #11883