### PR TITLE
release: Migrate artifacts publishing from legacy OSSRH to Central Portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ For [Bazel](https://bazel.build), you can either
 https://search.maven.org/search?q=g:io.grpc%20AND%20v:1.73.0
 
 Development snapshots are available in [Sonatypes's snapshot
-repository](https://oss.sonatype.org/content/repositories/snapshots/).
+repository](https://central.sonatype.com/repository/maven-snapshots/).
 
 Generated Code
 --------------

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -160,7 +160,7 @@ Tagging the Release
    repository can then be `released`, which will begin the process of pushing
    the new artifacts to Maven Central (the staging repository will be destroyed
    in the process). You can see the complete process for releasing to Maven
-   Central on the [OSSRH site](https://central.sonatype.org/pages/releasing-the-deployment.html).
+   Central on the [OSSRH site](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#deploying).
 
 10. We have containers for each release to detect compatibility regressions with
     old releases. Generate one for the new release by following the [GCR image

--- a/build.gradle
+++ b/build.gradle
@@ -389,11 +389,11 @@ subprojects {
                         url = new File(rootProject.repositoryDir).toURI()
                     } else {
                         String stagingUrl
+                        String baseUrl = "https://ossrh-staging-api.central.sonatype.com/service/local"
                         if (rootProject.hasProperty('repositoryId')) {
-                            stagingUrl = 'https://oss.sonatype.org/service/local/staging/deployByRepositoryId/' +
-                                    rootProject.repositoryId
+                            stagingUrl = "${baseUrl}/staging/deployByRepositoryId/" + rootProject.repositoryId
                         } else {
-                            stagingUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
+                            stagingUrl = "${baseUrl}/staging/deploy/maven2/"
                         }
                         credentials {
                             if (rootProject.hasProperty('ossrhUsername') && rootProject.hasProperty('ossrhPassword')) {
@@ -402,7 +402,7 @@ subprojects {
                             }
                         }
                         def releaseUrl = stagingUrl
-                        def snapshotUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
+                        def snapshotUrl = 'https://central.sonatype.com/repository/maven-snapshots/'
                         url = version.endsWith('SNAPSHOT') ? snapshotUrl : releaseUrl
                     }
                 }

--- a/buildscripts/sonatype-upload.sh
+++ b/buildscripts/sonatype-upload.sh
@@ -59,7 +59,7 @@ if [ -z "$USERNAME" -o -z "$PASSWORD" ]; then
   exit 1
 fi
 
-STAGING_URL="https://oss.sonatype.org/service/local/staging"
+STAGING_URL="https://ossrh-staging-api.central.sonatype.com/service/local/staging"
 
 # We go through the effort of using deloyByRepositoryId/ because it is
 # _substantially_ faster to upload files than deploy/maven2/. When using
@@ -108,3 +108,18 @@ XML="
 </promoteRequest>"
 curl --fail-with-body -X POST -d "$XML" -u "$USERPASS" -H "Content-Type: application/xml" \
   "$STAGING_URL/profiles/$PROFILE_ID/finish"
+
+# After closing the repository on the staging API, we must manually trigger
+# its upload to the main Central Publisher Portal. We set publishing_type=automatic
+# to have it release automatically upon passing validation.
+echo "Triggering release of repository ${REPOID} to the Central Portal"
+
+# The manual API endpoint requires a Bearer token, which is the base64 of user:pass.
+BEARER_TOKEN=$(echo -n "$USERPASS" | base64)
+
+curl --fail-with-body -X POST \
+  -H "Authorization: Bearer ${BEARER_TOKEN}" \
+  -H "Content-Type: application/json" \
+  "${MANUAL_API_URL}/upload/repository/${REPOID}?publishing_type=automatic"
+
+echo "Release triggered. Monitor progress at https://central.sonatype.com/publishing/deployments"


### PR DESCRIPTION
We will be using [Publish By Using the Portal OSSRH Staging API](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/) to have minimal changes in our release process.

We will generate new token by following the [Generating a Portal Token for Publishing](https://central.sonatype.org/publish/generate-portal-token/) documentation that gives us Central Portal Token through UI and update the same in our GCS file `sonatype-upload` with new token. We will also update our g3 docs defining `#auto-releasing-using-kokoro` and `#how-the-kokoro-release-job-is-structured` as required. (I'm not adding links because it's Google internal.)