### PR TITLE
xds: Fix XdsDepManager aggregate cluster child ordering and loop detection

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsConfig.java
+++ b/xds/src/main/java/io/grpc/xds/XdsConfig.java
@@ -18,6 +18,7 @@ package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.grpc.StatusOr;
 import io.grpc.xds.XdsClusterResource.CdsUpdate;
@@ -26,9 +27,9 @@ import io.grpc.xds.XdsListenerResource.LdsUpdate;
 import io.grpc.xds.XdsRouteConfigureResource.RdsUpdate;
 import java.io.Closeable;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * Represents the xDS configuration tree for a specified Listener.
@@ -191,10 +192,14 @@ final class XdsConfig {
 
     // The list of leaf clusters for an aggregate cluster.
     static final class AggregateConfig implements ClusterChild {
-      private final Set<String> leafNames;
+      private final List<String> leafNames;
 
-      public AggregateConfig(Set<String> leafNames) {
-        this.leafNames = checkNotNull(leafNames, "leafNames");
+      public AggregateConfig(List<String> leafNames) {
+        this.leafNames = ImmutableList.copyOf(checkNotNull(leafNames, "leafNames"));
+      }
+
+      public List<String> getLeafNames() {
+        return leafNames;
       }
 
       @Override


### PR DESCRIPTION
The children of aggregate clusters have a priority order, so we can't ever throw them in an ordinary set for later iteration.

This now detects recusion limits only after subscribing, but that matches our existing behavior in CdsLoadBalancer2. We don't get much value detecting the limit before subscribing and doing so makes watcher types more different.

Loops are still a bit broken as they won't be unwatched when orphaned, as they will form a reference loop. In CdsLoadBalancer2, duplicate clusters had duplicate watchers so there was single-ownership and reference cycles couldn't form. Fixing that is a bigger change.

Intermediate aggregate clusters are now included in XdsConfig, just for simplicity. It doesn't hurt anything whether they are present or missing. but it required updates to some tests.