### PR TITLE
no reflection in InstantTimeProvider, fixes #11975

### DIFF
--- a/core/src/main/java/io/grpc/internal/TimeProviderResolverFactory.java
+++ b/core/src/main/java/io/grpc/internal/TimeProviderResolverFactory.java
@@ -23,8 +23,8 @@ package io.grpc.internal;
 final class TimeProviderResolverFactory {
   static TimeProvider resolveTimeProvider() {
     try {
-      Class<?> instantClass = Class.forName("java.time.Instant");
-      return new InstantTimeProvider(instantClass);
+      Class.forName("java.time.Instant");
+      return new InstantTimeProvider();
     } catch (ClassNotFoundException ex) {
       return new ConcurrentTimeProvider();
     }

--- a/core/src/test/java/io/grpc/internal/InstantTimeProviderTest.java
+++ b/core/src/test/java/io/grpc/internal/InstantTimeProviderTest.java
@@ -34,8 +34,7 @@ public class InstantTimeProviderTest {
   @Test
   public void testInstantCurrentTimeNanos() throws Exception {
 
-    InstantTimeProvider instantTimeProvider = new InstantTimeProvider(
-        Class.forName("java.time.Instant"));
+    InstantTimeProvider instantTimeProvider = new InstantTimeProvider();
 
     // Get the current time from the InstantTimeProvider
     long actualTimeNanos = instantTimeProvider.currentTimeNanos();


### PR DESCRIPTION
Seems like there is not need to use reflection in InstantTimeProvider.
if Instant class is present, then we can use normally.