### PR TITLE
stub: Add RunWith(JUnit4) to support varied environments

### DIFF
--- a/stub/src/test/java/io/grpc/stub/StreamObserversTest.java
+++ b/stub/src/test/java/io/grpc/stub/StreamObserversTest.java
@@ -17,9 +17,12 @@
 package io.grpc.stub;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
 
+@RunWith(JUnit4.class)
 public class StreamObserversTest {
 
   @Test


### PR DESCRIPTION
Some JUnit environments require the RunWith annotation. Notably Blaze/Bazel needs it.