### PR TITLE
util: Deliver addresses in a random order in MultiChildLb

### DIFF
--- a/util/src/test/java/io/grpc/util/MultiChildLoadBalancerTest.java
+++ b/util/src/test/java/io/grpc/util/MultiChildLoadBalancerTest.java
@@ -264,6 +264,42 @@ public class MultiChildLoadBalancerTest {
         .testEquals();
   }
 
+  @Test
+  public void offsetIterable_positive() {
+    assertThat(MultiChildLoadBalancer.offsetIterable(Arrays.asList(1, 2, 3, 4), 9))
+        .containsExactly(2, 3, 4, 1)
+        .inOrder();
+    assertThat(MultiChildLoadBalancer.offsetIterable(Arrays.asList(1, 2, 3, 4, 5), 9))
+        .containsExactly(5, 1, 2, 3, 4)
+        .inOrder();
+    assertThat(MultiChildLoadBalancer.offsetIterable(Arrays.asList(1, 2, 3), 3))
+        .containsExactly(1, 2, 3)
+        .inOrder();
+    assertThat(MultiChildLoadBalancer.offsetIterable(Arrays.asList(1, 2, 3), 0))
+        .containsExactly(1, 2, 3)
+        .inOrder();
+    assertThat(MultiChildLoadBalancer.offsetIterable(Arrays.asList(1), 123))
+        .containsExactly(1)
+        .inOrder();
+  }
+
+  @Test
+  public void offsetIterable_negative() {
+    assertThat(MultiChildLoadBalancer.offsetIterable(Arrays.asList(1, 2, 3, 4), -1))
+        .containsExactly(4, 1, 2, 3)
+        .inOrder();
+  }
+
+  @Test
+  public void offsetIterable_empty() {
+    assertThat(MultiChildLoadBalancer.offsetIterable(Arrays.asList(), 1))
+        .isEmpty();
+    assertThat(MultiChildLoadBalancer.offsetIterable(Arrays.asList(), 0))
+        .isEmpty();
+    assertThat(MultiChildLoadBalancer.offsetIterable(Arrays.asList(), -1))
+        .isEmpty();
+  }
+
   private String addressesOnlyString(EquivalentAddressGroup eag) {
     if (eag == null) {
       return null;


### PR DESCRIPTION
This should often not matter much, but in b/412468630 it was cleary visible that child creation order can skew load for the first batch of RPCs. This doesn't solve all the cases, as further-away backends will still be less likely chosen initially and it is ignorant of the LB policy. But this doesn't impact correctness, is easy, and is one fewer cases to worry about.