### PR TITLE
xds: Use XdsDependencyManager for XdsNameResolver

### DIFF
--- a/api/src/testFixtures/java/io/grpc/StatusMatcher.java
+++ b/api/src/testFixtures/java/io/grpc/StatusMatcher.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2025 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import org.mockito.ArgumentMatcher;
+
+/**
+ * Mockito matcher for {@link Status}.
+ */
+public final class StatusMatcher implements ArgumentMatcher<Status> {
+  public static StatusMatcher statusHasCode(ArgumentMatcher<Status.Code> codeMatcher) {
+    return new StatusMatcher(codeMatcher, null);
+  }
+
+  public static StatusMatcher statusHasCode(Status.Code code) {
+    return statusHasCode(new EqualsMatcher<>(code));
+  }
+
+  private final ArgumentMatcher<Status.Code> codeMatcher;
+  private final ArgumentMatcher<String> descriptionMatcher;
+
+  private StatusMatcher(
+      ArgumentMatcher<Status.Code> codeMatcher,
+      ArgumentMatcher<String> descriptionMatcher) {
+    this.codeMatcher = checkNotNull(codeMatcher, "codeMatcher");
+    this.descriptionMatcher = descriptionMatcher;
+  }
+
+  public StatusMatcher andDescription(ArgumentMatcher<String> descriptionMatcher) {
+    checkState(this.descriptionMatcher == null, "Already has a description matcher");
+    return new StatusMatcher(codeMatcher, descriptionMatcher);
+  }
+
+  public StatusMatcher andDescription(String description) {
+    return andDescription(new EqualsMatcher<>(description));
+  }
+
+  public StatusMatcher andDescriptionContains(String substring) {
+    return andDescription(new StringContainsMatcher(substring));
+  }
+
+  @Override
+  public boolean matches(Status status) {
+    return status != null
+        && codeMatcher.matches(status.getCode())
+        && (descriptionMatcher == null || descriptionMatcher.matches(status.getDescription()));
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("{code=");
+    sb.append(codeMatcher);
+    if (descriptionMatcher != null) {
+      sb.append(", description=");
+      sb.append(descriptionMatcher);
+    }
+    sb.append("}");
+    return sb.toString();
+  }
+
+  // Use instead of lambda for better error message.
+  static final class EqualsMatcher<T> implements ArgumentMatcher<T> {
+    private final T obj;
+
+    EqualsMatcher(T obj) {
+      this.obj = checkNotNull(obj, "obj");
+    }
+
+    @Override
+    public boolean matches(Object other) {
+      return obj.equals(other);
+    }
+
+    @Override
+    public String toString() {
+      return obj.toString();
+    }
+  }
+
+  static final class StringContainsMatcher implements ArgumentMatcher<String> {
+    private final String needle;
+
+    StringContainsMatcher(String needle) {
+      this.needle = checkNotNull(needle, "needle");
+    }
+
+    @Override
+    public boolean matches(String haystack) {
+      if (haystack == null) {
+        return false;
+      }
+      return haystack.contains(needle);
+    }
+
+    @Override
+    public String toString() {
+      return "contains " + needle;
+    }
+  }
+}

--- a/api/src/testFixtures/java/io/grpc/StatusOrMatcher.java
+++ b/api/src/testFixtures/java/io/grpc/StatusOrMatcher.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2025 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import org.mockito.ArgumentMatcher;
+
+/**
+ * Mockito matcher for {@link StatusOr}.
+ */
+public final class StatusOrMatcher<T> implements ArgumentMatcher<StatusOr<T>> {
+  public static <T> StatusOrMatcher<T> hasValue(ArgumentMatcher<T> valueMatcher) {
+    return new StatusOrMatcher<T>(checkNotNull(valueMatcher, "valueMatcher"), null);
+  }
+
+  public static <T> StatusOrMatcher<T> hasStatus(ArgumentMatcher<Status> statusMatcher) {
+    return new StatusOrMatcher<T>(null, checkNotNull(statusMatcher, "statusMatcher"));
+  }
+
+  private final ArgumentMatcher<T> valueMatcher;
+  private final ArgumentMatcher<Status> statusMatcher;
+
+  private StatusOrMatcher(ArgumentMatcher<T> valueMatcher, ArgumentMatcher<Status> statusMatcher) {
+    this.valueMatcher = valueMatcher;
+    this.statusMatcher = statusMatcher;
+  }
+
+  @Override
+  public boolean matches(StatusOr<T> statusOr) {
+    if (statusOr == null) {
+      return false;
+    }
+    if (statusOr.hasValue() != (valueMatcher != null)) {
+      return false;
+    }
+    if (valueMatcher != null) {
+      return valueMatcher.matches(statusOr.getValue());
+    } else {
+      return statusMatcher.matches(statusOr.getStatus());
+    }
+  }
+
+  @Override
+  public String toString() {
+    if (valueMatcher != null) {
+      return "{value=" + valueMatcher + "}";
+    } else {
+      return "{status=" + statusMatcher + "}";
+    }
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/XdsAttributes.java
+++ b/xds/src/main/java/io/grpc/xds/XdsAttributes.java
@@ -37,6 +37,22 @@ final class XdsAttributes {
       Attributes.Key.create("io.grpc.xds.XdsAttributes.xdsClientPool");
 
   /**
+   * Attribute key for passing around the latest XdsConfig across NameResolver/LoadBalancers.
+   */
+  @NameResolver.ResolutionResultAttr
+  static final Attributes.Key<XdsConfig> XDS_CONFIG =
+      Attributes.Key.create("io.grpc.xds.XdsAttributes.xdsConfig");
+
+
+  /**
+   * Attribute key for passing around the XdsDependencyManager across NameResolver/LoadBalancers.
+   */
+  @NameResolver.ResolutionResultAttr
+  static final Attributes.Key<XdsConfig.XdsClusterSubscriptionRegistry>
+      XDS_CLUSTER_SUBSCRIPT_REGISTRY =
+      Attributes.Key.create("io.grpc.xds.XdsAttributes.xdsConfig.XdsClusterSubscriptionRegistry");
+
+  /**
    * Attribute key for obtaining the global provider that provides atomics for aggregating
    * outstanding RPCs sent to each cluster.
    */

--- a/xds/src/main/java/io/grpc/xds/XdsConfig.java
+++ b/xds/src/main/java/io/grpc/xds/XdsConfig.java
@@ -26,9 +26,9 @@ import io.grpc.xds.XdsListenerResource.LdsUpdate;
 import io.grpc.xds.XdsRouteConfigureResource.RdsUpdate;
 import java.io.Closeable;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Represents the xDS configuration tree for a specified Listener.
@@ -178,13 +178,22 @@ final class XdsConfig {
       public StatusOr<EdsUpdate> getEndpoint() {
         return endpoint;
       }
+
+      @Override
+      public String toString() {
+        if (endpoint.hasValue()) {
+          return "EndpointConfig{endpoint=" + endpoint.getValue() + "}";
+        } else {
+          return "EndpointConfig{error=" + endpoint.getStatus() + "}";
+        }
+      }
     }
 
     // The list of leaf clusters for an aggregate cluster.
     static final class AggregateConfig implements ClusterChild {
-      private final List<String> leafNames;
+      private final Set<String> leafNames;
 
-      public AggregateConfig(List<String> leafNames) {
+      public AggregateConfig(Set<String> leafNames) {
         this.leafNames = checkNotNull(leafNames, "leafNames");
       }
 
@@ -234,6 +243,7 @@ final class XdsConfig {
     XdsConfig build() {
       checkNotNull(listener, "listener");
       checkNotNull(route, "route");
+      checkNotNull(virtualHost, "virtualHost");
       return new XdsConfig(listener, route, clusters, virtualHost);
     }
   }

--- a/xds/src/main/java/io/grpc/xds/XdsDependencyManager.java
+++ b/xds/src/main/java/io/grpc/xds/XdsDependencyManager.java
@@ -646,8 +646,6 @@ final class XdsDependencyManager implements XdsConfig.XdsClusterSubscriptionRegi
 
   private interface RdsUpdateSupplier {
     StatusOr<RdsUpdate> getRdsUpdate();
-
-    String toContextString();
   }
 
   private class LdsWatcher extends XdsWatcherBase<XdsListenerResource.LdsUpdate>

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolverProvider.java
@@ -82,7 +82,7 @@ public final class XdsNameResolverProvider extends NameResolverProvider {
           args.getServiceConfigParser(), args.getSynchronizationContext(),
           args.getScheduledExecutorService(),
           bootstrapOverride,
-          args.getMetricRecorder());
+          args.getMetricRecorder(), args);
     }
     return null;
   }

--- a/xds/src/test/java/io/grpc/xds/XdsDependencyManagerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsDependencyManagerTest.java
@@ -332,7 +332,6 @@ public class XdsDependencyManagerTest {
   }
 
   @Test
-  // TODO fix - clusters with bad status are being suppressed instead of returned
   public void testMissingCdsAndEds() {
     // update config so that agg cluster references 2 existing & 1 non-existing cluster
     List<String> childNames = Arrays.asList("clusterC", "clusterB", "clusterA");
@@ -471,7 +470,6 @@ public class XdsDependencyManagerTest {
 
   @Test
   public void testChangeRdsName_fromLds() {
-    // TODO implement
     InOrder inOrder = Mockito.inOrder(xdsConfigWatcher);
     xdsDependencyManager = new XdsDependencyManager(xdsClient, xdsConfigWatcher, syncContext,
         serverName, serverName, nameResolverArgs, scheduler);

--- a/xds/src/test/java/io/grpc/xds/XdsDependencyManagerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsDependencyManagerTest.java
@@ -17,6 +17,7 @@
 package io.grpc.xds;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.grpc.StatusMatcher.statusHasCode;
 import static io.grpc.xds.XdsClusterResource.CdsUpdate.ClusterType.AGGREGATE;
 import static io.grpc.xds.XdsClusterResource.CdsUpdate.ClusterType.EDS;
 import static io.grpc.xds.XdsTestControlPlaneService.ADS_TYPE_URL_CDS;
@@ -32,7 +33,6 @@ import static io.grpc.xds.client.CommonBootstrapperTestUtils.SERVER_URI;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -53,6 +53,7 @@ import io.grpc.NameResolver;
 import io.grpc.Server;
 import io.grpc.Status;
 import io.grpc.StatusOr;
+import io.grpc.StatusOrMatcher;
 import io.grpc.SynchronizationContext;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.inprocess.InProcessServerBuilder;
@@ -136,9 +137,7 @@ public class XdsDependencyManagerTest {
   private XdsConfig defaultXdsConfig; // set in setUp()
 
   @Captor
-  private ArgumentCaptor<XdsConfig> xdsConfigCaptor;
-  @Captor
-  private ArgumentCaptor<Status> statusCaptor;
+  private ArgumentCaptor<StatusOr<XdsConfig>> xdsUpdateCaptor;
   private final NameResolver.Args nameResolverArgs = NameResolver.Args.newBuilder()
       .setDefaultPort(8080)
       .setProxyDetector(GrpcUtil.DEFAULT_PROXY_DETECTOR)
@@ -196,8 +195,8 @@ public class XdsDependencyManagerTest {
     xdsDependencyManager = new XdsDependencyManager(xdsClient, xdsConfigWatcher, syncContext,
         serverName, serverName, nameResolverArgs, scheduler);
 
-    verify(xdsConfigWatcher, timeout(1000)).onUpdate(defaultXdsConfig);
-    testWatcher.verifyStats(1, 0, 0);
+    verify(xdsConfigWatcher, timeout(1000)).onUpdate(StatusOr.fromValue(defaultXdsConfig));
+    testWatcher.verifyStats(1, 0);
   }
 
   @Test
@@ -206,14 +205,14 @@ public class XdsDependencyManagerTest {
         serverName, serverName, nameResolverArgs, scheduler);
 
     InOrder inOrder = Mockito.inOrder(xdsConfigWatcher);
-    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(defaultXdsConfig);
-    testWatcher.verifyStats(1, 0, 0);
+    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(StatusOr.fromValue(defaultXdsConfig));
+    testWatcher.verifyStats(1, 0);
     assertThat(testWatcher.lastConfig).isEqualTo(defaultXdsConfig);
 
     XdsTestUtils.setAdsConfig(controlPlaneService, serverName, "RDS2", "CDS2", "EDS2",
         ENDPOINT_HOSTNAME + "2", ENDPOINT_PORT + 2);
     inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(ArgumentMatchers.notNull());
-    testWatcher.verifyStats(2, 0, 0);
+    testWatcher.verifyStats(2, 0);
     assertThat(testWatcher.lastConfig).isNotEqualTo(defaultXdsConfig);
   }
 
@@ -222,7 +221,7 @@ public class XdsDependencyManagerTest {
     InOrder inOrder = Mockito.inOrder(xdsConfigWatcher);
     xdsDependencyManager = new XdsDependencyManager(xdsClient, xdsConfigWatcher, syncContext,
         serverName, serverName, nameResolverArgs, scheduler);
-    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(defaultXdsConfig);
+    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(StatusOr.fromValue(defaultXdsConfig));
 
     List<String> childNames = Arrays.asList("clusterC", "clusterB", "clusterA");
     String rootName = "root_c";
@@ -287,23 +286,25 @@ public class XdsDependencyManagerTest {
     inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(any());
 
     Closeable subscription2 = xdsDependencyManager.subscribeToCluster(rootName2);
-    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsConfigCaptor.capture());
-    testWatcher.verifyStats(3, 0, 0);
+    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsUpdateCaptor.capture());
+    testWatcher.verifyStats(3, 0);
     ImmutableSet.Builder<String> builder = ImmutableSet.builder();
     Set<String> expectedClusters = builder.add(rootName1).add(rootName2).add(CLUSTER_NAME)
         .addAll(childNames).addAll(childNames2).build();
-    assertThat(xdsConfigCaptor.getValue().getClusters().keySet()).isEqualTo(expectedClusters);
+    assertThat(xdsUpdateCaptor.getValue().getValue().getClusters().keySet())
+        .isEqualTo(expectedClusters);
 
     // Close 1 subscription shouldn't affect the other or RDS subscriptions
     subscription1.close();
-    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsConfigCaptor.capture());
+    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsUpdateCaptor.capture());
     builder = ImmutableSet.builder();
     Set<String> expectedClusters2 =
         builder.add(rootName2).add(CLUSTER_NAME).addAll(childNames2).build();
-    assertThat(xdsConfigCaptor.getValue().getClusters().keySet()).isEqualTo(expectedClusters2);
+    assertThat(xdsUpdateCaptor.getValue().getValue().getClusters().keySet())
+        .isEqualTo(expectedClusters2);
 
     subscription2.close();
-    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(defaultXdsConfig);
+    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(StatusOr.fromValue(defaultXdsConfig));
   }
 
   @Test
@@ -311,22 +312,23 @@ public class XdsDependencyManagerTest {
     InOrder inOrder = Mockito.inOrder(xdsConfigWatcher);
     xdsDependencyManager = new XdsDependencyManager(xdsClient, xdsConfigWatcher, syncContext,
         serverName, serverName, nameResolverArgs, scheduler);
-    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(defaultXdsConfig);
+    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(StatusOr.fromValue(defaultXdsConfig));
 
     String rootName1 = "root_c";
 
     Closeable subscription1 = xdsDependencyManager.subscribeToCluster(rootName1);
     assertThat(subscription1).isNotNull();
     fakeClock.forwardTime(16, TimeUnit.SECONDS);
-    inOrder.verify(xdsConfigWatcher).onUpdate(xdsConfigCaptor.capture());
-    assertThat(xdsConfigCaptor.getValue().getClusters().get(rootName1).toString()).isEqualTo(
-        StatusOr.fromStatus(Status.UNAVAILABLE.withDescription(
-            "No " + toContextStr(CLUSTER_TYPE_NAME, rootName1))).toString());
+    inOrder.verify(xdsConfigWatcher).onUpdate(xdsUpdateCaptor.capture());
+    Status status = xdsUpdateCaptor.getValue().getValue().getClusters().get(rootName1).getStatus();
+    assertThat(status.getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+    assertThat(status.getDescription()).contains(rootName1);
 
     List<String> childNames = Arrays.asList("clusterC", "clusterB", "clusterA");
     XdsTestUtils.addAggregateToExistingConfig(controlPlaneService, rootName1, childNames);
-    inOrder.verify(xdsConfigWatcher).onUpdate(xdsConfigCaptor.capture());
-    assertThat(xdsConfigCaptor.getValue().getClusters().get(rootName1).hasValue()).isTrue();
+    inOrder.verify(xdsConfigWatcher).onUpdate(xdsUpdateCaptor.capture());
+    assertThat(xdsUpdateCaptor.getValue().getValue().getClusters().get(rootName1).hasValue())
+        .isTrue();
   }
 
   @Test
@@ -360,43 +362,44 @@ public class XdsDependencyManagerTest {
         serverName, serverName, nameResolverArgs, scheduler);
 
     fakeClock.forwardTime(16, TimeUnit.SECONDS);
-    verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsConfigCaptor.capture());
+    verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsUpdateCaptor.capture());
 
     List<StatusOr<XdsClusterConfig>> returnedClusters = new ArrayList<>();
     for (String childName : childNames) {
-      returnedClusters.add(xdsConfigCaptor.getValue().getClusters().get(childName));
+      returnedClusters.add(xdsUpdateCaptor.getValue().getValue().getClusters().get(childName));
     }
 
     // Check that missing cluster reported Status and the other 2 are present
-    Status expectedClusterStatus = Status.UNAVAILABLE.withDescription(
-        "No " + toContextStr(CLUSTER_TYPE_NAME, childNames.get(2)));
     StatusOr<XdsClusterConfig> missingCluster = returnedClusters.get(2);
-    assertThat(missingCluster.getStatus().toString()).isEqualTo(expectedClusterStatus.toString());
+    assertThat(missingCluster.getStatus().getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+    assertThat(missingCluster.getStatus().getDescription()).contains(childNames.get(2));
     assertThat(returnedClusters.get(0).hasValue()).isTrue();
     assertThat(returnedClusters.get(1).hasValue()).isTrue();
 
     // Check that missing EDS reported Status, the other one is present and the garbage EDS is not
-    Status expectedEdsStatus = Status.UNAVAILABLE.withDescription(
-        "No " + toContextStr(ENDPOINT_TYPE_NAME, XdsTestUtils.EDS_NAME + 1));
     assertThat(getEndpoint(returnedClusters.get(0)).hasValue()).isTrue();
-    assertThat(getEndpoint(returnedClusters.get(1)).hasValue()).isFalse();
-    assertThat(getEndpoint(returnedClusters.get(1)).getStatus().toString())
-        .isEqualTo(expectedEdsStatus.toString());
+    assertThat(getEndpoint(returnedClusters.get(1)).getStatus().getCode())
+        .isEqualTo(Status.Code.UNAVAILABLE);
+    assertThat(getEndpoint(returnedClusters.get(1)).getStatus().getDescription())
+        .contains(XdsTestUtils.EDS_NAME + 1);
 
-    verify(xdsConfigWatcher, never()).onResourceDoesNotExist(any());
-    testWatcher.verifyStats(1, 0, 0);
+    verify(xdsConfigWatcher, never()).onUpdate(
+        argThat(StatusOrMatcher.hasStatus(statusHasCode(Status.Code.UNAVAILABLE))));
+    testWatcher.verifyStats(1, 0);
   }
 
   @Test
   public void testMissingLds() {
+    String ldsName = "badLdsName";
     xdsDependencyManager = new XdsDependencyManager(xdsClient, xdsConfigWatcher, syncContext,
-        serverName, "badLdsName", nameResolverArgs, scheduler);
+        serverName, ldsName, nameResolverArgs, scheduler);
 
     fakeClock.forwardTime(16, TimeUnit.SECONDS);
-    verify(xdsConfigWatcher, timeout(1000)).onResourceDoesNotExist(
-        toContextStr(XdsListenerResource.getInstance().typeName(), "badLdsName"));
+    verify(xdsConfigWatcher, timeout(1000)).onUpdate(
+        argThat(StatusOrMatcher.hasStatus(statusHasCode(Status.Code.UNAVAILABLE)
+            .andDescriptionContains(ldsName))));
 
-    testWatcher.verifyStats(0, 0, 1);
+    testWatcher.verifyStats(0, 1);
   }
 
   @Test
@@ -408,18 +411,17 @@ public class XdsDependencyManagerTest {
         serverName, serverName, nameResolverArgs, scheduler);
 
     fakeClock.forwardTime(16, TimeUnit.SECONDS);
-    Status expectedStatus = Status.UNAVAILABLE.withDescription("Not an API listener");
-    String context = toContextStr(XdsListenerResource.getInstance().typeName(), serverName);
-    verify(xdsConfigWatcher, timeout(1000))
-        .onError(eq(context), argThat(new XdsTestUtils.StatusMatcher(expectedStatus)));
+    verify(xdsConfigWatcher, timeout(1000)).onUpdate(
+        argThat(StatusOrMatcher.hasStatus(
+            statusHasCode(Status.Code.UNAVAILABLE).andDescriptionContains("Not an API listener"))));
 
-    testWatcher.verifyStats(0, 1, 0);
+    testWatcher.verifyStats(0, 1);
   }
 
   @Test
   public void testMissingRds() {
-    Listener clientListener =
-        ControlPlaneRule.buildClientListener(serverName, serverName, "badRdsName");
+    String rdsName = "badRdsName";
+    Listener clientListener = ControlPlaneRule.buildClientListener(serverName, serverName, rdsName);
     controlPlaneService.setXdsConfig(ADS_TYPE_URL_LDS,
         ImmutableMap.of(serverName, clientListener));
 
@@ -427,10 +429,11 @@ public class XdsDependencyManagerTest {
         serverName, serverName, nameResolverArgs, scheduler);
 
     fakeClock.forwardTime(16, TimeUnit.SECONDS);
-    verify(xdsConfigWatcher, timeout(1000)).onResourceDoesNotExist(
-        toContextStr(XdsRouteConfigureResource.getInstance().typeName(), "badRdsName"));
+    verify(xdsConfigWatcher, timeout(1000)).onUpdate(
+        argThat(StatusOrMatcher.hasStatus(statusHasCode(Status.Code.UNAVAILABLE)
+            .andDescriptionContains(rdsName))));
 
-    testWatcher.verifyStats(0, 0, 1);
+    testWatcher.verifyStats(0, 1);
   }
 
   @Test
@@ -443,11 +446,11 @@ public class XdsDependencyManagerTest {
         serverName, serverName, nameResolverArgs, scheduler);
 
     // Update with a config that has a virtual host that doesn't match the server name
-    verify(xdsConfigWatcher, timeout(1000)).onError(any(), statusCaptor.capture());
-    assertThat(statusCaptor.getValue().getDescription())
-        .isEqualTo("Failed to find virtual host matching hostname: " + serverName);
+    verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsUpdateCaptor.capture());
+    assertThat(xdsUpdateCaptor.getValue().getStatus().getDescription())
+        .contains("Failed to find virtual host matching hostname: " + serverName);
 
-    testWatcher.verifyStats(0, 1, 0);
+    testWatcher.verifyStats(0, 1);
   }
 
   @Test
@@ -458,14 +461,12 @@ public class XdsDependencyManagerTest {
     xdsDependencyManager = new XdsDependencyManager(xdsClient, xdsConfigWatcher, syncContext,
         serverName, ldsResourceName, nameResolverArgs, scheduler);
 
-    Status expectedStatus = Status.INVALID_ARGUMENT.withDescription(
-        "Wrong configuration: xds server does not exist for resource " + ldsResourceName);
-    String context = toContextStr(XdsListenerResource.getInstance().typeName(), ldsResourceName);
-    verify(xdsConfigWatcher, timeout(1000))
-        .onError(eq(context), argThat(new XdsTestUtils.StatusMatcher(expectedStatus)));
+    verify(xdsConfigWatcher, timeout(1000)).onUpdate(
+        argThat(StatusOrMatcher.hasStatus(
+            statusHasCode(Status.Code.UNAVAILABLE).andDescriptionContains(ldsResourceName))));
 
     fakeClock.forwardTime(16, TimeUnit.SECONDS);
-    testWatcher.verifyStats(0, 1, 0);
+    testWatcher.verifyStats(0, 1);
   }
 
   @Test
@@ -474,16 +475,16 @@ public class XdsDependencyManagerTest {
     InOrder inOrder = Mockito.inOrder(xdsConfigWatcher);
     xdsDependencyManager = new XdsDependencyManager(xdsClient, xdsConfigWatcher, syncContext,
         serverName, serverName, nameResolverArgs, scheduler);
-    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(defaultXdsConfig);
+    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(StatusOr.fromValue(defaultXdsConfig));
 
     String newRdsName = "newRdsName1";
 
     Listener clientListener = buildInlineClientListener(newRdsName, CLUSTER_NAME);
     controlPlaneService.setXdsConfig(ADS_TYPE_URL_LDS,
         ImmutableMap.of(serverName, clientListener));
-    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsConfigCaptor.capture());
-    assertThat(xdsConfigCaptor.getValue()).isNotEqualTo(defaultXdsConfig);
-    assertThat(xdsConfigCaptor.getValue().getVirtualHost().name()).isEqualTo(newRdsName);
+    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsUpdateCaptor.capture());
+    assertThat(xdsUpdateCaptor.getValue().getValue()).isNotEqualTo(defaultXdsConfig);
+    assertThat(xdsUpdateCaptor.getValue().getValue().getVirtualHost().name()).isEqualTo(newRdsName);
   }
 
   @Test
@@ -530,20 +531,20 @@ public class XdsDependencyManagerTest {
     InOrder inOrder = Mockito.inOrder(xdsConfigWatcher);
     xdsDependencyManager = new XdsDependencyManager(xdsClient, xdsConfigWatcher, syncContext,
         serverName, serverName, nameResolverArgs, scheduler);
-    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsConfigCaptor.capture());
-    XdsConfig initialConfig = xdsConfigCaptor.getValue();
+    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsUpdateCaptor.capture());
+    XdsConfig initialConfig = xdsUpdateCaptor.getValue().getValue();
 
     // Make sure that adding subscriptions that rds points at doesn't change the config
     Closeable rootSub = xdsDependencyManager.subscribeToCluster("root");
-    assertThat(xdsDependencyManager.buildConfig()).isEqualTo(initialConfig);
+    assertThat(xdsDependencyManager.buildUpdate().getValue()).isEqualTo(initialConfig);
     Closeable clusterAB11Sub = xdsDependencyManager.subscribeToCluster("clusterAB11");
-    assertThat(xdsDependencyManager.buildConfig()).isEqualTo(initialConfig);
+    assertThat(xdsDependencyManager.buildUpdate().getValue()).isEqualTo(initialConfig);
 
     // Make sure that closing subscriptions that rds points at doesn't change the config
     rootSub.close();
-    assertThat(xdsDependencyManager.buildConfig()).isEqualTo(initialConfig);
+    assertThat(xdsDependencyManager.buildUpdate().getValue()).isEqualTo(initialConfig);
     clusterAB11Sub.close();
-    assertThat(xdsDependencyManager.buildConfig()).isEqualTo(initialConfig);
+    assertThat(xdsDependencyManager.buildUpdate().getValue()).isEqualTo(initialConfig);
 
     // Make an explicit root subscription and then change RDS to point to A11
     rootSub = xdsDependencyManager.subscribeToCluster("root");
@@ -551,13 +552,14 @@ public class XdsDependencyManagerTest {
         XdsTestUtils.buildRouteConfiguration(serverName, XdsTestUtils.RDS_NAME, "clusterA11");
     controlPlaneService.setXdsConfig(
         ADS_TYPE_URL_RDS, ImmutableMap.of(XdsTestUtils.RDS_NAME, newRouteConfig));
-    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsConfigCaptor.capture());
-    assertThat(xdsConfigCaptor.getValue().getClusters().keySet().size()).isEqualTo(4);
+    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsUpdateCaptor.capture());
+    assertThat(xdsUpdateCaptor.getValue().getValue().getClusters().keySet().size()).isEqualTo(4);
 
     // Now that it is released, we should only have A11
     rootSub.close();
-    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsConfigCaptor.capture());
-    assertThat(xdsConfigCaptor.getValue().getClusters().keySet()).containsExactly("clusterA11");
+    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsUpdateCaptor.capture());
+    assertThat(xdsUpdateCaptor.getValue().getValue().getClusters().keySet())
+        .containsExactly("clusterA11");
   }
 
   @Test
@@ -590,8 +592,8 @@ public class XdsDependencyManagerTest {
     // Start the actual test
     xdsDependencyManager = new XdsDependencyManager(xdsClient, xdsConfigWatcher, syncContext,
         serverName, serverName, nameResolverArgs, scheduler);
-    verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsConfigCaptor.capture());
-    XdsConfig initialConfig = xdsConfigCaptor.getValue();
+    verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsUpdateCaptor.capture());
+    XdsConfig initialConfig = xdsUpdateCaptor.getValue().getValue();
     assertThat(initialConfig.getClusters().keySet())
         .containsExactly("root", "clusterA", "clusterB");
 
@@ -642,8 +644,8 @@ public class XdsDependencyManagerTest {
     Listener clientListener = buildInlineClientListener(newRdsName, "root");
     controlPlaneService.setXdsConfig(ADS_TYPE_URL_LDS,
         ImmutableMap.of(serverName, clientListener));
-    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsConfigCaptor.capture());
-    XdsConfig config = xdsConfigCaptor.getValue();
+    inOrder.verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsUpdateCaptor.capture());
+    XdsConfig config = xdsUpdateCaptor.getValue().getValue();
     assertThat(config.getVirtualHost().name()).isEqualTo(newRdsName);
     assertThat(config.getClusters().size()).isEqualTo(4);
   }
@@ -709,8 +711,9 @@ public class XdsDependencyManagerTest {
     xdsDependencyManager = new XdsDependencyManager(xdsClient, xdsConfigWatcher, syncContext,
         serverName, serverName, nameResolverArgs, scheduler);
 
-    verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsConfigCaptor.capture());
-    Status status = xdsConfigCaptor.getValue().getClusters().get(CLUSTER_NAME).getStatus();
+    verify(xdsConfigWatcher, timeout(1000)).onUpdate(xdsUpdateCaptor.capture());
+    Status status = xdsUpdateCaptor.getValue().getValue()
+        .getClusters().get(CLUSTER_NAME).getStatus();
     assertThat(status.getDescription()).contains(XdsTestUtils.CLUSTER_NAME);
   }
 
@@ -718,46 +721,32 @@ public class XdsDependencyManagerTest {
     return XdsTestUtils.buildInlineClientListener(rdsName, clusterName, serverName);
   }
 
-
-  private static String toContextStr(String type, String resourceName) {
-    return type + " resource: " + resourceName;
-  }
-
   private static class TestWatcher implements XdsDependencyManager.XdsConfigWatcher {
     XdsConfig lastConfig;
     int numUpdates = 0;
     int numError = 0;
-    int numDoesNotExist = 0;
 
     @Override
-    public void onUpdate(XdsConfig config) {
-      log.fine("Config changed: " + config);
-      lastConfig = config;
-      numUpdates++;
-    }
-
-    @Override
-    public void onError(String resourceContext, Status status) {
-      log.fine(String.format("Error %s for %s: ", status, resourceContext));
-      numError++;
-    }
-
-    @Override
-    public void onResourceDoesNotExist(String resourceName) {
-      log.fine("Resource does not exist: " + resourceName);
-      numDoesNotExist++;
+    public void onUpdate(StatusOr<XdsConfig> update) {
+      log.fine("Config update: " + update);
+      if (update.hasValue()) {
+        lastConfig = update.getValue();
+        numUpdates++;
+      } else {
+        numError++;
+      }
     }
 
     private List<Integer> getStats() {
-      return Arrays.asList(numUpdates, numError, numDoesNotExist);
+      return Arrays.asList(numUpdates, numError);
     }
 
-    private void verifyStats(int updt, int err, int notExist) {
-      assertThat(getStats()).isEqualTo(Arrays.asList(updt, err, notExist));
+    private void verifyStats(int updt, int err) {
+      assertThat(getStats()).isEqualTo(Arrays.asList(updt, err));
     }
   }
 
-  static class ClusterNameMatcher implements ArgumentMatcher<XdsConfig> {
+  static class ClusterNameMatcher implements ArgumentMatcher<StatusOr<XdsConfig>> {
     private final List<String> expectedNames;
 
     ClusterNameMatcher(List<String> expectedNames) {
@@ -765,7 +754,11 @@ public class XdsDependencyManagerTest {
     }
 
     @Override
-    public boolean matches(XdsConfig xdsConfig) {
+    public boolean matches(StatusOr<XdsConfig> update) {
+      if (!update.hasValue()) {
+        return false;
+      }
+      XdsConfig xdsConfig = update.getValue();
       if (xdsConfig == null || xdsConfig.getClusters() == null) {
         return false;
       }

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -636,7 +636,6 @@ public class XdsNameResolverTest {
         metricRecorder, nameResolverArgs);
     resolver.start(mockListener);
     FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
-    // TODO Why does the test expect to have listener.onResult2() called when this produces an error
     xdsClient.deliverLdsUpdateOnly(0L, Arrays.asList(virtualHost));
     fakeClock.forwardTime(15, TimeUnit.SECONDS);
     assertEmptyResolutionResult("random");

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -46,6 +46,7 @@ import com.google.protobuf.util.Durations;
 import com.google.re2j.Pattern;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
+import io.grpc.ChannelLogger;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
@@ -70,6 +71,7 @@ import io.grpc.Status.Code;
 import io.grpc.SynchronizationContext;
 import io.grpc.internal.AutoConfiguredLoadBalancerFactory;
 import io.grpc.internal.FakeClock;
+import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.JsonParser;
 import io.grpc.internal.JsonUtil;
 import io.grpc.internal.ObjectPool;
@@ -89,6 +91,8 @@ import io.grpc.xds.VirtualHost.Route.RouteAction.HashPolicy;
 import io.grpc.xds.VirtualHost.Route.RouteAction.RetryPolicy;
 import io.grpc.xds.VirtualHost.Route.RouteMatch;
 import io.grpc.xds.VirtualHost.Route.RouteMatch.PathMatcher;
+import io.grpc.xds.XdsClusterResource.CdsUpdate;
+import io.grpc.xds.XdsEndpointResource.EdsUpdate;
 import io.grpc.xds.XdsListenerResource.LdsUpdate;
 import io.grpc.xds.XdsRouteConfigureResource.RdsUpdate;
 import io.grpc.xds.client.Bootstrapper.AuthorityInfo;
@@ -104,6 +108,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -187,6 +192,15 @@ public class XdsNameResolverTest {
   private TestCall<?, ?> testCall;
   private boolean originalEnableTimeout;
   private URI targetUri;
+  private final NameResolver.Args nameResolverArgs = NameResolver.Args.newBuilder()
+      .setDefaultPort(8080)
+      .setProxyDetector(GrpcUtil.DEFAULT_PROXY_DETECTOR)
+      .setSynchronizationContext(syncContext)
+      .setServiceConfigParser(mock(NameResolver.ServiceConfigParser.class))
+      .setChannelLogger(mock(ChannelLogger.class))
+      .setScheduledExecutorService(fakeClock.getScheduledExecutorService())
+      .build();
+
 
   @Before
   public void setUp() {
@@ -213,7 +227,7 @@ public class XdsNameResolverTest {
 
     resolver = new XdsNameResolver(targetUri, null, AUTHORITY, null,
         serviceConfigParser, syncContext, scheduler,
-        xdsClientPoolFactory, mockRandom, filterRegistry, null, metricRecorder);
+        xdsClientPoolFactory, mockRandom, filterRegistry, null, metricRecorder, nameResolverArgs);
   }
 
   @After
@@ -259,7 +273,7 @@ public class XdsNameResolverTest {
     resolver = new XdsNameResolver(targetUri, null, AUTHORITY, null,
         serviceConfigParser, syncContext, scheduler,
         xdsClientPoolFactory, mockRandom, FilterRegistry.getDefaultRegistry(), null,
-        metricRecorder);
+        metricRecorder, nameResolverArgs);
     resolver.start(mockListener);
     verify(mockListener).onError(errorCaptor.capture());
     Status error = errorCaptor.getValue();
@@ -273,7 +287,7 @@ public class XdsNameResolverTest {
     resolver = new XdsNameResolver(targetUri,
         "notfound.google.com", AUTHORITY, null, serviceConfigParser, syncContext, scheduler,
         xdsClientPoolFactory, mockRandom, FilterRegistry.getDefaultRegistry(), null,
-        metricRecorder);
+        metricRecorder, nameResolverArgs);
     resolver.start(mockListener);
     verify(mockListener).onError(errorCaptor.capture());
     Status error = errorCaptor.getValue();
@@ -295,7 +309,7 @@ public class XdsNameResolverTest {
     resolver = new XdsNameResolver(
         targetUri, null, serviceAuthority, null, serviceConfigParser, syncContext,
         scheduler, xdsClientPoolFactory,
-        mockRandom, FilterRegistry.getDefaultRegistry(), null, metricRecorder);
+        mockRandom, FilterRegistry.getDefaultRegistry(), null, metricRecorder, nameResolverArgs);
     resolver.start(mockListener);
     verify(mockListener, never()).onError(any(Status.class));
   }
@@ -316,7 +330,7 @@ public class XdsNameResolverTest {
     resolver = new XdsNameResolver(
         targetUri, null, serviceAuthority, null, serviceConfigParser, syncContext, scheduler,
         xdsClientPoolFactory, mockRandom, FilterRegistry.getDefaultRegistry(), null,
-        metricRecorder);
+        metricRecorder, nameResolverArgs);
     resolver.start(mockListener);
     verify(mockListener, never()).onError(any(Status.class));
   }
@@ -337,7 +351,7 @@ public class XdsNameResolverTest {
     resolver = new XdsNameResolver(
         targetUri, null, serviceAuthority, null, serviceConfigParser, syncContext, scheduler,
         xdsClientPoolFactory, mockRandom, FilterRegistry.getDefaultRegistry(), null,
-        metricRecorder);
+        metricRecorder, nameResolverArgs);
 
 
     // The Service Authority must be URL encoded, but unlike the LDS resource name.
@@ -366,7 +380,7 @@ public class XdsNameResolverTest {
     resolver = new XdsNameResolver(targetUri,
         "xds.authority.com", serviceAuthority, null, serviceConfigParser, syncContext, scheduler,
         xdsClientPoolFactory, mockRandom, FilterRegistry.getDefaultRegistry(), null,
-        metricRecorder);
+        metricRecorder, nameResolverArgs);
     resolver.start(mockListener);
     verify(mockListener, never()).onError(any(Status.class));
   }
@@ -399,7 +413,7 @@ public class XdsNameResolverTest {
     resolver = new XdsNameResolver(targetUri, null, AUTHORITY, null,
         serviceConfigParser, syncContext, scheduler,
         xdsClientPoolFactory, mockRandom, FilterRegistry.getDefaultRegistry(), null,
-        metricRecorder);
+        metricRecorder, nameResolverArgs);
     // use different ldsResourceName and service authority. The virtualhost lookup should use
     // service authority.
     expectedLdsResourceName = "test-" + expectedLdsResourceName;
@@ -413,6 +427,7 @@ public class XdsNameResolverTest {
             Collections.singletonList(route1),
             ImmutableMap.of());
     xdsClient.deliverRdsUpdate(RDS_RESOURCE_NAME, Collections.singletonList(virtualHost));
+    createAndDeliverClusterUpdates(xdsClient, cluster1);
     verify(mockListener).onResult2(resolutionResultCaptor.capture());
     assertServiceConfigForLoadBalancingConfig(
         Collections.singletonList(cluster1),
@@ -429,6 +444,7 @@ public class XdsNameResolverTest {
             Collections.singletonList(route2),
             ImmutableMap.of());
     xdsClient.deliverRdsUpdate(alternativeRdsResource, Collections.singletonList(virtualHost));
+    createAndDeliverClusterUpdates(xdsClient, cluster2);
     // Two new service config updates triggered:
     //  - with load balancing config being able to select cluster1 and cluster2
     //  - with load balancing config being able to select cluster2 only
@@ -467,6 +483,7 @@ public class XdsNameResolverTest {
             Collections.singletonList(route),
             ImmutableMap.of());
     xdsClient.deliverRdsUpdate(RDS_RESOURCE_NAME, Collections.singletonList(virtualHost));
+    createAndDeliverClusterUpdates(xdsClient, cluster1);
     verify(mockListener).onResult2(resolutionResultCaptor.capture());
     assertServiceConfigForLoadBalancingConfig(
         Collections.singletonList(cluster1),
@@ -483,6 +500,7 @@ public class XdsNameResolverTest {
     verifyNoInteractions(mockListener);
     assertThat(xdsClient.rdsResource).isEqualTo(RDS_RESOURCE_NAME);
     xdsClient.deliverRdsUpdate(RDS_RESOURCE_NAME, Collections.singletonList(virtualHost));
+    createAndDeliverClusterUpdates(xdsClient, cluster1);
     verify(mockListener).onResult2(resolutionResultCaptor.capture());
     assertServiceConfigForLoadBalancingConfig(
         Collections.singletonList(cluster1),
@@ -506,6 +524,7 @@ public class XdsNameResolverTest {
             Collections.singletonList(route),
             ImmutableMap.of());
     xdsClient.deliverRdsUpdate(RDS_RESOURCE_NAME, Collections.singletonList(virtualHost));
+    createAndDeliverClusterUpdates(xdsClient, cluster1);
     verify(mockListener).onResult2(resolutionResultCaptor.capture());
     assertServiceConfigForLoadBalancingConfig(
         Collections.singletonList(cluster1),
@@ -529,11 +548,15 @@ public class XdsNameResolverTest {
     resolver.start(mockListener);
     FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
     xdsClient.deliverError(Status.UNAVAILABLE.withDescription("server unreachable"));
-    verify(mockListener).onError(errorCaptor.capture());
-    Status error = errorCaptor.getValue();
+    verify(mockListener).onResult2(resolutionResultCaptor.capture());
+    InternalConfigSelector configSelector = resolutionResultCaptor.getValue()
+        .getAttributes().get(InternalConfigSelector.KEY);
+    Result selectResult = configSelector.selectConfig(
+        newPickSubchannelArgs(call1.methodDescriptor, new Metadata(), CallOptions.DEFAULT));
+    Status error = selectResult.getStatus();
     assertThat(error.getCode()).isEqualTo(Code.UNAVAILABLE);
-    assertThat(error.getDescription()).isEqualTo("Unable to load LDS " + AUTHORITY
-        + ". xDS server returned: UNAVAILABLE: server unreachable");
+    assertThat(error.getDescription()).contains(AUTHORITY);
+    assertThat(error.getDescription()).contains("UNAVAILABLE: server unreachable");
   }
 
   @Test
@@ -541,11 +564,15 @@ public class XdsNameResolverTest {
     resolver.start(mockListener);
     FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
     xdsClient.deliverError(Status.NOT_FOUND.withDescription("server unreachable"));
-    verify(mockListener).onError(errorCaptor.capture());
-    Status error = errorCaptor.getValue();
+    verify(mockListener).onResult2(resolutionResultCaptor.capture());
+    InternalConfigSelector configSelector = resolutionResultCaptor.getValue()
+        .getAttributes().get(InternalConfigSelector.KEY);
+    Result selectResult = configSelector.selectConfig(
+        newPickSubchannelArgs(call1.methodDescriptor, new Metadata(), CallOptions.DEFAULT));
+    Status error = selectResult.getStatus();
     assertThat(error.getCode()).isEqualTo(Code.UNAVAILABLE);
-    assertThat(error.getDescription()).isEqualTo("Unable to load LDS " + AUTHORITY
-        + ". xDS server returned: NOT_FOUND: server unreachable");
+    assertThat(error.getDescription()).contains(AUTHORITY);
+    assertThat(error.getDescription()).contains("NOT_FOUND: server unreachable");
     assertThat(error.getCause()).isNull();
   }
 
@@ -555,15 +582,15 @@ public class XdsNameResolverTest {
     FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
     xdsClient.deliverLdsUpdateForRdsName(RDS_RESOURCE_NAME);
     xdsClient.deliverError(Status.UNAVAILABLE.withDescription("server unreachable"));
-    verify(mockListener, times(2)).onError(errorCaptor.capture());
-    Status error = errorCaptor.getAllValues().get(0);
+    verify(mockListener).onResult2(resolutionResultCaptor.capture());
+    InternalConfigSelector configSelector = resolutionResultCaptor.getValue()
+        .getAttributes().get(InternalConfigSelector.KEY);
+    Result selectResult = configSelector.selectConfig(
+        newPickSubchannelArgs(call1.methodDescriptor, new Metadata(), CallOptions.DEFAULT));
+    Status error = selectResult.getStatus();
     assertThat(error.getCode()).isEqualTo(Code.UNAVAILABLE);
-    assertThat(error.getDescription()).isEqualTo("Unable to load LDS " + AUTHORITY
-        + ". xDS server returned: UNAVAILABLE: server unreachable");
-    error = errorCaptor.getAllValues().get(1);
-    assertThat(error.getCode()).isEqualTo(Code.UNAVAILABLE);
-    assertThat(error.getDescription()).isEqualTo("Unable to load RDS " + RDS_RESOURCE_NAME
-        + ". xDS server returned: UNAVAILABLE: server unreachable");
+    assertThat(error.getDescription()).contains(RDS_RESOURCE_NAME);
+    assertThat(error.getDescription()).contains("UNAVAILABLE: server unreachable");
   }
 
   @SuppressWarnings("unchecked")
@@ -581,10 +608,11 @@ public class XdsNameResolverTest {
     resolver = new XdsNameResolver(targetUri, null, AUTHORITY, "random",
         serviceConfigParser, syncContext, scheduler,
         xdsClientPoolFactory, mockRandom, FilterRegistry.getDefaultRegistry(), null,
-        metricRecorder);
+        metricRecorder, nameResolverArgs);
     resolver.start(mockListener);
     FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
     xdsClient.deliverLdsUpdate(0L, Arrays.asList(virtualHost));
+    createAndDeliverClusterUpdates(xdsClient, cluster1);
     verify(mockListener).onResult2(resolutionResultCaptor.capture());
     assertServiceConfigForLoadBalancingConfig(
         Collections.singletonList(cluster1),
@@ -605,10 +633,12 @@ public class XdsNameResolverTest {
     resolver = new XdsNameResolver(targetUri, null, AUTHORITY, "random",
         serviceConfigParser, syncContext, scheduler,
         xdsClientPoolFactory, mockRandom, FilterRegistry.getDefaultRegistry(), null,
-        metricRecorder);
+        metricRecorder, nameResolverArgs);
     resolver.start(mockListener);
     FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
-    xdsClient.deliverLdsUpdate(0L, Arrays.asList(virtualHost));
+    // TODO Why does the test expect to have listener.onResult2() called when this produces an error
+    xdsClient.deliverLdsUpdateOnly(0L, Arrays.asList(virtualHost));
+    fakeClock.forwardTime(15, TimeUnit.SECONDS);
     assertEmptyResolutionResult("random");
   }
 
@@ -617,7 +647,7 @@ public class XdsNameResolverTest {
     resolver = new XdsNameResolver(targetUri, null, AUTHORITY, AUTHORITY,
         serviceConfigParser, syncContext, scheduler,
         xdsClientPoolFactory, mockRandom, FilterRegistry.getDefaultRegistry(), null,
-        metricRecorder);
+        metricRecorder, nameResolverArgs);
     resolver.start(mockListener);
     FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
     xdsClient.deliverLdsUpdate(0L, buildUnmatchedVirtualHosts());
@@ -702,7 +732,7 @@ public class XdsNameResolverTest {
         true, 5, 5, new AutoConfiguredLoadBalancerFactory("pick-first"));
     resolver = new XdsNameResolver(targetUri, null, AUTHORITY, null, realParser, syncContext,
         scheduler, xdsClientPoolFactory, mockRandom, FilterRegistry.getDefaultRegistry(), null,
-        metricRecorder);
+        metricRecorder, nameResolverArgs);
     resolver.start(mockListener);
     FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
     RetryPolicy retryPolicy = RetryPolicy.create(
@@ -913,7 +943,7 @@ public class XdsNameResolverTest {
     resolver = new XdsNameResolver(targetUri, null, AUTHORITY, null, serviceConfigParser,
         syncContext, scheduler,
         xdsClientPoolFactory, mockRandom, FilterRegistry.getDefaultRegistry(), null,
-        metricRecorder);
+        metricRecorder, nameResolverArgs);
     resolver.start(mockListener);
     xdsClient = (FakeXdsClient) resolver.getXdsClient();
     xdsClient.deliverLdsUpdate(
@@ -946,7 +976,7 @@ public class XdsNameResolverTest {
   public void resolved_routeActionHasAutoHostRewrite_emitsCallOptionForTheSame() {
     resolver = new XdsNameResolver(targetUri, null, AUTHORITY, null, serviceConfigParser,
         syncContext, scheduler, xdsClientPoolFactory, mockRandom,
-        FilterRegistry.getDefaultRegistry(), null, metricRecorder);
+        FilterRegistry.getDefaultRegistry(), null, metricRecorder, nameResolverArgs);
     resolver.start(mockListener);
     FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
     xdsClient.deliverLdsUpdate(
@@ -977,7 +1007,7 @@ public class XdsNameResolverTest {
   public void resolved_routeActionNoAutoHostRewrite_doesntEmitCallOptionForTheSame() {
     resolver = new XdsNameResolver(targetUri, null, AUTHORITY, null, serviceConfigParser,
         syncContext, scheduler, xdsClientPoolFactory, mockRandom,
-        FilterRegistry.getDefaultRegistry(), null, metricRecorder);
+        FilterRegistry.getDefaultRegistry(), null, metricRecorder, nameResolverArgs);
     resolver.start(mockListener);
     FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
     xdsClient.deliverLdsUpdate(
@@ -1190,6 +1220,20 @@ public class XdsNameResolverTest {
     assertCallSelectClusterResult(call1, configSelector, cluster1, 20.0);
   }
 
+  /** Creates and delivers both CDS and EDS updates for the given clusters. */
+  private static void createAndDeliverClusterUpdates(
+      FakeXdsClient xdsClient, String... clusterNames) {
+    for (String clusterName : clusterNames) {
+      CdsUpdate.Builder forEds = CdsUpdate
+          .forEds(clusterName, clusterName, null, null, null, null, false)
+              .roundRobinLbPolicy();
+      xdsClient.deliverCdsUpdate(clusterName, forEds.build());
+      EdsUpdate edsUpdate = new EdsUpdate(clusterName,
+          XdsTestUtils.createMinimalLbEndpointsMap("host"), Collections.emptyList());
+      xdsClient.deliverEdsUpdate(clusterName, edsUpdate);
+    }
+  }
+
   @Test
   public void resolved_simpleCallSucceeds_routeToRls() {
     when(mockRandom.nextInt(anyInt())).thenReturn(90, 10);
@@ -1305,6 +1349,7 @@ public class XdsNameResolverTest {
 
     // LDS 1.
     xdsClient.deliverLdsUpdateWithFilters(vhost, filterStateTestConfigs(STATEFUL_1, STATEFUL_2));
+    createAndDeliverClusterUpdates(xdsClient, cluster1);
     assertClusterResolutionResult(call1, cluster1);
     ImmutableList<StatefulFilter> lds1Snapshot = statefulFilterProvider.getAllInstances();
     // Verify that StatefulFilter with different filter names result in different Filter instances.
@@ -1359,7 +1404,7 @@ public class XdsNameResolverTest {
    * Verifies the lifecycle of HCM filter instances across RDS updates.
    *
    * <p>Filter instances:
-   *   1. Must have instantiated by the initial LDS.
+   *   1. Must have instantiated by the initial LDS/RDS.
    *   2. Must be reused by all subsequent RDS updates.
    *   3. Must be not shutdown (closed) by valid RDS updates.
    */
@@ -1371,22 +1416,19 @@ public class XdsNameResolverTest {
     // LDS 1.
     xdsClient.deliverLdsUpdateForRdsNameWithFilters(RDS_RESOURCE_NAME,
         filterStateTestConfigs(STATEFUL_1, STATEFUL_2));
-    ImmutableList<StatefulFilter> lds1Snapshot = statefulFilterProvider.getAllInstances();
-    // Verify that StatefulFilter with different filter names result in different Filter instances.
-    assertWithMessage("LDS 1: expected to create filter instances").that(lds1Snapshot).hasSize(2);
-    // Naming: lds<LDS#>Filter<name#>
-    StatefulFilter lds1Filter1 = lds1Snapshot.get(0);
-    StatefulFilter lds1Filter2 = lds1Snapshot.get(1);
-    assertThat(lds1Filter1).isNotSameInstanceAs(lds1Filter2);
-
     // RDS 1.
     VirtualHost vhost1 = filterStateTestVhost();
     xdsClient.deliverRdsUpdate(RDS_RESOURCE_NAME, vhost1);
+    createAndDeliverClusterUpdates(xdsClient, cluster1);
     assertClusterResolutionResult(call1, cluster1);
     // Initial RDS update should not generate Filter instances.
     ImmutableList<StatefulFilter> rds1Snapshot = statefulFilterProvider.getAllInstances();
-    assertWithMessage("RDS 1: Expected Filter instances to be reused across RDS route updates")
-        .that(rds1Snapshot).isEqualTo(lds1Snapshot);
+    // Verify that StatefulFilter with different filter names result in different Filter instances.
+    assertWithMessage("RDS 1: expected to create filter instances").that(rds1Snapshot).hasSize(2);
+    // Naming: lds<LDS#>Filter<name#>
+    StatefulFilter lds1Filter1 = rds1Snapshot.get(0);
+    StatefulFilter lds1Filter2 = rds1Snapshot.get(1);
+    assertThat(lds1Filter1).isNotSameInstanceAs(lds1Filter2);
 
     // RDS 2: exactly the same as RDS 1.
     xdsClient.deliverRdsUpdate(RDS_RESOURCE_NAME, vhost1);
@@ -1394,7 +1436,7 @@ public class XdsNameResolverTest {
     ImmutableList<StatefulFilter> rds2Snapshot = statefulFilterProvider.getAllInstances();
     // Neither should any subsequent RDS updates.
     assertWithMessage("RDS 2: Expected Filter instances to be reused across RDS route updates")
-        .that(rds2Snapshot).isEqualTo(lds1Snapshot);
+        .that(rds2Snapshot).isEqualTo(rds1Snapshot);
 
     // RDS 3: Contains a per-route override for STATEFUL_1.
     VirtualHost vhost3 = filterStateTestVhost(ImmutableMap.of(
@@ -1406,7 +1448,7 @@ public class XdsNameResolverTest {
     // As with any other Route update, typed_per_filter_config overrides should not result in
     // creating new filter instances.
     assertWithMessage("RDS 3: Expected Filter instances to be reused on per-route filter overrides")
-        .that(rds3Snapshot).isEqualTo(lds1Snapshot);
+        .that(rds3Snapshot).isEqualTo(rds1Snapshot);
   }
 
   /**
@@ -1427,7 +1469,7 @@ public class XdsNameResolverTest {
         .register(statefulFilterProvider, altStatefulFilterProvider, ROUTER_FILTER_PROVIDER);
     resolver = new XdsNameResolver(targetUri, null, AUTHORITY, null, serviceConfigParser,
         syncContext, scheduler, xdsClientPoolFactory, mockRandom, filterRegistry, null,
-        metricRecorder);
+        metricRecorder, nameResolverArgs);
     resolver.start(mockListener);
 
     FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
@@ -1435,6 +1477,7 @@ public class XdsNameResolverTest {
 
     // LDS 1.
     xdsClient.deliverLdsUpdateWithFilters(vhost, filterStateTestConfigs(STATEFUL_1, STATEFUL_2));
+    createAndDeliverClusterUpdates(xdsClient, cluster1);
     assertClusterResolutionResult(call1, cluster1);
     ImmutableList<StatefulFilter> lds1Snapshot = statefulFilterProvider.getAllInstances();
     ImmutableList<StatefulFilter> lds1SnapshotAlt = altStatefulFilterProvider.getAllInstances();
@@ -1483,6 +1526,7 @@ public class XdsNameResolverTest {
 
     // LDS 1.
     xdsClient.deliverLdsUpdateWithFilters(vhost, filterStateTestConfigs(STATEFUL_1, STATEFUL_2));
+    createAndDeliverClusterUpdates(xdsClient, cluster1);
     assertClusterResolutionResult(call1, cluster1);
     ImmutableList<StatefulFilter> lds1Snapshot = statefulFilterProvider.getAllInstances();
     assertWithMessage("LDS 1: expected to create filter instances").that(lds1Snapshot).hasSize(2);
@@ -1510,6 +1554,7 @@ public class XdsNameResolverTest {
 
     // LDS 1.
     xdsClient.deliverLdsUpdateWithFilters(vhost, filterStateTestConfigs(STATEFUL_1, STATEFUL_2));
+    createAndDeliverClusterUpdates(xdsClient, cluster1);
     assertClusterResolutionResult(call1, cluster1);
     ImmutableList<StatefulFilter> lds1Snapshot = statefulFilterProvider.getAllInstances();
     assertWithMessage("LDS 1: expected to create filter instances").that(lds1Snapshot).hasSize(2);
@@ -1526,33 +1571,32 @@ public class XdsNameResolverTest {
   }
 
   /**
-   * Verifies that filter instances are NOT shutdown on RDS_RESOURCE_NAME not found.
+   * Verifies that all filter instances are shutdown (closed) on RDS resource not found.
    */
   @Test
-  public void filterState_shutdown_noShutdownOnRdsNotFound() {
+  public void filterState_shutdown_onRdsNotFound() {
     StatefulFilter.Provider statefulFilterProvider = filterStateTestSetupResolver();
     FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
 
     // LDS 1.
     xdsClient.deliverLdsUpdateForRdsNameWithFilters(RDS_RESOURCE_NAME,
         filterStateTestConfigs(STATEFUL_1, STATEFUL_2));
-    ImmutableList<StatefulFilter> lds1Snapshot = statefulFilterProvider.getAllInstances();
-    assertWithMessage("LDS 1: expected to create filter instances").that(lds1Snapshot).hasSize(2);
-    // Naming: lds<LDS#>Filter<name#>
-    StatefulFilter lds1Filter1 = lds1Snapshot.get(0);
-    StatefulFilter lds1Filter2 = lds1Snapshot.get(1);
-
     // RDS 1: Standard vhost with a route.
     xdsClient.deliverRdsUpdate(RDS_RESOURCE_NAME, filterStateTestVhost());
+    createAndDeliverClusterUpdates(xdsClient, cluster1);
     assertClusterResolutionResult(call1, cluster1);
-    assertThat(statefulFilterProvider.getAllInstances()).isEqualTo(lds1Snapshot);
+    ImmutableList<StatefulFilter> rds1Snapshot = statefulFilterProvider.getAllInstances();
+    assertWithMessage("RDS 1: expected to create filter instances").that(rds1Snapshot).hasSize(2);
+    // Naming: lds<LDS#>Filter<name#>
+    StatefulFilter lds1Filter1 = rds1Snapshot.get(0);
+    StatefulFilter lds1Filter2 = rds1Snapshot.get(1);
 
     // RDS 2: RDS_RESOURCE_NAME not found.
     reset(mockListener);
     xdsClient.deliverRdsResourceNotFound(RDS_RESOURCE_NAME);
     assertEmptyResolutionResult(RDS_RESOURCE_NAME);
-    assertThat(lds1Filter1.isShutdown()).isFalse();
-    assertThat(lds1Filter2.isShutdown()).isFalse();
+    assertThat(lds1Filter1.isShutdown()).isTrue();
+    assertThat(lds1Filter2.isShutdown()).isTrue();
   }
 
   private StatefulFilter.Provider filterStateTestSetupResolver() {
@@ -1561,7 +1605,7 @@ public class XdsNameResolverTest {
         .register(statefulFilterProvider, ROUTER_FILTER_PROVIDER);
     resolver = new XdsNameResolver(targetUri, null, AUTHORITY, null, serviceConfigParser,
         syncContext, scheduler, xdsClientPoolFactory, mockRandom, filterRegistry, null,
-        metricRecorder);
+        metricRecorder, nameResolverArgs);
     resolver.start(mockListener);
     return statefulFilterProvider;
   }
@@ -1762,6 +1806,7 @@ public class XdsNameResolverTest {
             ImmutableList.of(route1, route2, route3),
             ImmutableMap.of());
     xdsClient.deliverRdsUpdate(RDS_RESOURCE_NAME, Collections.singletonList(virtualHost));
+    createAndDeliverClusterUpdates(xdsClient, "cluster-foo", "cluster-bar", "cluster-baz");
 
     verify(mockListener).onResult2(resolutionResultCaptor.capture());
     String expectedServiceConfigJson =
@@ -2385,6 +2430,8 @@ public class XdsNameResolverTest {
     private String rdsResource;
     private ResourceWatcher<LdsUpdate> ldsWatcher;
     private ResourceWatcher<RdsUpdate> rdsWatcher;
+    private final Map<String, List<ResourceWatcher<CdsUpdate>>> cdsWatchers = new HashMap<>();
+    private final Map<String, List<ResourceWatcher<EdsUpdate>>> edsWatchers = new HashMap<>();
 
     @Override
     public BootstrapInfo getBootstrapInfo() {
@@ -2412,10 +2459,19 @@ public class XdsNameResolverTest {
           rdsResource = resourceName;
           rdsWatcher = (ResourceWatcher<RdsUpdate>) watcher;
           break;
+        case "CDS":
+          cdsWatchers.computeIfAbsent(resourceName, k -> new ArrayList<>())
+              .add((ResourceWatcher<CdsUpdate>) watcher);
+          break;
+        case "EDS":
+          edsWatchers.computeIfAbsent(resourceName, k -> new ArrayList<>())
+              .add((ResourceWatcher<EdsUpdate>) watcher);
+          break;
         default:
       }
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <T extends ResourceUpdate> void cancelXdsResourceWatch(XdsResourceType<T> type,
                                                                   String resourceName,
@@ -2434,14 +2490,37 @@ public class XdsNameResolverTest {
           rdsResource = null;
           rdsWatcher = null;
           break;
+        case "CDS":
+          assertThat(cdsWatchers).containsKey(resourceName);
+          assertThat(cdsWatchers.get(resourceName)).contains(watcher);
+          cdsWatchers.get(resourceName).remove((ResourceWatcher<CdsUpdate>) watcher);
+          break;
+        case "EDS":
+          assertThat(edsWatchers).containsKey(resourceName);
+          assertThat(edsWatchers.get(resourceName)).contains(watcher);
+          edsWatchers.get(resourceName).remove((ResourceWatcher<EdsUpdate>) watcher);
+          break;
         default:
       }
     }
 
-    void deliverLdsUpdate(long httpMaxStreamDurationNano, List<VirtualHost> virtualHosts) {
+    void deliverLdsUpdateOnly(long httpMaxStreamDurationNano, List<VirtualHost> virtualHosts) {
       syncContext.execute(() -> {
         ldsWatcher.onChanged(LdsUpdate.forApiListener(HttpConnectionManager.forVirtualHosts(
             httpMaxStreamDurationNano, virtualHosts, null)));
+      });
+    }
+
+    void deliverLdsUpdate(long httpMaxStreamDurationNano, List<VirtualHost> virtualHosts) {
+      List<String> clusterNames = new ArrayList<>();
+      for (VirtualHost vh : virtualHosts) {
+        clusterNames.addAll(getClusterNames(vh.routes()));
+      }
+
+      syncContext.execute(() -> {
+        ldsWatcher.onChanged(LdsUpdate.forApiListener(HttpConnectionManager.forVirtualHosts(
+            httpMaxStreamDurationNano, virtualHosts, null)));
+        createAndDeliverClusterUpdates(this, clusterNames.toArray(new String[0]));
       });
     }
 
@@ -2450,9 +2529,14 @@ public class XdsNameResolverTest {
           VirtualHost.create(
               "virtual-host", Collections.singletonList(expectedLdsResourceName), routes,
               ImmutableMap.of());
+      List<String> clusterNames = getClusterNames(routes);
+
       syncContext.execute(() -> {
         ldsWatcher.onChanged(LdsUpdate.forApiListener(HttpConnectionManager.forVirtualHosts(
             0L, Collections.singletonList(virtualHost), null)));
+        if (!clusterNames.isEmpty()) {
+          createAndDeliverClusterUpdates(this, clusterNames.toArray(new String[0]));
+        }
       });
     }
 
@@ -2508,6 +2592,7 @@ public class XdsNameResolverTest {
       syncContext.execute(() -> {
         ldsWatcher.onChanged(LdsUpdate.forApiListener(HttpConnectionManager.forVirtualHosts(
             0L, Collections.singletonList(virtualHost), filterChain)));
+        createAndDeliverClusterUpdates(this, cluster);
       });
     }
 
@@ -2543,6 +2628,29 @@ public class XdsNameResolverTest {
       syncContext.execute(() -> {
         ldsWatcher.onResourceDoesNotExist(expectedLdsResourceName);
       });
+    }
+
+    private List<String> getClusterNames(List<Route> routes) {
+      List<String> clusterNames = new ArrayList<>();
+      for (Route r : routes) {
+        if (r.routeAction() == null) {
+          continue;
+        }
+        String cluster = r.routeAction().cluster();
+        if (cluster != null) {
+          clusterNames.add(cluster);
+        } else {
+          List<ClusterWeight> weightedClusters = r.routeAction().weightedClusters();
+          if (weightedClusters == null) {
+            continue;
+          }
+          for (ClusterWeight wc : weightedClusters) {
+            clusterNames.add(wc.name());
+          }
+        }
+      }
+
+      return clusterNames;
     }
 
     void deliverRdsUpdateWithFaultInjection(
@@ -2581,6 +2689,7 @@ public class XdsNameResolverTest {
           overrideConfig);
       syncContext.execute(() -> {
         rdsWatcher.onChanged(new RdsUpdate(Collections.singletonList(virtualHost)));
+        createAndDeliverClusterUpdates(this, cluster1);
       });
     }
 
@@ -2606,6 +2715,29 @@ public class XdsNameResolverTest {
       });
     }
 
+    private void deliverCdsUpdate(String clusterName, CdsUpdate update) {
+      if (!cdsWatchers.containsKey(clusterName)) {
+        return;
+      }
+      syncContext.execute(() -> {
+        List<ResourceWatcher<CdsUpdate>> resourceWatchers =
+            ImmutableList.copyOf(cdsWatchers.get(clusterName));
+        resourceWatchers.forEach(w -> w.onChanged(update));
+      });
+    }
+
+    private void deliverEdsUpdate(String name, EdsUpdate update) {
+      syncContext.execute(() -> {
+        if (!edsWatchers.containsKey(name)) {
+          return;
+        }
+        List<ResourceWatcher<EdsUpdate>> resourceWatchers =
+            ImmutableList.copyOf(edsWatchers.get(name));
+        resourceWatchers.forEach(w -> w.onChanged(update));
+      });
+    }
+
+
     void deliverError(final Status error) {
       if (ldsWatcher != null) {
         syncContext.execute(() -> {
@@ -2617,6 +2749,11 @@ public class XdsNameResolverTest {
           rdsWatcher.onError(error);
         });
       }
+      syncContext.execute(() -> {
+        cdsWatchers.values().stream()
+            .flatMap(List::stream)
+            .forEach(w -> w.onError(error));
+      });
     }
   }
 

--- a/xds/src/test/java/io/grpc/xds/XdsTestUtils.java
+++ b/xds/src/test/java/io/grpc/xds/XdsTestUtils.java
@@ -51,7 +51,6 @@ import io.envoyproxy.envoy.service.load_stats.v3.LoadStatsResponse;
 import io.grpc.BindableService;
 import io.grpc.Context;
 import io.grpc.Context.CancellationListener;
-import io.grpc.Status;
 import io.grpc.StatusOr;
 import io.grpc.internal.JsonParser;
 import io.grpc.stub.StreamObserver;
@@ -414,20 +413,6 @@ public class XdsTestUtils {
               .setLoadReportingInterval(Durations.fromNanos(loadReportIntervalNano))
               .build();
       responseObserver.onNext(response);
-    }
-  }
-
-  static class StatusMatcher implements ArgumentMatcher<Status> {
-    private final Status expectedStatus;
-
-    StatusMatcher(Status expectedStatus) {
-      this.expectedStatus = expectedStatus;
-    }
-
-    @Override
-    public boolean matches(Status status) {
-      return status != null && expectedStatus.getCode().equals(status.getCode())
-          && expectedStatus.getDescription().equals(status.getDescription());
     }
   }
 }

--- a/xds/src/test/java/io/grpc/xds/XdsTestUtils.java
+++ b/xds/src/test/java/io/grpc/xds/XdsTestUtils.java
@@ -281,6 +281,16 @@ public class XdsTestUtils {
     return builder.build();
   }
 
+  static Map<Locality, LocalityLbEndpoints> createMinimalLbEndpointsMap(String serverHostName) {
+    Map<Locality, LocalityLbEndpoints> lbEndpointsMap = new HashMap<>();
+    LbEndpoint lbEndpoint = LbEndpoint.create(
+        serverHostName, ENDPOINT_PORT, 0, true, ENDPOINT_HOSTNAME, ImmutableMap.of());
+    lbEndpointsMap.put(
+        Locality.create("", "", ""),
+        LocalityLbEndpoints.create(ImmutableList.of(lbEndpoint), 10, 0, ImmutableMap.of()));
+    return lbEndpointsMap;
+  }
+
   @SuppressWarnings("unchecked")
   private static ImmutableMap<String, ?> getWrrLbConfigAsMap() throws IOException {
     String lbConfigStr = "{\"wrr_locality_experimental\" : "
@@ -353,7 +363,6 @@ public class XdsTestUtils {
     return Listener.newBuilder()
         .setName(serverName)
         .setApiListener(clientListenerBuilder.build()).build();
-
   }
 
   /**


### PR DESCRIPTION
I'm going to leave this in draft form until after I squash and rebase on master (once the review has gotten to that point).

~"Gracefully handle tcp listeners. Fix error processing in XdsNR" is partly speculative right now, as we have a discussion of how error handling should be done. The tcp listeners is needed, but it got mixed together with onError() behavior. I can split it up needed.~ The gRFC changed to match the behavior here. https://github.com/grpc/proposal/commit/fea37889f085c4f55e61e29678356e9a57dc4bf0