### PR TITLE
Update psm-dualstack.cfg (v1.69.x backport)

### DIFF
--- a/buildscripts/kokoro/psm-dualstack.cfg
+++ b/buildscripts/kokoro/psm-dualstack.cfg
@@ -2,7 +2,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-java/buildscripts/kokoro/psm-interop-test-java.sh"
-timeout_mins: 120
+timeout_mins: 240
 
 action {
   define_artifacts {


### PR DESCRIPTION
Backport of #11950 to v1.69.x.
---
120 minutes has not been sufficient, causing frequent VM timeout errors in the test runs.