### PR TITLE
documentation: upgrade to junit 4.13.2

### DIFF
--- a/documentation/server-reflection-tutorial.md
+++ b/documentation/server-reflection-tutorial.md
@@ -28,7 +28,7 @@ need to make the following changes:
 +  compile "io.grpc:grpc-services:${grpcVersion}"
    compile "io.grpc:grpc-stub:${grpcVersion}"
  
-   testCompile "junit:junit:4.12"
+   testCompile "junit:junit:4.13.2"
 --- a/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldServer.java
 +++ b/examples/src/main/java/io/grpc/examples/helloworld/HelloWorldServer.java
 @@ -33,6 +33,7 @@ package io.grpc.examples.helloworld;


### PR DESCRIPTION
FYI https://github.com/grpc/grpc-java/pull/9820, we already moved on to 4.13.2 