### PR TITLE
Rename PSM interop fallback test suite to light

### DIFF
--- a/buildscripts/kokoro/psm-light.cfg
+++ b/buildscripts/kokoro/psm-light.cfg
@@ -13,5 +13,5 @@ action {
 }
 env_vars {
   key: "PSM_TEST_SUITE"
-  value: "fallback"
+  value: "light"
 }


### PR DESCRIPTION
This is part of a cross-repository change to generalize the fallback test suite to support other tests, and to change the name for clarity. See also https://github.com/grpc/psm-interop/pull/179.