### PR TITLE
core: Log any exception during panic because of exception

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -187,7 +187,12 @@ final class ManagedChannelImpl extends ManagedChannel implements
               Level.SEVERE,
               "[" + getLogId() + "] Uncaught exception in the SynchronizationContext. Panic!",
               e);
-          panic(e);
+          try {
+            panic(e);
+          } catch (Throwable t) {
+            logger.log(
+                Level.SEVERE, "[" + getLogId() + "] Uncaught exception while panic()ing", e);
+          }
         }
       });
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -189,9 +189,9 @@ final class ManagedChannelImpl extends ManagedChannel implements
               e);
           try {
             panic(e);
-          } catch (Throwable t) {
+          } catch (Throwable anotherT) {
             logger.log(
-                Level.SEVERE, "[" + getLogId() + "] Uncaught exception while panic()ing", e);
+                Level.SEVERE, "[" + getLogId() + "] Uncaught exception while panicking", anotherT);
           }
         }
       });


### PR DESCRIPTION
panic() calls a good amount of code, so it could get another exception. The SynchronizationContext is running on an arbitrary thread and we don't want to propagate this secondary exception up its stack (to be handled by its UncaughtExceptionHandler); it we wanted that we'd propagate the original exception.

This second exception will only be seen in the logs; the first exception was logged and will be used to fail RPCs.

Also related to http://yaqs/8493785598685872128 and b692b9d26