### PR TITLE
xds: Disable LOGICAL_DNS in XdsDepMan until used

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsDependencyManager.java
+++ b/xds/src/main/java/io/grpc/xds/XdsDependencyManager.java
@@ -82,6 +82,9 @@ final class XdsDependencyManager implements XdsConfig.XdsClusterSubscriptionRegi
   private static final Locality LOGICAL_DNS_CLUSTER_LOCALITY = Locality.create("", "", "");
 
   private static final int MAX_CLUSTER_RECURSION_DEPTH = 16; // Specified by gRFC A37
+
+  static boolean enableLogicalDns = false;
+
   private final String listenerName;
   private final XdsClient xdsClient;
   private final SynchronizationContext syncContext;
@@ -363,9 +366,14 @@ final class XdsDependencyManager implements XdsConfig.XdsClusterSubscriptionRegi
         }
         break;
       case LOGICAL_DNS:
-        TrackedWatcher<List<EquivalentAddressGroup>> dnsWatcher =
-            tracer.getWatcher(DNS_TYPE, cdsUpdate.dnsHostName());
-        child = new EndpointConfig(dnsToEdsUpdate(dnsWatcher.getData(), cdsUpdate.dnsHostName()));
+        if (enableLogicalDns) {
+          TrackedWatcher<List<EquivalentAddressGroup>> dnsWatcher =
+              tracer.getWatcher(DNS_TYPE, cdsUpdate.dnsHostName());
+          child = new EndpointConfig(dnsToEdsUpdate(dnsWatcher.getData(), cdsUpdate.dnsHostName()));
+        } else {
+          child = new EndpointConfig(StatusOr.fromStatus(
+              Status.INTERNAL.withDescription("Logical DNS in dependency manager unsupported")));
+        }
         break;
       default:
         child = new EndpointConfig(StatusOr.fromStatus(Status.UNAVAILABLE.withDescription(
@@ -806,7 +814,9 @@ final class XdsDependencyManager implements XdsConfig.XdsClusterSubscriptionRegi
           addEdsWatcher(getEdsServiceName());
           break;
         case LOGICAL_DNS:
-          addDnsWatcher(update.dnsHostName());
+          if (enableLogicalDns) {
+            addDnsWatcher(update.dnsHostName());
+          }
           break;
         case AGGREGATE:
           update.prioritizedClusterNames()

--- a/xds/src/test/java/io/grpc/xds/XdsDependencyManagerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsDependencyManagerTest.java
@@ -152,6 +152,7 @@ public class XdsDependencyManagerTest {
 
   private XdsDependencyManager xdsDependencyManager = new XdsDependencyManager(
       xdsClient, syncContext, serverName, serverName, nameResolverArgs);
+  private boolean savedEnableLogicalDns;
 
   @Before
   public void setUp() throws Exception {
@@ -168,6 +169,8 @@ public class XdsDependencyManagerTest {
     testWatcher = new TestWatcher();
     xdsConfigWatcher = mock(TestWatcher.class, delegatesTo(testWatcher));
     defaultXdsConfig = XdsTestUtils.getDefaultXdsConfig(serverName);
+
+    savedEnableLogicalDns = XdsDependencyManager.enableLogicalDns;
   }
 
   @After
@@ -180,6 +183,8 @@ public class XdsDependencyManagerTest {
     assertThat(adsEnded.get()).isTrue();
     assertThat(lrsEnded.get()).isTrue();
     assertThat(fakeClock.getPendingTasks()).isEmpty();
+
+    XdsDependencyManager.enableLogicalDns = savedEnableLogicalDns;
   }
 
   @Test
@@ -749,6 +754,7 @@ public class XdsDependencyManagerTest {
 
   @Test
   public void testLogicalDns_success() {
+    XdsDependencyManager.enableLogicalDns = true;
     FakeSocketAddress fakeAddress = new FakeSocketAddress();
     nameResolverRegistry.register(new FakeNameResolverProvider(
         "dns:///dns.example.com:1111", fakeAddress));
@@ -789,6 +795,7 @@ public class XdsDependencyManagerTest {
 
   @Test
   public void testLogicalDns_noDnsNr() {
+    XdsDependencyManager.enableLogicalDns = true;
     Cluster cluster = Cluster.newBuilder()
         .setName(CLUSTER_NAME)
         .setType(Cluster.DiscoveryType.LOGICAL_DNS)


### PR DESCRIPTION
ClusterResolverLb is still doing DNS itself, so disable it in XdsDepMan until that migration has finished. EDS is fine in XdsDepman, because XdsClient will share the result with ClusterResolverLb.