### PR TITLE
gae-interop-testing: Upgrade to Java 17 (v1.66.x backport)

### DIFF
--- a/gae-interop-testing/gae-jdk8/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/gae-interop-testing/gae-jdk8/src/main/webapp/WEB-INF/appengine-web.xml
@@ -14,6 +14,6 @@
 <!-- [START config] -->
 <appengine-web-app xmlns='http://appengine.google.com/ns/1.0'>
   <service>java-gae-interop-test</service>
-  <runtime>java11</runtime>
+  <runtime>java17</runtime>
 </appengine-web-app>
 <!-- [END config] -->


### PR DESCRIPTION
Backport of #11699 to v1.66.x.
---
Java 11 is out-of-support on GAE. Unfortunately the docs use the term "deprecated" as "deleted," not "discouraged." So they talk about it being deprecated _after_ it is no longer supported.

https://cloud.google.com/appengine/docs/standard/lifecycle/support-schedule#java https://cloud.google.com/appengine/docs/flexible/lifecycle/support-schedule#java