### PR TITLE
Fix for data race on `acknowledgedIncomingBytes` in class `BinderTransport`

### DIFF
--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -484,8 +484,8 @@ public abstract class BinderTransport
         inbound.handleTransaction(parcel);
       }
       long nib = numIncomingBytes.addAndGet(size);
-      if ((nib - acknowledgedIncomingBytes) > TRANSACTION_BYTES_WINDOW_FORCE_ACK) {
-        synchronized (this) {
+      synchronized (this) {
+        if ((nib - acknowledgedIncomingBytes) > TRANSACTION_BYTES_WINDOW_FORCE_ACK) {
           sendAcknowledgeBytes(checkNotNull(outgoingBinder));
         }
       }


### PR DESCRIPTION
There is a data race on the field `acknowledgedIncomingBytes` in class `BinderTransport`. As a consequence, if two threads execute `handleAcknowledgedBytes` concurrently the following execution could occur:
1. One thread writes reading the field `acknowledgedIncomingBytes` when executing [this line](https://github.com/grpc/grpc-java/blob/b1bc0a9d240c2cc6ccf9cf02543c9d9118132c14/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java#L525)
2. The other executing thread reads a stale/outdated value of `acknowledgedIncomingBytes` when executing [this line](https://github.com/grpc/grpc-java/blob/b1bc0a9d240c2cc6ccf9cf02543c9d9118132c14/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java#L487).

Furthermore, this data race shows a violation of the `@GuardedBy("this")` annotation for the field `acknowledgedIncomingBytes` in class `BinderTransport`. The reason is that the read is not guarded by lock.

This PR proposes to solve the problem by including the read in [this line](https://github.com/grpc/grpc-java/blob/b1bc0a9d240c2cc6ccf9cf02543c9d9118132c14/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java#L487) within the synchronized block. This prevents the data race and ensuring that reads always read the latest written value on the field.