### PR TITLE
Implement grpc.lb.backend_service optional label

### DIFF
--- a/api/src/main/java/io/grpc/NameResolver.java
+++ b/api/src/main/java/io/grpc/NameResolver.java
@@ -275,6 +275,11 @@ public abstract class NameResolver {
   @Documented
   public @interface ResolutionResultAttr {}
 
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/11989")
+  @ResolutionResultAttr
+  public static final Attributes.Key<String> ATTR_BACKEND_SERVICE =
+      Attributes.Key.create("io.grpc.NameResolver.ATTR_BACKEND_SERVICE");
+
   /**
    * Information that a {@link Factory} uses to create a {@link NameResolver}.
    *

--- a/opentelemetry/src/main/java/io/grpc/opentelemetry/internal/OpenTelemetryConstants.java
+++ b/opentelemetry/src/main/java/io/grpc/opentelemetry/internal/OpenTelemetryConstants.java
@@ -33,6 +33,9 @@ public final class OpenTelemetryConstants {
   public static final AttributeKey<String> LOCALITY_KEY =
       AttributeKey.stringKey("grpc.lb.locality");
 
+  public static final AttributeKey<String> BACKEND_SERVICE_KEY =
+      AttributeKey.stringKey("grpc.lb.backend_service");
+
   public static final List<Double> LATENCY_BUCKETS =
       ImmutableList.of(
           0d,     0.00001d, 0.00005d, 0.0001d, 0.0003d, 0.0006d, 0.0008d, 0.001d, 0.002d,

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -32,6 +32,7 @@ import io.grpc.EquivalentAddressGroup;
 import io.grpc.InternalLogId;
 import io.grpc.LoadBalancer;
 import io.grpc.Metadata;
+import io.grpc.NameResolver;
 import io.grpc.Status;
 import io.grpc.internal.ForwardingClientStreamTracer;
 import io.grpc.internal.GrpcUtil;
@@ -150,7 +151,9 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
 
     childSwitchLb.handleResolvedAddresses(
         resolvedAddresses.toBuilder()
-            .setAttributes(attributes)
+            .setAttributes(attributes.toBuilder()
+              .set(NameResolver.ATTR_BACKEND_SERVICE, cluster)
+              .build())
             .setLoadBalancingPolicyConfig(config.childConfig)
             .build());
     return Status.OK;

--- a/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
@@ -50,6 +50,7 @@ import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
+import io.grpc.NameResolver;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.SynchronizationContext;
@@ -198,6 +199,7 @@ public class ClusterImplLoadBalancerTest {
     assertThat(childBalancer.config).isSameInstanceAs(weightedTargetConfig);
     assertThat(childBalancer.attributes.get(XdsAttributes.XDS_CLIENT_POOL))
         .isSameInstanceAs(xdsClientPool);
+    assertThat(childBalancer.attributes.get(NameResolver.ATTR_BACKEND_SERVICE)).isEqualTo(CLUSTER);
   }
 
   /**


### PR DESCRIPTION
This completes gRFC A89. 7162d2d66 and fc86084df had already implemented the LB plumbing for the optional label on RPC metrics. This observes the value in OpenTelemetry and adds it to WRR metrics as well.

https://github.com/grpc/proposal/blob/master/A89-backend-service-metric-label.md