### PR TITLE
core: Delete stale SuppressWarnings("deprecated") for ATTR_LOAD_BALANCING_CONFIG

### DIFF
--- a/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
+++ b/core/src/main/java/io/grpc/internal/AutoConfiguredLoadBalancerFactory.java
@@ -40,8 +40,6 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 
-// TODO(creamsoup) fully deprecate LoadBalancer.ATTR_LOAD_BALANCING_CONFIG
-@SuppressWarnings("deprecation")
 public final class AutoConfiguredLoadBalancerFactory {
 
   private final LoadBalancerRegistry registry;


### PR DESCRIPTION
ATTR_LOAD_BALANCING_CONFIG was deleted in bf7a42dbd.

-----

FWIW, I don't know why checkstyle isn't complaining about the public class not having javadoc. It really shouldn't be public, but it is being used in XdsNameResolverTest to validate a service config.