### PR TITLE
Cleans up FileWatcherCertificateProvider in XdsSecurityClientSecurityTest

### DIFF
--- a/xds/src/test/java/io/grpc/xds/XdsSecurityClientServerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsSecurityClientServerTest.java
@@ -130,6 +130,7 @@ public class XdsSecurityClientServerTest {
   private FakeXdsClient xdsClient = new FakeXdsClient();
   private FakeXdsClientPoolFactory fakePoolFactory = new FakeXdsClientPoolFactory(xdsClient);
   private static final String OVERRIDE_AUTHORITY = "foo.test.google.fr";
+  private Attributes sslContextAttributes;
 
   @Parameters(name = "enableSpiffe={0}")
   public static Collection<Boolean> data() {
@@ -152,6 +153,14 @@ public class XdsSecurityClientServerTest {
       NameResolverRegistry.getDefaultRegistry().deregister(fakeNameResolverFactory);
     }
     FileWatcherCertificateProviderProvider.enableSpiffe = originalEnableSpiffe;
+    if (sslContextAttributes != null) {
+      SslContextProviderSupplier sslContextProviderSupplier = sslContextAttributes.get(
+              SecurityProtocolNegotiators.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER);
+      if (sslContextProviderSupplier != null) {
+        sslContextProviderSupplier.close();
+      }
+      sslContextAttributes = null;
+    }
   }
 
   @Test
@@ -651,7 +660,7 @@ public class XdsSecurityClientServerTest {
     InetSocketAddress socketAddress =
         new InetSocketAddress(Inet4Address.getLoopbackAddress(), port);
     tlsContextManagerForClient = new TlsContextManagerImpl(bootstrapInfoForClient);
-    Attributes attrs =
+    sslContextAttributes =
         (upstreamTlsContext != null)
             ? Attributes.newBuilder()
                 .set(SecurityProtocolNegotiators.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER,
@@ -660,7 +669,7 @@ public class XdsSecurityClientServerTest {
                 .build()
             : Attributes.EMPTY;
     fakeNameResolverFactory.setServers(
-        ImmutableList.of(new EquivalentAddressGroup(socketAddress, attrs)));
+        ImmutableList.of(new EquivalentAddressGroup(socketAddress, sslContextAttributes)));
     return SimpleServiceGrpc.newBlockingStub(cleanupRule.register(channelBuilder.build()));
   }
 
@@ -796,13 +805,6 @@ public class XdsSecurityClientServerTest {
 
       @Override
       public void shutdown() {
-        for (EquivalentAddressGroup s : servers) {
-          SslContextProviderSupplier sslContextProviderSupplier = s.getAttributes()
-                  .get(SecurityProtocolNegotiators.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER);
-          if (sslContextProviderSupplier != null) {
-            sslContextProviderSupplier.close();
-          }
-        }
       }
 
       @Override

--- a/xds/src/test/java/io/grpc/xds/XdsSecurityClientServerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsSecurityClientServerTest.java
@@ -796,6 +796,13 @@ public class XdsSecurityClientServerTest {
 
       @Override
       public void shutdown() {
+        for (EquivalentAddressGroup s : servers) {
+          SslContextProviderSupplier sslContextProviderSupplier = s.getAttributes()
+                  .get(SecurityProtocolNegotiators.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER);
+          if (sslContextProviderSupplier != null) {
+            sslContextProviderSupplier.close();
+          }
+        }
       }
 
       @Override


### PR DESCRIPTION
Fixes: https://github.com/grpc/grpc-java/issues/11692