### PR TITLE
xds: Enable deprecation warnings

### DIFF
--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -133,8 +133,6 @@ tasks.named("checkstyleThirdparty").configure {
 
 tasks.named("compileJava").configure {
     it.options.compilerArgs += [
-        // TODO: remove
-        "-Xlint:-deprecation",
         // only has AutoValue annotation processor
         "-Xlint:-processing",
     ]

--- a/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancer.java
@@ -673,7 +673,7 @@ final class ClusterResolverLoadBalancer extends LoadBalancer {
                   resolutionResult.getAddressesOrError();
           if (addressesOrError.hasValue()) {
             backoffPolicy = null;  // reset backoff sequence if succeeded
-            for (EquivalentAddressGroup eag : resolutionResult.getAddresses()) {
+            for (EquivalentAddressGroup eag : addressesOrError.getValue()) {
               // No weight attribute is attached, all endpoint-level LB policy should be able
               // to handle such it.
               String localityName = localityName(LOGICAL_DNS_CLUSTER_LOCALITY);

--- a/xds/src/main/java/io/grpc/xds/RbacFilter.java
+++ b/xds/src/main/java/io/grpc/xds/RbacFilter.java
@@ -276,8 +276,13 @@ final class RbacFilter implements Filter {
         return createSourceIpMatcher(principal.getDirectRemoteIp());
       case REMOTE_IP:
         return createSourceIpMatcher(principal.getRemoteIp());
-      case SOURCE_IP:
-        return createSourceIpMatcher(principal.getSourceIp());
+      case SOURCE_IP: {
+        // gRFC A41 has identical handling of source_ip as remote_ip and direct_remote_ip and
+        // pre-dates the deprecation.
+        @SuppressWarnings("deprecation")
+        CidrRange sourceIp = principal.getSourceIp();
+        return createSourceIpMatcher(sourceIp);
+      }
       case HEADER:
         return parseHeaderMatcher(principal.getHeader());
       case NOT_ID:

--- a/xds/src/main/java/io/grpc/xds/XdsClusterResource.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClusterResource.java
@@ -450,15 +450,6 @@ class XdsClusterResource extends XdsResourceType<CdsUpdate> {
       throw new ResourceInvalidException(
           "common-tls-context with validation_context_sds_secret_config is not supported");
     }
-    if (commonTlsContext.hasValidationContextCertificateProvider()) {
-      throw new ResourceInvalidException(
-          "common-tls-context with validation_context_certificate_provider is not supported");
-    }
-    if (commonTlsContext.hasValidationContextCertificateProviderInstance()) {
-      throw new ResourceInvalidException(
-          "common-tls-context with validation_context_certificate_provider_instance is not"
-              + " supported");
-    }
     String certInstanceName = getIdentityCertInstanceName(commonTlsContext);
     if (certInstanceName == null) {
       if (server) {
@@ -470,10 +461,6 @@ class XdsClusterResource extends XdsResourceType<CdsUpdate> {
             "tls_certificate_provider_instance is unset");
       }
       if (commonTlsContext.getTlsCertificateSdsSecretConfigsCount() > 0) {
-        throw new ResourceInvalidException(
-            "tls_certificate_provider_instance is unset");
-      }
-      if (commonTlsContext.hasTlsCertificateCertificateProvider()) {
         throw new ResourceInvalidException(
             "tls_certificate_provider_instance is unset");
       }
@@ -505,7 +492,9 @@ class XdsClusterResource extends XdsResourceType<CdsUpdate> {
             .getDefaultValidationContext();
       }
       if (certificateValidationContext != null) {
-        if (certificateValidationContext.getMatchSubjectAltNamesCount() > 0 && server) {
+        @SuppressWarnings("deprecation") // gRFC A29 predates match_typed_subject_alt_names
+        int matchSubjectAltNamesCount = certificateValidationContext.getMatchSubjectAltNamesCount();
+        if (matchSubjectAltNamesCount > 0 && server) {
           throw new ResourceInvalidException(
               "match_subject_alt_names only allowed in upstream_tls_context");
         }
@@ -536,8 +525,6 @@ class XdsClusterResource extends XdsResourceType<CdsUpdate> {
   private static String getIdentityCertInstanceName(CommonTlsContext commonTlsContext) {
     if (commonTlsContext.hasTlsCertificateProviderInstance()) {
       return commonTlsContext.getTlsCertificateProviderInstance().getInstanceName();
-    } else if (commonTlsContext.hasTlsCertificateCertificateProviderInstance()) {
-      return commonTlsContext.getTlsCertificateCertificateProviderInstance().getInstanceName();
     }
     return null;
   }
@@ -556,10 +543,6 @@ class XdsClusterResource extends XdsResourceType<CdsUpdate> {
           .hasCaCertificateProviderInstance()) {
         return combinedCertificateValidationContext.getDefaultValidationContext()
             .getCaCertificateProviderInstance().getInstanceName();
-      } else if (combinedCertificateValidationContext
-          .hasValidationContextCertificateProviderInstance()) {
-        return combinedCertificateValidationContext
-            .getValidationContextCertificateProviderInstance().getInstanceName();
       }
     }
     return null;

--- a/xds/src/main/java/io/grpc/xds/XdsRouteConfigureResource.java
+++ b/xds/src/main/java/io/grpc/xds/XdsRouteConfigureResource.java
@@ -451,8 +451,7 @@ class XdsRouteConfigureResource extends XdsResourceType<RdsUpdate> {
               config.getHeader();
           Pattern regEx = null;
           String regExSubstitute = null;
-          if (headerCfg.hasRegexRewrite() && headerCfg.getRegexRewrite().hasPattern()
-              && headerCfg.getRegexRewrite().getPattern().hasGoogleRe2()) {
+          if (headerCfg.hasRegexRewrite() && headerCfg.getRegexRewrite().hasPattern()) {
             regEx = Pattern.compile(headerCfg.getRegexRewrite().getPattern().getRegex());
             regExSubstitute = headerCfg.getRegexRewrite().getSubstitution();
           }

--- a/xds/src/main/java/io/grpc/xds/internal/MatcherParser.java
+++ b/xds/src/main/java/io/grpc/xds/internal/MatcherParser.java
@@ -26,9 +26,12 @@ public final class MatcherParser {
           io.envoyproxy.envoy.config.route.v3.HeaderMatcher proto) {
     switch (proto.getHeaderMatchSpecifierCase()) {
       case EXACT_MATCH:
+        @SuppressWarnings("deprecation") // gRFC A63: support indefinitely
+        String exactMatch = proto.getExactMatch();
         return Matchers.HeaderMatcher.forExactValue(
-                        proto.getName(), proto.getExactMatch(), proto.getInvertMatch());
+                        proto.getName(), exactMatch, proto.getInvertMatch());
       case SAFE_REGEX_MATCH:
+        @SuppressWarnings("deprecation") // gRFC A63: support indefinitely
         String rawPattern = proto.getSafeRegexMatch().getRegex();
         Pattern safeRegExMatch;
         try {
@@ -49,14 +52,20 @@ public final class MatcherParser {
         return Matchers.HeaderMatcher.forPresent(
               proto.getName(), proto.getPresentMatch(), proto.getInvertMatch());
       case PREFIX_MATCH:
+        @SuppressWarnings("deprecation") // gRFC A63: support indefinitely
+        String prefixMatch = proto.getPrefixMatch();
         return Matchers.HeaderMatcher.forPrefix(
-              proto.getName(), proto.getPrefixMatch(), proto.getInvertMatch());
+              proto.getName(), prefixMatch, proto.getInvertMatch());
       case SUFFIX_MATCH:
+        @SuppressWarnings("deprecation") // gRFC A63: support indefinitely
+        String suffixMatch = proto.getSuffixMatch();
         return Matchers.HeaderMatcher.forSuffix(
-              proto.getName(), proto.getSuffixMatch(), proto.getInvertMatch());
+              proto.getName(), suffixMatch, proto.getInvertMatch());
       case CONTAINS_MATCH:
+        @SuppressWarnings("deprecation") // gRFC A63: support indefinitely
+        String containsMatch = proto.getContainsMatch();
         return Matchers.HeaderMatcher.forContains(
-              proto.getName(), proto.getContainsMatch(), proto.getInvertMatch());
+              proto.getName(), containsMatch, proto.getInvertMatch());
       case STRING_MATCH:
         return Matchers.HeaderMatcher.forString(
           proto.getName(), parseStringMatcher(proto.getStringMatch()), proto.getInvertMatch());

--- a/xds/src/main/java/io/grpc/xds/internal/security/CommonTlsContextUtil.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/CommonTlsContextUtil.java
@@ -34,25 +34,16 @@ public final class CommonTlsContextUtil {
   }
 
   private static boolean hasCertProviderValidationContext(CommonTlsContext commonTlsContext) {
-    if (commonTlsContext.hasCombinedValidationContext()) {
-      CombinedCertificateValidationContext combinedCertificateValidationContext =
-          commonTlsContext.getCombinedValidationContext();
-      return combinedCertificateValidationContext.hasValidationContextCertificateProviderInstance();
-    }
     return hasValidationProviderInstance(commonTlsContext);
   }
 
   private static boolean hasIdentityCertificateProviderInstance(CommonTlsContext commonTlsContext) {
-    return commonTlsContext.hasTlsCertificateProviderInstance()
-        || commonTlsContext.hasTlsCertificateCertificateProviderInstance();
+    return commonTlsContext.hasTlsCertificateProviderInstance();
   }
 
   private static boolean hasValidationProviderInstance(CommonTlsContext commonTlsContext) {
-    if (commonTlsContext.hasValidationContext() && commonTlsContext.getValidationContext()
-        .hasCaCertificateProviderInstance()) {
-      return true;
-    }
-    return commonTlsContext.hasValidationContextCertificateProviderInstance();
+    return commonTlsContext.hasValidationContext() && commonTlsContext.getValidationContext()
+        .hasCaCertificateProviderInstance();
   }
 
   /**

--- a/xds/src/main/java/io/grpc/xds/internal/security/CommonTlsContextUtil.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/CommonTlsContextUtil.java
@@ -18,7 +18,6 @@ package io.grpc.xds.internal.security;
 
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateProviderPluginInstance;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext;
-import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext.CombinedCertificateValidationContext;
 
 /** Class for utility functions for {@link CommonTlsContext}. */
 public final class CommonTlsContextUtil {

--- a/xds/src/main/java/io/grpc/xds/internal/security/CommonTlsContextUtil.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/CommonTlsContextUtil.java
@@ -28,21 +28,18 @@ public final class CommonTlsContextUtil {
     if (commonTlsContext == null) {
       return false;
     }
-    return hasIdentityCertificateProviderInstance(commonTlsContext)
-        || hasCertProviderValidationContext(commonTlsContext);
-  }
-
-  private static boolean hasCertProviderValidationContext(CommonTlsContext commonTlsContext) {
-    return hasValidationProviderInstance(commonTlsContext);
-  }
-
-  private static boolean hasIdentityCertificateProviderInstance(CommonTlsContext commonTlsContext) {
-    return commonTlsContext.hasTlsCertificateProviderInstance();
+    return commonTlsContext.hasTlsCertificateProviderInstance()
+        || hasValidationProviderInstance(commonTlsContext);
   }
 
   private static boolean hasValidationProviderInstance(CommonTlsContext commonTlsContext) {
-    return commonTlsContext.hasValidationContext() && commonTlsContext.getValidationContext()
-        .hasCaCertificateProviderInstance();
+    if (commonTlsContext.hasValidationContext() && commonTlsContext.getValidationContext()
+        .hasCaCertificateProviderInstance()) {
+      return true;
+    }
+    return commonTlsContext.hasCombinedValidationContext()
+        && commonTlsContext.getCombinedValidationContext().getDefaultValidationContext()
+          .hasCaCertificateProviderInstance();
   }
 
   /**

--- a/xds/src/main/java/io/grpc/xds/internal/security/certprovider/CertProviderSslContextProvider.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/certprovider/CertProviderSslContextProvider.java
@@ -99,8 +99,6 @@ abstract class CertProviderSslContextProvider extends DynamicSslContextProvider 
       CommonTlsContext commonTlsContext) {
     if (commonTlsContext.hasTlsCertificateProviderInstance()) {
       return CommonTlsContextUtil.convert(commonTlsContext.getTlsCertificateProviderInstance());
-    } else if (commonTlsContext.hasTlsCertificateCertificateProviderInstance()) {
-      return commonTlsContext.getTlsCertificateCertificateProviderInstance();
     }
     return null;
   }
@@ -127,15 +125,6 @@ abstract class CertProviderSslContextProvider extends DynamicSslContextProvider 
         commonTlsContext);
     if (certValidationContext != null && certValidationContext.hasCaCertificateProviderInstance()) {
       return CommonTlsContextUtil.convert(certValidationContext.getCaCertificateProviderInstance());
-    }
-    if (commonTlsContext.hasCombinedValidationContext()) {
-      CommonTlsContext.CombinedCertificateValidationContext combinedValidationContext =
-          commonTlsContext.getCombinedValidationContext();
-      if (combinedValidationContext.hasValidationContextCertificateProviderInstance()) {
-        return combinedValidationContext.getValidationContextCertificateProviderInstance();
-      }
-    } else if (commonTlsContext.hasValidationContextCertificateProviderInstance()) {
-      return commonTlsContext.getValidationContextCertificateProviderInstance();
     }
     return null;
   }

--- a/xds/src/main/java/io/grpc/xds/internal/security/trust/XdsX509TrustManager.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/trust/XdsX509TrustManager.java
@@ -207,6 +207,7 @@ final class XdsX509TrustManager extends X509ExtendedTrustManager implements X509
     if (certContext == null) {
       return;
     }
+    @SuppressWarnings("deprecation") // gRFC A29 predates match_typed_subject_alt_names
     List<StringMatcher> verifyList = certContext.getMatchSubjectAltNamesList();
     if (verifyList.isEmpty()) {
       return;

--- a/xds/src/test/java/io/grpc/xds/FilterChainMatchingProtocolNegotiatorsTest.java
+++ b/xds/src/test/java/io/grpc/xds/FilterChainMatchingProtocolNegotiatorsTest.java
@@ -1125,7 +1125,6 @@ public class FilterChainMatchingProtocolNegotiatorsTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void filterChainMatch_unsupportedMatchers() throws Exception {
     EnvoyServerProtoData.DownstreamTlsContext tlsContext1 =
             CommonTlsContextTestsUtil.buildTestInternalDownstreamTlsContext("CERT1", "ROOTCA");
@@ -1194,7 +1193,7 @@ public class FilterChainMatchingProtocolNegotiatorsTest {
     assertThat(sslSet.get()).isEqualTo(defaultFilterChain.sslContextProviderSupplier());
     assertThat(routingSettable.get()).isEqualTo(noopConfig);
     assertThat(sslSet.get().getTlsContext().getCommonTlsContext()
-            .getTlsCertificateCertificateProviderInstance()
+            .getTlsCertificateProviderInstance()
             .getCertificateName()).isEqualTo("CERT3");
   }
 

--- a/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplDataTest.java
@@ -98,7 +98,6 @@ import io.envoyproxy.envoy.extensions.transport_sockets.http_11_proxy.v3.Http11P
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateProviderPluginInstance;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateValidationContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext;
-import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext.CertificateProviderInstance;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext.CombinedCertificateValidationContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.SdsSecretConfig;
@@ -3043,35 +3042,6 @@ public class GrpcXdsClientImplDataTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
-  public void validateCommonTlsContext_validationContextCertificateProvider()
-      throws ResourceInvalidException {
-    CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
-        .setValidationContextCertificateProvider(
-            CommonTlsContext.CertificateProvider.getDefaultInstance())
-        .build();
-    thrown.expect(ResourceInvalidException.class);
-    thrown.expectMessage(
-        "common-tls-context with validation_context_certificate_provider is not supported");
-    XdsClusterResource.validateCommonTlsContext(commonTlsContext, null, false);
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  public void validateCommonTlsContext_validationContextCertificateProviderInstance()
-      throws ResourceInvalidException {
-    CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
-        .setValidationContextCertificateProviderInstance(
-            CommonTlsContext.CertificateProviderInstance.getDefaultInstance())
-        .build();
-    thrown.expect(ResourceInvalidException.class);
-    thrown.expectMessage(
-        "common-tls-context with validation_context_certificate_provider_instance is not "
-            + "supported");
-    XdsClusterResource.validateCommonTlsContext(commonTlsContext, null, false);
-  }
-
-  @Test
   public void validateCommonTlsContext_tlsCertificateProviderInstance_isRequiredForServer()
       throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
@@ -3083,36 +3053,33 @@ public class GrpcXdsClientImplDataTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_tlsNewCertificateProviderInstance()
       throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
         .setTlsCertificateProviderInstance(
-            CertificateProviderPluginInstance.newBuilder().setInstanceName("name1").build())
+            CertificateProviderPluginInstance.newBuilder().setInstanceName("name1"))
         .build();
     XdsClusterResource
         .validateCommonTlsContext(commonTlsContext, ImmutableSet.of("name1", "name2"), true);
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_tlsCertificateProviderInstance()
       throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
-        .setTlsCertificateCertificateProviderInstance(
-            CertificateProviderInstance.newBuilder().setInstanceName("name1").build())
+        .setTlsCertificateProviderInstance(
+            CertificateProviderPluginInstance.newBuilder().setInstanceName("name1"))
         .build();
     XdsClusterResource
         .validateCommonTlsContext(commonTlsContext, ImmutableSet.of("name1", "name2"), true);
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_tlsCertificateProviderInstance_absentInBootstrapFile()
           throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
-        .setTlsCertificateCertificateProviderInstance(
-            CertificateProviderInstance.newBuilder().setInstanceName("bad-name").build())
+        .setTlsCertificateProviderInstance(
+            CertificateProviderPluginInstance.newBuilder().setInstanceName("bad-name"))
         .build();
     thrown.expect(ResourceInvalidException.class);
     thrown.expectMessage(
@@ -3122,15 +3089,17 @@ public class GrpcXdsClientImplDataTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_validationContextProviderInstance()
           throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
         .setCombinedValidationContext(
             CommonTlsContext.CombinedCertificateValidationContext.newBuilder()
-                .setValidationContextCertificateProviderInstance(
-                    CertificateProviderInstance.newBuilder().setInstanceName("name1").build())
+              .setDefaultValidationContext(CertificateValidationContext.newBuilder()
+                .setCaCertificateProviderInstance(CertificateProviderPluginInstance.newBuilder()
+                  .setInstanceName("name1")
+                  .build())
                 .build())
+              .build())
         .build();
     XdsClusterResource
         .validateCommonTlsContext(commonTlsContext, ImmutableSet.of("name1", "name2"), false);
@@ -3218,15 +3187,14 @@ public class GrpcXdsClientImplDataTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_validationContextProviderInstance_absentInBootstrapFile()
           throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
         .setCombinedValidationContext(
             CommonTlsContext.CombinedCertificateValidationContext.newBuilder()
-                .setValidationContextCertificateProviderInstance(
-                    CertificateProviderInstance.newBuilder().setInstanceName("bad-name").build())
-                .build())
+              .setDefaultValidationContext(CertificateValidationContext.newBuilder()
+                .setCaCertificateProviderInstance(CertificateProviderPluginInstance.newBuilder()
+                  .setInstanceName("bad-name"))))
         .build();
     thrown.expect(ResourceInvalidException.class);
     thrown.expectMessage(
@@ -3251,20 +3219,6 @@ public class GrpcXdsClientImplDataTest {
       throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
         .addTlsCertificateSdsSecretConfigs(SdsSecretConfig.getDefaultInstance())
-        .build();
-    thrown.expect(ResourceInvalidException.class);
-    thrown.expectMessage(
-        "tls_certificate_provider_instance is unset");
-    XdsClusterResource.validateCommonTlsContext(commonTlsContext, null, false);
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  public void validateCommonTlsContext_tlsCertificateCertificateProvider()
-      throws ResourceInvalidException {
-    CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
-        .setTlsCertificateCertificateProvider(
-            CommonTlsContext.CertificateProvider.getDefaultInstance())
         .build();
     thrown.expect(ResourceInvalidException.class);
     thrown.expectMessage(
@@ -3304,13 +3258,13 @@ public class GrpcXdsClientImplDataTest {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
         .setCombinedValidationContext(
             CombinedCertificateValidationContext.newBuilder()
-                .setValidationContextCertificateProviderInstance(
-                    CertificateProviderInstance.getDefaultInstance())
                 .setDefaultValidationContext(CertificateValidationContext.newBuilder()
+                    .setCaCertificateProviderInstance(
+                        CertificateProviderPluginInstance.getDefaultInstance())
                     .addMatchSubjectAltNames(StringMatcher.newBuilder().setExact("foo.com").build())
                     .build()))
-        .setTlsCertificateCertificateProviderInstance(
-            CertificateProviderInstance.getDefaultInstance())
+        .setTlsCertificateProviderInstance(
+            CertificateProviderPluginInstance.getDefaultInstance())
         .build();
     thrown.expect(ResourceInvalidException.class);
     thrown.expectMessage("match_subject_alt_names only allowed in upstream_tls_context");
@@ -3318,18 +3272,16 @@ public class GrpcXdsClientImplDataTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_combinedValContextWithDefaultValContextVerifyCertSpki()
       throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
         .setCombinedValidationContext(
             CommonTlsContext.CombinedCertificateValidationContext.newBuilder()
-                .setValidationContextCertificateProviderInstance(
-                    CommonTlsContext.CertificateProviderInstance.getDefaultInstance())
-                .setDefaultValidationContext(
-                    CertificateValidationContext.newBuilder().addVerifyCertificateSpki("foo")))
-        .setTlsCertificateCertificateProviderInstance(
-            CommonTlsContext.CertificateProviderInstance.getDefaultInstance())
+                .setDefaultValidationContext(CertificateValidationContext.newBuilder()
+                    .setCaCertificateProviderInstance(
+                        CertificateProviderPluginInstance.getDefaultInstance())
+                    .addVerifyCertificateSpki("foo")))
+        .setTlsCertificateProviderInstance(CertificateProviderPluginInstance.getDefaultInstance())
         .build();
     thrown.expect(ResourceInvalidException.class);
     thrown.expectMessage("verify_certificate_spki in default_validation_context is not "
@@ -3338,18 +3290,16 @@ public class GrpcXdsClientImplDataTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_combinedValContextWithDefaultValContextVerifyCertHash()
       throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
         .setCombinedValidationContext(
             CommonTlsContext.CombinedCertificateValidationContext.newBuilder()
-                .setValidationContextCertificateProviderInstance(
-                    CommonTlsContext.CertificateProviderInstance.getDefaultInstance())
-                .setDefaultValidationContext(
-                    CertificateValidationContext.newBuilder().addVerifyCertificateHash("foo")))
-        .setTlsCertificateCertificateProviderInstance(
-            CommonTlsContext.CertificateProviderInstance.getDefaultInstance())
+                .setDefaultValidationContext(CertificateValidationContext.newBuilder()
+                    .setCaCertificateProviderInstance(
+                        CertificateProviderPluginInstance.getDefaultInstance())
+                    .addVerifyCertificateHash("foo")))
+        .setTlsCertificateProviderInstance(CertificateProviderPluginInstance.getDefaultInstance())
         .build();
     thrown.expect(ResourceInvalidException.class);
     thrown.expectMessage("verify_certificate_hash in default_validation_context is not "
@@ -3358,18 +3308,17 @@ public class GrpcXdsClientImplDataTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_combinedValContextDfltValContextRequireSignedCertTimestamp()
       throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
         .setCombinedValidationContext(
             CommonTlsContext.CombinedCertificateValidationContext.newBuilder()
-                .setValidationContextCertificateProviderInstance(
-                    CommonTlsContext.CertificateProviderInstance.getDefaultInstance())
                 .setDefaultValidationContext(CertificateValidationContext.newBuilder()
+                    .setCaCertificateProviderInstance(
+                        CertificateProviderPluginInstance.getDefaultInstance())
                     .setRequireSignedCertificateTimestamp(BoolValue.of(true))))
-        .setTlsCertificateCertificateProviderInstance(
-            CommonTlsContext.CertificateProviderInstance.getDefaultInstance())
+        .setTlsCertificateProviderInstance(
+            CertificateProviderPluginInstance.getDefaultInstance())
         .build();
     thrown.expect(ResourceInvalidException.class);
     thrown.expectMessage(
@@ -3379,18 +3328,16 @@ public class GrpcXdsClientImplDataTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_combinedValidationContextWithDefaultValidationContextCrl()
       throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
         .setCombinedValidationContext(
             CommonTlsContext.CombinedCertificateValidationContext.newBuilder()
-                .setValidationContextCertificateProviderInstance(
-                    CommonTlsContext.CertificateProviderInstance.getDefaultInstance())
                 .setDefaultValidationContext(CertificateValidationContext.newBuilder()
+                    .setCaCertificateProviderInstance(
+                        CertificateProviderPluginInstance.getDefaultInstance())
                     .setCrl(DataSource.getDefaultInstance())))
-        .setTlsCertificateCertificateProviderInstance(
-            CommonTlsContext.CertificateProviderInstance.getDefaultInstance())
+        .setTlsCertificateProviderInstance(CertificateProviderPluginInstance.getDefaultInstance())
         .build();
     thrown.expect(ResourceInvalidException.class);
     thrown.expectMessage("crl in default_validation_context is not supported");
@@ -3398,18 +3345,16 @@ public class GrpcXdsClientImplDataTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void validateCommonTlsContext_combinedValContextWithDfltValContextCustomValidatorConfig()
       throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
         .setCombinedValidationContext(
             CommonTlsContext.CombinedCertificateValidationContext.newBuilder()
-                .setValidationContextCertificateProviderInstance(
-                    CommonTlsContext.CertificateProviderInstance.getDefaultInstance())
                 .setDefaultValidationContext(CertificateValidationContext.newBuilder()
+                    .setCaCertificateProviderInstance(
+                        CertificateProviderPluginInstance.getDefaultInstance())
                     .setCustomValidatorConfig(TypedExtensionConfig.getDefaultInstance())))
-        .setTlsCertificateCertificateProviderInstance(
-            CommonTlsContext.CertificateProviderInstance.getDefaultInstance())
+        .setTlsCertificateProviderInstance(CertificateProviderPluginInstance.getDefaultInstance())
         .build();
     thrown.expect(ResourceInvalidException.class);
     thrown.expectMessage("custom_validator_config in default_validation_context is not "
@@ -3426,15 +3371,14 @@ public class GrpcXdsClientImplDataTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void validateDownstreamTlsContext_hasRequireSni() throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
         .setCombinedValidationContext(
             CommonTlsContext.CombinedCertificateValidationContext.newBuilder()
-                .setValidationContextCertificateProviderInstance(
-                    CommonTlsContext.CertificateProviderInstance.getDefaultInstance()))
-        .setTlsCertificateCertificateProviderInstance(
-            CommonTlsContext.CertificateProviderInstance.getDefaultInstance())
+                .setDefaultValidationContext(CertificateValidationContext.newBuilder()
+                    .setCaCertificateProviderInstance(
+                        CertificateProviderPluginInstance.getDefaultInstance())))
+        .setTlsCertificateProviderInstance(CertificateProviderPluginInstance.getDefaultInstance())
         .build();
     DownstreamTlsContext downstreamTlsContext = DownstreamTlsContext.newBuilder()
         .setCommonTlsContext(commonTlsContext)
@@ -3446,15 +3390,14 @@ public class GrpcXdsClientImplDataTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void validateDownstreamTlsContext_hasOcspStaplePolicy() throws ResourceInvalidException {
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
         .setCombinedValidationContext(
             CommonTlsContext.CombinedCertificateValidationContext.newBuilder()
-                .setValidationContextCertificateProviderInstance(
-                    CommonTlsContext.CertificateProviderInstance.getDefaultInstance()))
-        .setTlsCertificateCertificateProviderInstance(
-            CommonTlsContext.CertificateProviderInstance.getDefaultInstance())
+                .setDefaultValidationContext(CertificateValidationContext.newBuilder()
+                    .setCaCertificateProviderInstance(
+                        CertificateProviderPluginInstance.getDefaultInstance())))
+        .setTlsCertificateProviderInstance(CertificateProviderPluginInstance.getDefaultInstance())
         .build();
     DownstreamTlsContext downstreamTlsContext = DownstreamTlsContext.newBuilder()
         .setCommonTlsContext(commonTlsContext)

--- a/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplDataTest.java
@@ -3096,10 +3096,7 @@ public class GrpcXdsClientImplDataTest {
             CommonTlsContext.CombinedCertificateValidationContext.newBuilder()
               .setDefaultValidationContext(CertificateValidationContext.newBuilder()
                 .setCaCertificateProviderInstance(CertificateProviderPluginInstance.newBuilder()
-                  .setInstanceName("name1")
-                  .build())
-                .build())
-              .build())
+                  .setInstanceName("name1"))))
         .build();
     XdsClusterResource
         .validateCommonTlsContext(commonTlsContext, ImmutableSet.of("name1", "name2"), false);

--- a/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplTestBase.java
@@ -47,7 +47,6 @@ import io.envoyproxy.envoy.config.route.v3.FilterConfig;
 import io.envoyproxy.envoy.config.route.v3.WeightedCluster;
 import io.envoyproxy.envoy.extensions.filters.http.router.v3.Router;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateProviderPluginInstance;
-import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext;
 import io.grpc.BindableService;
 import io.grpc.ChannelCredentials;
 import io.grpc.Context;
@@ -2245,7 +2244,6 @@ public abstract class GrpcXdsClientImplTestBase {
    * CDS response containing UpstreamTlsContext for a cluster.
    */
   @Test
-  @SuppressWarnings("deprecation")
   public void cdsResponseWithUpstreamTlsContext() {
     DiscoveryRpcCall call = startResourceWatcher(XdsClusterResource.getInstance(), CDS_RESOURCE,
         cdsResourceWatcher);
@@ -2269,9 +2267,9 @@ public abstract class GrpcXdsClientImplTestBase {
     verify(cdsResourceWatcher, times(1))
         .onChanged(cdsUpdateCaptor.capture());
     CdsUpdate cdsUpdate = cdsUpdateCaptor.getValue();
-    CommonTlsContext.CertificateProviderInstance certificateProviderInstance =
+    CertificateProviderPluginInstance certificateProviderInstance =
         cdsUpdate.upstreamTlsContext().getCommonTlsContext().getCombinedValidationContext()
-            .getValidationContextCertificateProviderInstance();
+            .getDefaultValidationContext().getCaCertificateProviderInstance();
     assertThat(certificateProviderInstance.getInstanceName()).isEqualTo("cert-instance-name");
     assertThat(certificateProviderInstance.getCertificateName()).isEqualTo("cert1");
     verifyResourceMetadataAcked(CDS, CDS_RESOURCE, clusterEds, VERSION_1, TIME_INCREMENT);
@@ -2282,7 +2280,6 @@ public abstract class GrpcXdsClientImplTestBase {
    * CDS response containing new UpstreamTlsContext for a cluster.
    */
   @Test
-  @SuppressWarnings("deprecation")
   public void cdsResponseWithNewUpstreamTlsContext() {
     DiscoveryRpcCall call = startResourceWatcher(XdsClusterResource.getInstance(), CDS_RESOURCE,
         cdsResourceWatcher);
@@ -2344,7 +2341,6 @@ public abstract class GrpcXdsClientImplTestBase {
    * CDS response containing OutlierDetection for a cluster.
    */
   @Test
-  @SuppressWarnings("deprecation")
   public void cdsResponseWithOutlierDetection() {
     DiscoveryRpcCall call = startResourceWatcher(XdsClusterResource.getInstance(), CDS_RESOURCE,
         cdsResourceWatcher);
@@ -2413,7 +2409,6 @@ public abstract class GrpcXdsClientImplTestBase {
    * CDS response containing OutlierDetection for a cluster.
    */
   @Test
-  @SuppressWarnings("deprecation")
   public void cdsResponseWithInvalidOutlierDetectionNacks() {
 
     DiscoveryRpcCall call = startResourceWatcher(XdsClusterResource.getInstance(), CDS_RESOURCE,

--- a/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplV3Test.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplV3Test.java
@@ -613,18 +613,15 @@ public class GrpcXdsClientImplV3Test extends GrpcXdsClientImplTestBase {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
     protected Message buildUpstreamTlsContext(String instanceName, String certName) {
       CommonTlsContext.Builder commonTlsContextBuilder = CommonTlsContext.newBuilder();
       if (instanceName != null && certName != null) {
-        CommonTlsContext.CertificateProviderInstance providerInstance =
-            CommonTlsContext.CertificateProviderInstance.newBuilder()
-                .setInstanceName(instanceName)
-                .setCertificateName(certName)
-                .build();
         CommonTlsContext.CombinedCertificateValidationContext combined =
             CommonTlsContext.CombinedCertificateValidationContext.newBuilder()
-                .setValidationContextCertificateProviderInstance(providerInstance)
+                .setDefaultValidationContext(CertificateValidationContext.newBuilder()
+                  .setCaCertificateProviderInstance(CertificateProviderPluginInstance.newBuilder()
+                    .setInstanceName(instanceName)
+                    .setCertificateName(certName)))
                 .build();
         commonTlsContextBuilder.setCombinedValidationContext(combined);
       }
@@ -751,7 +748,6 @@ public class GrpcXdsClientImplV3Test extends GrpcXdsClientImplTestBase {
           .build();
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     protected FilterChain buildFilterChain(
         List<String> alpn, Message tlsContext, String transportSocketName,

--- a/xds/src/test/java/io/grpc/xds/internal/security/ClientSslContextProviderFactoryTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/ClientSslContextProviderFactoryTest.java
@@ -317,7 +317,6 @@ public class ClientSslContextProviderFactoryTest {
         .isSameInstanceAs(sslContextProvider);
   }
 
-  @SuppressWarnings("deprecation")
   static CommonTlsContext.Builder addFilenames(
       CommonTlsContext.Builder builder, String certChain, String privateKey, String trustCa) {
     TlsCertificate tlsCert =
@@ -329,13 +328,10 @@ public class ClientSslContextProviderFactoryTest {
         CertificateValidationContext.newBuilder()
             .setTrustedCa(DataSource.newBuilder().setFilename(trustCa))
             .build();
-    CommonTlsContext.CertificateProviderInstance certificateProviderInstance =
-        builder.getValidationContextCertificateProviderInstance();
     CommonTlsContext.CombinedCertificateValidationContext.Builder combinedBuilder =
         CommonTlsContext.CombinedCertificateValidationContext.newBuilder();
     combinedBuilder
-        .setDefaultValidationContext(certContext)
-        .setValidationContextCertificateProviderInstance(certificateProviderInstance);
+        .setDefaultValidationContext(certContext);
     return builder
         .addTlsCertificates(tlsCert)
         .setCombinedValidationContext(combinedBuilder.build());

--- a/xds/src/test/java/io/grpc/xds/internal/security/CommonTlsContextTestsUtil.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/CommonTlsContextTestsUtil.java
@@ -23,7 +23,6 @@ import com.google.protobuf.BoolValue;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateProviderPluginInstance;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CertificateValidationContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext;
-import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext.CertificateProviderInstance;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext.CombinedCertificateValidationContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext;
@@ -63,48 +62,26 @@ public class CommonTlsContextTestsUtil {
   public static final String BAD_CLIENT_KEY_FILE = "badclient.key";
 
   /** takes additional values and creates CombinedCertificateValidationContext as needed. */
-  @SuppressWarnings("deprecation")
-  static CommonTlsContext buildCommonTlsContextWithAdditionalValues(
+  private static CommonTlsContext buildCommonTlsContextWithAdditionalValues(
       String certInstanceName, String certName,
       String validationContextCertInstanceName, String validationContextCertName,
       Iterable<StringMatcher> matchSubjectAltNames,
       Iterable<String> alpnNames) {
-
-    CommonTlsContext.Builder builder = CommonTlsContext.newBuilder();
-
-    CertificateProviderInstance certificateProviderInstance = CertificateProviderInstance
-        .newBuilder().setInstanceName(certInstanceName).setCertificateName(certName).build();
-    if (certificateProviderInstance != null) {
-      builder.setTlsCertificateCertificateProviderInstance(certificateProviderInstance);
-    }
-    CertificateProviderInstance validationCertificateProviderInstance =
-        CertificateProviderInstance.newBuilder().setInstanceName(validationContextCertInstanceName)
-            .setCertificateName(validationContextCertName).build();
-    CertificateValidationContext certValidationContext =
-        matchSubjectAltNames == null
-            ? null
-            : CertificateValidationContext.newBuilder()
-                .addAllMatchSubjectAltNames(matchSubjectAltNames)
-                .build();
-    if (validationCertificateProviderInstance != null) {
-      CombinedCertificateValidationContext.Builder combinedBuilder =
-          CombinedCertificateValidationContext.newBuilder()
-              .setValidationContextCertificateProviderInstance(
-                  validationCertificateProviderInstance);
-      if (certValidationContext != null) {
-        combinedBuilder = combinedBuilder.setDefaultValidationContext(certValidationContext);
-      }
-      builder.setCombinedValidationContext(combinedBuilder);
-    } else if (validationCertificateProviderInstance != null) {
-      builder
-          .setValidationContextCertificateProviderInstance(validationCertificateProviderInstance);
-    } else if (certValidationContext != null) {
-      builder.setValidationContext(certValidationContext);
-    }
-    if (alpnNames != null) {
-      builder.addAllAlpnProtocols(alpnNames);
-    }
-    return builder.build();
+    @SuppressWarnings("deprecation") // gRFC A29 predates match_typed_subject_alt_names
+    CertificateValidationContext.Builder certificateValidationContextBuilder
+        = CertificateValidationContext.newBuilder()
+        .addAllMatchSubjectAltNames(matchSubjectAltNames);
+    return CommonTlsContext.newBuilder()
+        .setTlsCertificateProviderInstance(CertificateProviderPluginInstance.newBuilder()
+          .setInstanceName(certInstanceName)
+          .setCertificateName(certName))
+        .setCombinedValidationContext(CombinedCertificateValidationContext.newBuilder()
+          .setDefaultValidationContext(certificateValidationContextBuilder
+            .setCaCertificateProviderInstance(CertificateProviderPluginInstance.newBuilder()
+              .setInstanceName(validationContextCertInstanceName)
+              .setCertificateName(validationContextCertName))))
+        .addAllAlpnProtocols(alpnNames)
+        .build();
   }
 
   /** Helper method to build DownstreamTlsContext for multiple test classes. */
@@ -152,7 +129,7 @@ public class CommonTlsContextTestsUtil {
           useSans ? Arrays.asList(
               StringMatcher.newBuilder()
                   .setExact("spiffe://grpc-sds-testing.svc.id.goog/ns/default/sa/bob")
-                  .build()) : null,
+                  .build()) : Arrays.asList(),
           Arrays.asList("managed-tls"));
     }
     return buildDownstreamTlsContext(commonTlsContext, /* requireClientCert= */ false);
@@ -199,7 +176,6 @@ public class CommonTlsContextTestsUtil {
     }
   }
 
-  @SuppressWarnings("deprecation")
   private static CommonTlsContext buildCommonTlsContextForCertProviderInstance(
       String certInstanceName,
       String certName,
@@ -210,10 +186,10 @@ public class CommonTlsContextTestsUtil {
     CommonTlsContext.Builder builder = CommonTlsContext.newBuilder();
     if (certInstanceName != null) {
       builder =
-          builder.setTlsCertificateCertificateProviderInstance(
-              CommonTlsContext.CertificateProviderInstance.newBuilder()
-                  .setInstanceName(certInstanceName)
-                  .setCertificateName(certName));
+              builder.setTlsCertificateProviderInstance(
+                      CertificateProviderPluginInstance.newBuilder()
+                              .setInstanceName(certInstanceName)
+                              .setCertificateName(certName));
     }
     builder =
         addCertificateValidationContext(
@@ -248,35 +224,28 @@ public class CommonTlsContextTestsUtil {
     return builder.build();
   }
 
-  @SuppressWarnings("deprecation")
   private static CommonTlsContext.Builder addCertificateValidationContext(
       CommonTlsContext.Builder builder,
       String rootInstanceName,
       String rootCertName,
       CertificateValidationContext staticCertValidationContext) {
-    CertificateProviderInstance providerInstance = null;
+    if (staticCertValidationContext == null && rootInstanceName == null) {
+      return builder;
+    }
+    CertificateValidationContext.Builder contextBuilder;
+    if (staticCertValidationContext == null) {
+      contextBuilder = CertificateValidationContext.newBuilder();
+    } else {
+      contextBuilder = staticCertValidationContext.toBuilder();
+    }
     if (rootInstanceName != null) {
-      providerInstance = CertificateProviderInstance.newBuilder()
+      contextBuilder.setCaCertificateProviderInstance(CertificateProviderPluginInstance.newBuilder()
           .setInstanceName(rootInstanceName)
-          .setCertificateName(rootCertName)
-          .build();
+          .setCertificateName(rootCertName));
+      builder.setValidationContext(contextBuilder.build());
     }
-    if (providerInstance != null) {
-      builder = builder.setValidationContextCertificateProviderInstance(providerInstance);
-    }
-    CombinedCertificateValidationContext.Builder combined =
-        CombinedCertificateValidationContext.newBuilder();
-    if (providerInstance != null) {
-      combined = combined.setValidationContextCertificateProviderInstance(providerInstance);
-    }
-    if (staticCertValidationContext != null) {
-      combined = combined.setDefaultValidationContext(staticCertValidationContext);
-    }
-    if (combined.hasValidationContextCertificateProviderInstance()
-        || combined.hasDefaultValidationContext()) {
-      builder = builder.setCombinedValidationContext(combined.build());
-    }
-    return builder;
+    return builder.setCombinedValidationContext(CombinedCertificateValidationContext.newBuilder()
+        .setDefaultValidationContext(contextBuilder));
   }
 
   private static CommonTlsContext.Builder addNewCertificateValidationContext(

--- a/xds/src/test/java/io/grpc/xds/internal/security/certprovider/CertificateProviderStoreTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/certprovider/CertificateProviderStoreTest.java
@@ -123,7 +123,6 @@ public class CertificateProviderStoreTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void onePluginSameConfig_sameInstance() {
     registerPlugin("plugin1");
     CertificateProvider.Watcher mockWatcher1 = mock(CertificateProvider.Watcher.class);
@@ -167,7 +166,6 @@ public class CertificateProviderStoreTest {
   }
 
   @Test
-  @SuppressWarnings("deprecation")
   public void onePluginSameConfig_secondWatcherAfterFirstNotify() {
     registerPlugin("plugin1");
     CertificateProvider.Watcher mockWatcher1 = mock(CertificateProvider.Watcher.class);
@@ -275,7 +273,6 @@ public class CertificateProviderStoreTest {
         mockWatcher1, handle1, certProviderProvider1, mockWatcher2, handle2, certProviderProvider2);
   }
 
-  @SuppressWarnings("deprecation")
   private static void checkDifferentInstances(
       CertificateProvider.Watcher mockWatcher1,
       CertificateProviderStore.Handle handle1,


### PR DESCRIPTION
The security code referenced fields removed from gRFC A29 before it was finalized.