### PR TITLE
xds: Log cluster_manager config update before applying config

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterManagerLoadBalancer.java
@@ -81,6 +81,9 @@ class ClusterManagerLoadBalancer extends MultiChildLoadBalancer {
 
     ClusterManagerConfig config = (ClusterManagerConfig)
         resolvedAddresses.getLoadBalancingPolicyConfig();
+    logger.log(
+        XdsLogLevel.INFO,
+        "Received cluster_manager lb config: child names={0}", config.childPolicies.keySet());
     Map<Object, ResolvedAddresses> childAddresses = new HashMap<>();
 
     // Reactivate children with config; deactivate children without config
@@ -108,9 +111,6 @@ class ClusterManagerLoadBalancer extends MultiChildLoadBalancer {
           .build();
       childAddresses.put(childPolicy.getKey(), addresses);
     }
-    logger.log(
-        XdsLogLevel.INFO,
-        "Received cluster_manager lb config: child names={0}", config.childPolicies.keySet());
     return childAddresses;
   }
 


### PR DESCRIPTION
It is confusing/harder to read the logs when the
activations/deactivations because of the config happen before the log entry describing the new config.