### PR TITLE
Rename PSM interop fallback test suite to light (1.72.x)

### DIFF
--- a/buildscripts/kokoro/psm-light.cfg
+++ b/buildscripts/kokoro/psm-light.cfg
@@ -13,5 +13,5 @@ action {
 }
 env_vars {
   key: "PSM_TEST_SUITE"
-  value: "fallback"
+  value: "light"
 }


### PR DESCRIPTION
Backport https://github.com/grpc/grpc-java/pull/12091 to v1.72.x