### PR TITLE
xds: cancelled=true on watch close in XdsDepManager

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsDependencyManager.java
+++ b/xds/src/main/java/io/grpc/xds/XdsDependencyManager.java
@@ -525,6 +525,7 @@ final class XdsDependencyManager implements XdsConfig.XdsClusterSubscriptionRegi
     }
 
     public void close() {
+      cancelled = true;
       xdsClient.cancelXdsResourceWatch(type, resourceName, this);
     }
 


### PR DESCRIPTION
1fd29bc80 replaced cancelWatcher() with watcher.close(). But setting cancelled was missing. Because the config update checks for shutdown, the cancelled flag no longer avoids exceptions. But it seems best to continue avoiding any processing after close to avoid surprises.