### PR TITLE
.github/workflows: Bump action major versions (v1.66.x backport)

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -9,5 +9,5 @@ jobs:
     name: "Gradle wrapper validation"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: actions/checkout@v4
+      - uses: gradle/actions/wrapper-validation@v4

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -13,7 +13,7 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v4
+      - uses: dessant/lock-threads@v5
         with:
           github-token: ${{ github.token }}
           issue-inactive-days: 90

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,14 +21,14 @@ jobs:
       fail-fast: false # Should swap to true if we grow a large matrix
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-java@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.jre }}
         distribution: 'temurin'
 
     - name: Gradle cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.gradle/caches
@@ -37,7 +37,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gradle-
     - name: Maven cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.m2/repository
@@ -46,7 +46,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Protobuf cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: /tmp/protobuf-cache
         key: ${{ runner.os }}-maven-${{ hashFiles('buildscripts/make_dependencies.sh') }}
@@ -55,7 +55,7 @@ jobs:
       run: buildscripts/kokoro/unix.sh
     - name: Post Failure Upload Test Reports to Artifacts
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Test Reports (JRE ${{ matrix.jre }})
         path: |
@@ -71,7 +71,9 @@ jobs:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       run: ./gradlew :grpc-all:coveralls -PskipAndroid=true -x compileJava
     - name: Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   bazel:
     runs-on: ubuntu-latest
@@ -79,7 +81,7 @@ jobs:
       USE_BAZEL_VERSION: 6.0.0
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Check versions match in MODULE.bazel and repositories.bzl
       run: |
@@ -87,7 +89,7 @@ jobs:
                 <(sed -n '/GRPC_DEPS_START/,/GRPC_DEPS_END/ {/GRPC_DEPS_/! p}' repositories.bzl)
 
     - name: Bazel cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cache/bazel/*/cache

--- a/gae-interop-testing/gae-jdk8/src/main/webapp/WEB-INF/appengine-web.xml
+++ b/gae-interop-testing/gae-jdk8/src/main/webapp/WEB-INF/appengine-web.xml
@@ -14,6 +14,6 @@
 <!-- [START config] -->
 <appengine-web-app xmlns='http://appengine.google.com/ns/1.0'>
   <service>java-gae-interop-test</service>
-  <runtime>java11</runtime>
+  <runtime>java17</runtime>
 </appengine-web-app>
 <!-- [END config] -->


### PR DESCRIPTION
Backport of #11476 and #11669 to v1.66.x.
---
GitHub began the Node16 deprecation process a year ago [^1][^2]. This PR updates all workflows to use the latest Node20 actions. I have tested the workflows in my fork repository.

The last update was made almost two years ago in PR https://github.com/grpc/grpc-java/pull/9648.

![image](https://github.com/user-attachments/assets/432c9143-99d0-4138-a58f-8502a09b152c)

Java 11 is out-of-support on GAE, hence bumping to Java 17. 

[^1]: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
[^2]: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/