### PR TITLE
Bump com.google.protobuf gradle plugin to 0.9.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ For non-Android protobuf-based codegen integrated with the Gradle build system,
 you can use [protobuf-gradle-plugin][]:
 ```gradle
 plugins {
-    id 'com.google.protobuf' version '0.9.4'
+    id 'com.google.protobuf' version '0.9.5'
 }
 
 protobuf {
@@ -185,7 +185,7 @@ use protobuf-gradle-plugin but specify the 'lite' options:
 
 ```gradle
 plugins {
-    id 'com.google.protobuf' version '0.9.4'
+    id 'com.google.protobuf' version '0.9.5'
 }
 
 protobuf {

--- a/build.gradle
+++ b/build.gradle
@@ -151,7 +151,7 @@ subprojects {
                 appendToProperty(
                     it.options.errorprone.excludedPaths,
                     ".*/src/generated/[^/]+/java/.*" +
-                        "|.*/build/generated/source/proto/[^/]+/java/.*",
+                        "|.*/build/generated/sources/proto/[^/]+/java/.*",
                     "|")
             }
         }

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -152,7 +152,7 @@ dependencies {
 }
 
 tasks.named("compileTestJava").configure {
-    options.errorprone.excludedPaths = ".*/build/generated/source/proto/.*"
+    options.errorprone.excludedPaths = ".*/build/generated/sources/proto/.*"
 }
 
 tasks.named("compileTestLiteJava").configure {
@@ -160,7 +160,7 @@ tasks.named("compileTestLiteJava").configure {
     options.compilerArgs += [
         "-Xlint:-cast"
     ]
-    options.errorprone.excludedPaths = ".*/build/generated/source/proto/.*"
+    options.errorprone.excludedPaths = ".*/build/generated/sources/proto/.*"
 }
 
 tasks.named("checkstyleTestLite").configure {

--- a/examples/android/clientcache/build.gradle
+++ b/examples/android/clientcache/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.4"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.5"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/helloworld/build.gradle
+++ b/examples/android/helloworld/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.4"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.5"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/routeguide/build.gradle
+++ b/examples/android/routeguide/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.4"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.5"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/android/strictmode/build.gradle
+++ b/examples/android/strictmode/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.4.0'
-        classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.4"
+        classpath "com.google.protobuf:protobuf-gradle-plugin:0.9.5"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
-    id 'com.google.protobuf' version '0.9.4'
+    id 'com.google.protobuf' version '0.9.5'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
 }
@@ -49,16 +49,6 @@ protobuf {
     }
     generateProtoTasks {
         all()*.plugins { grpc {} }
-    }
-}
-
-// Inform IDEs like IntelliJ IDEA, Eclipse or NetBeans about the generated code.
-sourceSets {
-    main {
-        java {
-            srcDirs 'build/generated/source/proto/main/grpc'
-            srcDirs 'build/generated/source/proto/main/java'
-        }
     }
 }
 

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
-    id 'com.google.protobuf' version '0.9.4'
+    id 'com.google.protobuf' version '0.9.5'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
 }
@@ -37,16 +37,6 @@ protobuf {
     }
     generateProtoTasks {
         all()*.plugins { grpc {} }
-    }
-}
-
-// Inform IDEs like IntelliJ IDEA, Eclipse or NetBeans about the generated code.
-sourceSets {
-    main {
-        java {
-            srcDirs 'build/generated/source/proto/main/grpc'
-            srcDirs 'build/generated/source/proto/main/java'
-        }
     }
 }
 

--- a/examples/example-debug/build.gradle
+++ b/examples/example-debug/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'application' // Provide convenience executables for trying out the examples.
     id 'java'
 
-    id "com.google.protobuf" version "0.9.4"
+    id "com.google.protobuf" version "0.9.5"
 
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'

--- a/examples/example-dualstack/build.gradle
+++ b/examples/example-dualstack/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'application' // Provide convenience executables for trying out the examples.
     id 'java'
 
-    id "com.google.protobuf" version "0.9.4"
+    id "com.google.protobuf" version "0.9.5"
 
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
-    id 'com.google.protobuf' version '0.9.4'
+    id 'com.google.protobuf' version '0.9.5'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
 }
@@ -43,16 +43,6 @@ protobuf {
     }
     generateProtoTasks {
         all()*.plugins { grpc {} }
-    }
-}
-
-// Inform IDEs like IntelliJ IDEA, Eclipse or NetBeans about the generated code.
-sourceSets {
-    main {
-        java {
-            srcDirs 'build/generated/source/proto/main/grpc'
-            srcDirs 'build/generated/source/proto/main/java'
-        }
     }
 }
 

--- a/examples/example-gcp-csm-observability/build.gradle
+++ b/examples/example-gcp-csm-observability/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
-    id 'com.google.protobuf' version '0.9.4'
+    id 'com.google.protobuf' version '0.9.5'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
     id 'java'

--- a/examples/example-gcp-observability/build.gradle
+++ b/examples/example-gcp-observability/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
-    id 'com.google.protobuf' version '0.9.4'
+    id 'com.google.protobuf' version '0.9.5'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
     id 'java'

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'application' // Provide convenience executables for trying out the examples.
     id 'java'
 
-    id "com.google.protobuf" version "0.9.4"
+    id "com.google.protobuf" version "0.9.5"
     id 'com.google.cloud.tools.jib' version '3.4.4' // For releasing to Docker Hub
 }
 

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
-    id 'com.google.protobuf' version '0.9.4'
+    id 'com.google.protobuf' version '0.9.5'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
 }
@@ -48,16 +48,6 @@ protobuf {
     }
     generateProtoTasks {
         all()*.plugins { grpc {} }
-    }
-}
-
-// Inform IDEs like IntelliJ IDEA, Eclipse or NetBeans about the generated code.
-sourceSets {
-    main {
-        java {
-            srcDirs 'build/generated/source/proto/main/grpc'
-            srcDirs 'build/generated/source/proto/main/java'
-        }
     }
 }
 

--- a/examples/example-oauth/build.gradle
+++ b/examples/example-oauth/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
-    id 'com.google.protobuf' version '0.9.4'
+    id 'com.google.protobuf' version '0.9.5'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
 }
@@ -48,16 +48,6 @@ protobuf {
     }
     generateProtoTasks {
         all()*.plugins { grpc {} }
-    }
-}
-
-// Inform IDEs like IntelliJ IDEA, Eclipse or NetBeans about the generated code.
-sourceSets {
-    main {
-        java {
-            srcDirs 'build/generated/source/proto/main/grpc'
-            srcDirs 'build/generated/source/proto/main/java'
-        }
     }
 }
 

--- a/examples/example-opentelemetry/build.gradle
+++ b/examples/example-opentelemetry/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
-    id 'com.google.protobuf' version '0.9.4'
+    id 'com.google.protobuf' version '0.9.5'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
 }

--- a/examples/example-orca/build.gradle
+++ b/examples/example-orca/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application' // Provide convenience executables for trying out the examples.
-    id 'com.google.protobuf' version '0.9.4'
+    id 'com.google.protobuf' version '0.9.5'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
     id 'java'

--- a/examples/example-reflection/build.gradle
+++ b/examples/example-reflection/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application' // Provide convenience executables for trying out the examples.
-    id 'com.google.protobuf' version '0.9.4'
+    id 'com.google.protobuf' version '0.9.5'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
     id 'java'

--- a/examples/example-servlet/build.gradle
+++ b/examples/example-servlet/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.google.protobuf' version '0.9.4'
+    id 'com.google.protobuf' version '0.9.5'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
     id 'war'
@@ -32,15 +32,5 @@ protobuf {
     plugins { grpc { artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}" } }
     generateProtoTasks {
         all()*.plugins { grpc {} }
-    }
-}
-
-// Inform IDEs like IntelliJ IDEA, Eclipse or NetBeans about the generated code.
-sourceSets {
-    main {
-        java {
-            srcDirs 'build/generated/source/proto/main/grpc'
-            srcDirs 'build/generated/source/proto/main/java'
-        }
     }
 }

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     // Provide convenience executables for trying out the examples.
     id 'application'
-    id 'com.google.protobuf' version '0.9.4'
+    id 'com.google.protobuf' version '0.9.5'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
 }
@@ -38,16 +38,6 @@ protobuf {
     }
     generateProtoTasks {
         all()*.plugins { grpc {} }
-    }
-}
-
-// Inform IDEs like IntelliJ IDEA, Eclipse or NetBeans about the generated code.
-sourceSets {
-    main {
-        java {
-            srcDirs 'build/generated/source/proto/main/grpc'
-            srcDirs 'build/generated/source/proto/main/java'
-        }
     }
 }
 

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'application' // Provide convenience executables for trying out the examples.
-    id 'com.google.protobuf' version '0.9.4'
+    id 'com.google.protobuf' version '0.9.5'
     // Generate IntelliJ IDEA's .idea & .iml project files
     id 'idea'
     id 'java'

--- a/protobuf-lite/build.gradle
+++ b/protobuf-lite/build.gradle
@@ -39,7 +39,7 @@ tasks.named("compileTestJava").configure {
     options.compilerArgs += [
         "-Xlint:-cast"
     ]
-    options.errorprone.excludedPaths = ".*/build/generated/source/proto/.*"
+    options.errorprone.excludedPaths = ".*/build/generated/sources/proto/.*"
 }
 
 protobuf {

--- a/settings.gradle
+++ b/settings.gradle
@@ -13,7 +13,7 @@ pluginManagement {
 	// https://github.com/google/osdetector-gradle-plugin/tags
         id "com.google.osdetector" version "1.7.3"
         // https://github.com/google/protobuf-gradle-plugin/releases
-        id "com.google.protobuf" version "0.9.4"
+        id "com.google.protobuf" version "0.9.5"
         // https://github.com/GradleUp/shadow/releases
         // 8.3.2+ requires Java 11+
         // 8.3.1 breaks apache imports for netty/shaded, fixed in 8.3.2


### PR DESCRIPTION
The plugin now outputs to "generated/sources". The IDE configuration explicitly adding the folders to the source sets hasn't been needed for some years.