### PR TITLE
xds: temporary flag protection of GcpAuthenticationFilter (v1.73.x backport)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/FilterRegistry.java
+++ b/xds/src/main/java/io/grpc/xds/FilterRegistry.java
@@ -17,6 +17,7 @@
 package io.grpc.xds;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.grpc.internal.GrpcUtil;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -32,12 +33,18 @@ final class FilterRegistry {
 
   private FilterRegistry() {}
 
+  static boolean isEnabledGcpAuthnFilter =
+      GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_GCP_AUTHENTICATION_FILTER", false);
+
   static synchronized FilterRegistry getDefaultRegistry() {
     if (instance == null) {
       instance = newRegistry().register(
               new FaultFilter.Provider(),
               new RouterFilter.Provider(),
               new RbacFilter.Provider());
+      if (isEnabledGcpAuthnFilter) {
+        instance.register(new GcpAuthenticationFilter.Provider());
+      }
     }
     return instance;
   }

--- a/xds/src/main/java/io/grpc/xds/GcpAuthenticationFilter.java
+++ b/xds/src/main/java/io/grpc/xds/GcpAuthenticationFilter.java
@@ -17,6 +17,7 @@
 package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.grpc.xds.FilterRegistry.isEnabledGcpAuthnFilter;
 import static io.grpc.xds.XdsNameResolver.CLUSTER_SELECTION_KEY;
 import static io.grpc.xds.XdsNameResolver.XDS_CONFIG_CALL_OPTION_KEY;
 
@@ -312,6 +313,10 @@ final class GcpAuthenticationFilter implements Filter {
     public AudienceWrapper parse(Any any) throws ResourceInvalidException {
       Audience audience;
       try {
+        if (!isEnabledGcpAuthnFilter) {
+          throw new InvalidProtocolBufferException("Environment variable for GCP Authentication "
+              + "Filter is Not Set");
+        }
         audience = any.unpack(Audience.class);
       } catch (InvalidProtocolBufferException ex) {
         throw new ResourceInvalidException("Invalid Resource in address proto", ex);

--- a/xds/src/test/java/io/grpc/xds/GcpAuthenticationFilterTest.java
+++ b/xds/src/test/java/io/grpc/xds/GcpAuthenticationFilterTest.java
@@ -73,6 +73,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -88,6 +89,11 @@ public class GcpAuthenticationFilterTest {
   private static final EdsUpdate edsUpdate = getEdsUpdate();
   private static final RdsUpdate rdsUpdate = getRdsUpdate();
   private static final CdsUpdate cdsUpdate = getCdsUpdate();
+
+  @Before
+  public void setUp() {
+    System.setProperty("GRPC_EXPERIMENTAL_XDS_GCP_AUTHENTICATION_FILTER", "true");
+  }
 
   @Test
   public void testNewFilterInstancesPerFilterName() {

--- a/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplDataTest.java
@@ -2417,6 +2417,7 @@ public class GrpcXdsClientImplDataTest {
 
   @Test
   public void processCluster_parsesAudienceMetadata() throws Exception {
+    FilterRegistry.isEnabledGcpAuthnFilter = true;
     MetadataRegistry.getInstance();
 
     Audience audience = Audience.newBuilder()
@@ -2460,10 +2461,14 @@ public class GrpcXdsClientImplDataTest {
         "FILTER_METADATA", ImmutableMap.of(
             "key1", "value1",
             "key2", 42.0));
-    assertThat(update.parsedMetadata().get("FILTER_METADATA"))
-        .isEqualTo(expectedParsedMetadata.get("FILTER_METADATA"));
-    assertThat(update.parsedMetadata().get("AUDIENCE_METADATA"))
-        .isInstanceOf(AudienceWrapper.class);
+    try {
+      assertThat(update.parsedMetadata().get("FILTER_METADATA"))
+          .isEqualTo(expectedParsedMetadata.get("FILTER_METADATA"));
+      assertThat(update.parsedMetadata().get("AUDIENCE_METADATA"))
+          .isInstanceOf(AudienceWrapper.class);
+    } finally {
+      FilterRegistry.isEnabledGcpAuthnFilter = false;
+    }
   }
 
   @Test


### PR DESCRIPTION
Backport of #12075 to v1.73.x.
---
Missing and final piece of [gRFC A83-xds-gcp-authn-filter.md](https://github.com/grpc/proposal/blob/master/A83-xds-gcp-authn-filter.md#temporary-environment-variable-protection)