### PR TITLE
kokoro: Don't run grpc codegen in android-interop

### DIFF
--- a/buildscripts/kokoro/android-interop.sh
+++ b/buildscripts/kokoro/android-interop.sh
@@ -2,15 +2,7 @@
 
 set -exu -o pipefail
 
-# Install gRPC and codegen for the Android interop app
-# (a composite gradle build can't find protoc-gen-grpc-java)
-
 cd github/grpc-java
-
-export LDFLAGS="$(PKG_CONFIG_PATH=/tmp/protobuf/lib/pkgconfig pkg-config --libs protobuf)"
-export CXXFLAGS="$(PKG_CONFIG_PATH=/tmp/protobuf/lib/pkgconfig pkg-config --cflags protobuf)"
-export LD_LIBRARY_PATH=/tmp/protobuf/lib
-export OS_NAME=$(uname)
 
 export ANDROID_HOME=/tmp/Android/Sdk
 mkdir -p "${ANDROID_HOME}/cmdline-tools"
@@ -21,15 +13,12 @@ rm cmdline.zip
 mv "${ANDROID_HOME}/cmdline-tools/cmdline-tools" "${ANDROID_HOME}/cmdline-tools/latest"
 (yes || true) | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses
 
-# Proto deps
-buildscripts/make_dependencies.sh
-
 # Build Android with Java 11, this adds it to the PATH
 sudo update-java-alternatives --set java-1.11.0-openjdk-amd64
 # Unset any existing JAVA_HOME env var to stop Gradle from using it
 unset JAVA_HOME
 
-GRADLE_FLAGS="-Pandroid.useAndroidX=true -Dorg.gradle.jvmargs=-Xmx1024m"
+GRADLE_FLAGS="-Pandroid.useAndroidX=true -Dorg.gradle.jvmargs=-Xmx1024m -PskipCodegen=true"
 
 ./gradlew $GRADLE_FLAGS :grpc-android-interop-testing:assembleDebug
 ./gradlew $GRADLE_FLAGS :grpc-android-interop-testing:assembleDebugAndroidTest


### PR DESCRIPTION
android-interop has been failing to build since 46485c8 because it didn't have cmake installed and defined LDFLAGS/CXXFLAGS with pkg-config before make_dependencies.sh had been run.

Android-interop didn't verify the codegen is up-to-date. Building the codegen was just a relic from when android was its own separate gradle build. Avoiding codegen means we don't have to compile absl/protobuf and have a C++ toolchain.

Test run: https://source.cloud.google.com/results/invocations/819d793c-6abb-41d6-8483-d4a7e726e721