### PR TITLE
Update psm-dualstack.cfg

### DIFF
--- a/buildscripts/kokoro/psm-dualstack.cfg
+++ b/buildscripts/kokoro/psm-dualstack.cfg
@@ -2,7 +2,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-java/buildscripts/kokoro/psm-interop-test-java.sh"
-timeout_mins: 120
+timeout_mins: 240
 
 action {
   define_artifacts {


### PR DESCRIPTION
120 minutes has not been sufficient, causing frequent VM timeout errors in the test runs: https://testgrid.corp.google.com/grpc-psm-java#v1.67.x&width=20&graph-metrics=test-duration-minutes&include-filter-by-regex=psm-dualstack$