### PR TITLE
xds: Non-SOTW resources need onError() callbacks, too

### DIFF
--- a/xds/src/main/java/io/grpc/xds/client/XdsClientImpl.java
+++ b/xds/src/main/java/io/grpc/xds/client/XdsClientImpl.java
@@ -592,18 +592,17 @@ public final class XdsClientImpl extends XdsClient implements ResourceStore {
         subscriber.onRejected(args.versionInfo, updateTime, errorDetail);
       }
 
-      // Nothing else to do for incremental ADS resources.
-      if (!xdsResourceType.isFullStateOfTheWorld()) {
-        continue;
-      }
-
-      // Handle State of the World ADS: invalid resources.
       if (invalidResources.contains(resourceName)) {
         // The resource is missing. Reuse the cached resource if possible.
         if (subscriber.data == null) {
           // No cached data. Notify the watchers of an invalid update.
           subscriber.onError(Status.UNAVAILABLE.withDescription(errorDetail), processingTracker);
         }
+        continue;
+      }
+
+      // Nothing else to do for incremental ADS resources.
+      if (!xdsResourceType.isFullStateOfTheWorld()) {
         continue;
       }
 

--- a/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplTestBase.java
@@ -3270,6 +3270,8 @@ public abstract class GrpcXdsClientImplTestBase {
         + "locality:Locality{region=region2, zone=zone2, subZone=subzone2} for priority:1";
     call.verifyRequestNack(EDS, EDS_RESOURCE, "", "0001", NODE, ImmutableList.of(
         errorMsg));
+    verify(edsResourceWatcher).onError(errorCaptor.capture());
+    assertThat(errorCaptor.getValue().getDescription()).contains(errorMsg);
   }
 
   @Test


### PR DESCRIPTION
SOTW is unique in that it can become absent after being found. But if we NACK when initially loading the resource, we don't want to delay, depend on the resource timeout, and then give a poor error.

This was noticed while adding the EDS restriction that address is not a hostname and some tests started hanging instead of failing quickly.