### PR TITLE
stub: fix onError metadata race condition (1.72.x backport)

### DIFF
--- a/stub/src/main/java/io/grpc/stub/ServerCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ServerCalls.java
@@ -382,9 +382,10 @@ public final class ServerCalls {
 
     @Override
     public void onError(Throwable t) {
-      Metadata metadata = Status.trailersFromThrowable(t);
-      if (metadata == null) {
-        metadata = new Metadata();
+      Metadata metadata = new Metadata();
+      Metadata trailers = Status.trailersFromThrowable(t);
+      if (trailers != null) {
+        metadata.merge(trailers);
       }
       call.close(Status.fromThrowable(t), metadata);
       aborted = true;


### PR DESCRIPTION
https://github.com/grpc/grpc-java/issues/11973

this maybe have a little performance implications.

Backport of #11979

CC @JoeCqupt