### PR TITLE
core: Apply ManagedChannelImpl's updateBalancingState() immediately

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -1388,24 +1388,18 @@ final class ManagedChannelImpl extends ManagedChannel implements
       syncContext.throwIfNotInThisSynchronizationContext();
       checkNotNull(newState, "newState");
       checkNotNull(newPicker, "newPicker");
-      final class UpdateBalancingState implements Runnable {
-        @Override
-        public void run() {
-          if (LbHelperImpl.this != lbHelper || panicMode) {
-            return;
-          }
-          updateSubchannelPicker(newPicker);
-          // It's not appropriate to report SHUTDOWN state from lb.
-          // Ignore the case of newState == SHUTDOWN for now.
-          if (newState != SHUTDOWN) {
-            channelLogger.log(
-                ChannelLogLevel.INFO, "Entering {0} state with picker: {1}", newState, newPicker);
-            channelStateManager.gotoState(newState);
-          }
-        }
-      }
 
-      syncContext.execute(new UpdateBalancingState());
+      if (LbHelperImpl.this != lbHelper || panicMode) {
+        return;
+      }
+      updateSubchannelPicker(newPicker);
+      // It's not appropriate to report SHUTDOWN state from lb.
+      // Ignore the case of newState == SHUTDOWN for now.
+      if (newState != SHUTDOWN) {
+        channelLogger.log(
+            ChannelLogLevel.INFO, "Entering {0} state with picker: {1}", newState, newPicker);
+        channelStateManager.gotoState(newState);
+      }
     }
 
     @Override


### PR DESCRIPTION
ffcc360ba adjusted updateBalancingState() to require being run within the sync context. However, it still queued the work into the sync context, which was unnecessary. This re-entering the sync context unnecessarily delays the new state from being used.

----

I found this with a new xds test I've prepared, after fixing some problems in xds name resolver. See https://github.com/grpc/grpc-java/compare/master...ejona86:grpc-java:xds-cluster-race (which I'll send out once this is merged). After fixing XdsNameResolver, the test went from failing 2% to ~0.2% of the time. That led me to discover this delayed processing. With both changes, there were no flakes in 1000 runs.

CC @kannanjgithub, @danielzhaotongliu 