### PR TITLE
xds: Use getWatchers more often in XdsDepManager

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsDependencyManager.java
+++ b/xds/src/main/java/io/grpc/xds/XdsDependencyManager.java
@@ -472,7 +472,7 @@ final class XdsDependencyManager implements XdsConfig.XdsClusterSubscriptionRegi
   private void addClusterWatcher(String clusterName, Object parentContext, int depth) {
     CdsWatcher watcher = (CdsWatcher) getWatchers(CLUSTER_RESOURCE).get(clusterName);
     if (watcher != null) {
-      watcher.parentContexts.add(parentContext);
+      watcher.parentContexts.put(parentContext, depth);
       return;
     }
 


### PR DESCRIPTION
This provides better type and missing-map handling. Note that getWatchers() now implicitly creates the map if it doesn't exist, instead of just returning an empty map. That makes it a bit easier to use and more importantly avoids accidents where a bug tries to modify the immutable map.