### PR TITLE
Cronet:  (Set User-Agent on CronetEngine)  Deleted TODO, Current beha…

### DIFF
--- a/cronet/src/main/java/io/grpc/cronet/CronetClientStream.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetClientStream.java
@@ -362,7 +362,6 @@ class CronetClientStream extends AbstractClientStream {
   private void setGrpcHeaders(BidirectionalStream.Builder builder) {
     // Psuedo-headers are set by cronet.
     // All non-pseudo headers must come after pseudo headers.
-    // TODO(ericgribkoff): remove this and set it on CronetEngine after crbug.com/588204 gets fixed.
     builder.addHeader(USER_AGENT_KEY.name(), userAgent);
     builder.addHeader(CONTENT_TYPE_KEY.name(), GrpcUtil.CONTENT_TYPE_GRPC);
     builder.addHeader("te", GrpcUtil.TE_TRAILERS);


### PR DESCRIPTION
Cronet : Set User-Agent on CronetEngine now that crbug.com/588204 is fixed .
- No implementation changes required for user-agent handling
- Current behavior will remain as-is
- developer should set user-agent explicitly via hey should just explicitly call the CronetChannelBuilder I'd needed.