### PR TITLE
api: Remove deprecated SubchannelPicker.requestConnection()

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -452,18 +452,6 @@ public abstract class LoadBalancer {
      * @since 1.3.0
      */
     public abstract PickResult pickSubchannel(PickSubchannelArgs args);
-
-    /**
-     * Tries to establish connections now so that the upcoming RPC may then just pick a ready
-     * connection without having to connect first.
-     *
-     * <p>No-op if unsupported.
-     *
-     * @deprecated override {@link LoadBalancer#requestConnection} instead.
-     * @since 1.11.0
-     */
-    @Deprecated
-    public void requestConnection() {}
   }
 
   /**

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -228,11 +228,6 @@ final class ManagedChannelImpl extends ManagedChannel implements
   @Nullable
   private LbHelperImpl lbHelper;
 
-  // Must ONLY be assigned from updateSubchannelPicker(), which is called from syncContext.
-  // null if channel is in idle mode.
-  @Nullable
-  private volatile SubchannelPicker subchannelPicker;
-
   // Must be accessed from the syncContext
   private boolean panicMode;
 
@@ -259,8 +254,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
   // Channel's shutdown process:
   // 1. shutdown(): stop accepting new calls from applications
   //   1a shutdown <- true
-  //   1b subchannelPicker <- null
-  //   1c delayedTransport.shutdown()
+  //   1b delayedTransport.shutdown()
   // 2. delayedTransport terminated: stop stream-creation functionality
   //   2a terminating <- true
   //   2b loadBalancer.shutdown()
@@ -393,7 +387,6 @@ final class ManagedChannelImpl extends ManagedChannel implements
       lbHelper.lb.shutdown();
       lbHelper = null;
     }
-    subchannelPicker = null;
   }
 
   /**
@@ -804,7 +797,6 @@ final class ManagedChannelImpl extends ManagedChannel implements
 
   // Called from syncContext
   private void updateSubchannelPicker(SubchannelPicker newPicker) {
-    subchannelPicker = newPicker;
     delayedTransport.reprocess(newPicker);
   }
 
@@ -1228,9 +1220,6 @@ final class ManagedChannelImpl extends ManagedChannel implements
         @Override
         public void run() {
           exitIdleMode();
-          if (subchannelPicker != null) {
-            subchannelPicker.requestConnection();
-          }
           if (lbHelper != null) {
             lbHelper.lb.requestConnection();
           }

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -2590,7 +2590,6 @@ public class ManagedChannelImplTest {
 
     assertEquals(IDLE, channel.getState(true));
     verify(mockLoadBalancerProvider).newLoadBalancer(any(Helper.class));
-    verify(mockPicker).requestConnection();
     verify(mockLoadBalancer).requestConnection();
   }
 

--- a/xds/src/main/java/io/grpc/xds/LazyLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/LazyLoadBalancer.java
@@ -107,11 +107,6 @@ final class LazyLoadBalancer extends ForwardingLoadBalancer {
         helper.getSynchronizationContext().execute(LazyDelegate.this::activate);
         return PickResult.withNoResult();
       }
-
-      @Override
-      public void requestConnection() {
-        helper.getSynchronizationContext().execute(LazyDelegate.this::requestConnection);
-      }
     }
   }
 


### PR DESCRIPTION
It has been deprecated since cec9ee368, six years ago. It was replaced with LoadBalancer.requestConnection().