### PR TITLE
xds: Enable least request by default (v1.73.x backport)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsClusterResource.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClusterResource.java
@@ -60,7 +60,8 @@ class XdsClusterResource extends XdsResourceType<CdsUpdate> {
   static boolean enableLeastRequest =
       !Strings.isNullOrEmpty(System.getenv("GRPC_EXPERIMENTAL_ENABLE_LEAST_REQUEST"))
           ? Boolean.parseBoolean(System.getenv("GRPC_EXPERIMENTAL_ENABLE_LEAST_REQUEST"))
-          : Boolean.parseBoolean(System.getProperty("io.grpc.xds.experimentalEnableLeastRequest"));
+          : Boolean.parseBoolean(
+              System.getProperty("io.grpc.xds.experimentalEnableLeastRequest", "true"));
   @VisibleForTesting
   public static boolean enableSystemRootCerts =
       GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_SYSTEM_ROOT_CERTS", false);

--- a/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplDataTest.java
@@ -186,7 +186,6 @@ public class GrpcXdsClientImplDataTest {
     originalEnableRouteLookup = XdsRouteConfigureResource.enableRouteLookup;
     originalEnableLeastRequest = XdsClusterResource.enableLeastRequest;
     originalEnableUseSystemRootCerts = XdsClusterResource.enableSystemRootCerts;
-    assertThat(originalEnableLeastRequest).isFalse();
   }
 
   @After


### PR DESCRIPTION
Backport of #12054 to v1.73.x.
---
It has seen good testing by users and behaved as expected.

Fixes #11996

-----

CC @atollena, @yannickepstein