### PR TITLE
Android: Clean up lint warnings and other warnings to get build success

### DIFF
--- a/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
+++ b/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
@@ -217,7 +217,6 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
         connectivityManager.registerDefaultNetworkCallback(defaultNetworkCallback);
         unregisterRunnable =
             new Runnable() {
-              @TargetApi(Build.VERSION_CODES.LOLLIPOP)
               @Override
               public void run() {
                 connectivityManager.unregisterNetworkCallback(defaultNetworkCallback);
@@ -231,7 +230,6 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
         context.registerReceiver(networkReceiver, networkIntentFilter);
         unregisterRunnable =
             new Runnable() {
-              @TargetApi(Build.VERSION_CODES.LOLLIPOP)
               @Override
               public void run() {
                 context.unregisterReceiver(networkReceiver);

--- a/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
+++ b/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
@@ -20,6 +20,7 @@ import static android.content.Intent.URI_ANDROID_APP_SCHEME;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
+import android.annotation.SuppressLint;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
@@ -165,6 +166,7 @@ public final class AndroidComponentAddress extends SocketAddress {
    *
    * <p>See {@link Intent#URI_ANDROID_APP_SCHEME} for details.
    */
+  @SuppressLint("InlinedApi")
   public String asAndroidAppUri() {
     Intent intentForUri = bindIntent;
     if (intentForUri.getPackage() == null) {

--- a/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
+++ b/binder/src/main/java/io/grpc/binder/SecurityPolicies.java
@@ -184,7 +184,6 @@ public final class SecurityPolicies {
    * Creates {@link SecurityPolicy} which checks if the app is a device owner app. See {@link
    * DevicePolicyManager}.
    */
-  @RequiresApi(18)
   public static io.grpc.binder.SecurityPolicy isDeviceOwner(Context applicationContext) {
     DevicePolicyManager devicePolicyManager =
         (DevicePolicyManager) applicationContext.getSystemService(Context.DEVICE_POLICY_SERVICE);
@@ -199,7 +198,6 @@ public final class SecurityPolicies {
    * Creates {@link SecurityPolicy} which checks if the app is a profile owner app. See {@link
    * DevicePolicyManager}.
    */
-  @RequiresApi(21)
   public static SecurityPolicy isProfileOwner(Context applicationContext) {
     DevicePolicyManager devicePolicyManager =
         (DevicePolicyManager) applicationContext.getSystemService(Context.DEVICE_POLICY_SERVICE);

--- a/binder/src/main/java/io/grpc/binder/internal/ServiceBinding.java
+++ b/binder/src/main/java/io/grpc/binder/internal/ServiceBinding.java
@@ -23,6 +23,7 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
+import android.os.Build;
 import android.os.IBinder;
 import android.os.UserHandle;
 import androidx.annotation.AnyThread;
@@ -183,18 +184,22 @@ final class ServiceBinding implements Bindable, ServiceConnection {
           bindResult = context.bindService(bindIntent, conn, flags);
           break;
         case BIND_SERVICE_AS_USER:
-          bindResult = context.bindServiceAsUser(bindIntent, conn, flags, targetUserHandle);
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            bindResult = context.bindServiceAsUser(bindIntent, conn, flags, targetUserHandle);
+          }
           break;
         case DEVICE_POLICY_BIND_SEVICE_ADMIN:
           DevicePolicyManager devicePolicyManager =
-              (DevicePolicyManager) context.getSystemService(Context.DEVICE_POLICY_SERVICE);
-          bindResult =
-              devicePolicyManager.bindDeviceAdminServiceAsUser(
-                  channelCredentials.getDevicePolicyAdminComponentName(),
-                  bindIntent,
-                  conn,
-                  flags,
-                  targetUserHandle);
+                  (DevicePolicyManager) context.getSystemService(Context.DEVICE_POLICY_SERVICE);
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            bindResult =
+                    devicePolicyManager.bindDeviceAdminServiceAsUser(
+                            channelCredentials.getDevicePolicyAdminComponentName(),
+                            bindIntent,
+                            conn,
+                            flags,
+                            targetUserHandle);
+          }
           break;
       }
       if (!bindResult) {

--- a/lint.xml
+++ b/lint.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="OldTargetApi" severity="ignore" />
+</lint>


### PR DESCRIPTION
Fixes :  #6868  #12142
Worked on clearing the lint warnings (OldTargetApi, ObsoleteSdkInt, InlinedApi, NewApi)