### PR TITLE
11243::RLS cleanups test

### DIFF
--- a/rls/src/main/java/io/grpc/rls/LinkedHashLruCache.java
+++ b/rls/src/main/java/io/grpc/rls/LinkedHashLruCache.java
@@ -349,6 +349,7 @@ abstract class LinkedHashLruCache<K, V> implements LruCache<K, V> {
    * setting the estimatedSizeBytes
    */
   public final void setEstimatedSizeBytes(long newSizeBytes) {
+    //testing email link
     this.estimatedSizeBytes = newSizeBytes;
   }
 }

--- a/rls/src/main/java/io/grpc/rls/LinkedHashLruCache.java
+++ b/rls/src/main/java/io/grpc/rls/LinkedHashLruCache.java
@@ -215,7 +215,7 @@ abstract class LinkedHashLruCache<K, V> implements LruCache<K, V> {
   protected final boolean fitToLimit() {
     boolean removedAnyUnexpired = false;
     if (estimatedSizeBytes <= estimatedMaxSizeBytes) {
-      // new size is larger no need to do cleanup
+      // there is space available so no need to do cleanup
       return false;
     }
     // cleanup expired entries
@@ -336,5 +336,19 @@ abstract class LinkedHashLruCache<K, V> implements LruCache<K, V> {
           .add("value", value)
           .toString();
     }
+  }
+
+  /**
+   * setting the estimatedMaxSizeBytes
+   */
+  public final void setEstimatedMaxSizeBytes(long newSizeBytes) {
+    this.estimatedMaxSizeBytes = newSizeBytes;
+  }
+
+  /**
+   * setting the estimatedSizeBytes
+   */
+  public final void setEstimatedSizeBytes(long newSizeBytes) {
+    this.estimatedSizeBytes = newSizeBytes;
   }
 }

--- a/rls/src/main/java/io/grpc/rls/LinkedHashLruCache.java
+++ b/rls/src/main/java/io/grpc/rls/LinkedHashLruCache.java
@@ -349,7 +349,6 @@ abstract class LinkedHashLruCache<K, V> implements LruCache<K, V> {
    * setting the estimatedSizeBytes
    */
   public final void setEstimatedSizeBytes(long newSizeBytes) {
-    //testing email link
     this.estimatedSizeBytes = newSizeBytes;
   }
 }

--- a/rls/src/test/java/io/grpc/rls/LinkedHashLruCacheTest.java
+++ b/rls/src/test/java/io/grpc/rls/LinkedHashLruCacheTest.java
@@ -266,4 +266,42 @@ public class LinkedHashLruCacheTest {
       return Objects.hash(value, expireTime);
     }
   }
+
+  @Test
+  public void testFitToLimitWithEstimatedMaxSizeBytes() {
+
+    Entry entry1 = new Entry("Entry1", ticker.read() + 10,4);
+    Entry entry2 = new Entry("Entry2", ticker.read() + 20,2);
+    Entry entry3 = new Entry("Entry3", ticker.read() + 30,1);
+
+    cache.cache(1, entry1);
+    cache.cache(2, entry2);
+    cache.cache(3, entry3);
+
+    assertThat(cache.estimatedSize()).isEqualTo(2);
+    cache.setEstimatedMaxSizeBytes(2);
+
+    assertThat(cache.estimatedMaxSizeBytes()).isEqualTo(2);
+    assertThat(cache.fitToLimit()).isEqualTo(true);
+    assertThat(cache.estimatedSizeBytes()).isEqualTo(1);
+  }
+
+  @Test
+  public void testFitToLimitWithEstimatedSizeBytes() {
+
+    Entry entry1 = new Entry("Entry1", ticker.read() + 10,4);
+    Entry entry2 = new Entry("Entry2", ticker.read() + 20,2);
+    Entry entry3 = new Entry("Entry3", ticker.read() + 30,1);
+
+    cache.cache(1, entry1);
+    cache.cache(2, entry2);
+    cache.cache(3, entry3);
+
+    assertThat(cache.estimatedSize()).isEqualTo(2);
+    cache.setEstimatedSizeBytes(7);
+
+    assertThat(cache.estimatedMaxSizeBytes()).isEqualTo(5);
+    assertThat(cache.fitToLimit()).isEqualTo(true);
+    assertThat(cache.estimatedSizeBytes()).isEqualTo(5);
+  }
 }


### PR DESCRIPTION
addressed the review comments provided on https://github.com/grpc/grpc-java/pull/11234

1. adding junit's for cache.fitToLimit()
2. updated the comments as per the suggestions on https://github.com/grpc/grpc-java/pull/11203