### PR TITLE
core: Rely on ping-pong for flow control testing

### DIFF
--- a/core/src/testFixtures/java/io/grpc/internal/AbstractTransportTest.java
+++ b/core/src/testFixtures/java/io/grpc/internal/AbstractTransportTest.java
@@ -1449,7 +1449,7 @@ public abstract class AbstractTransportTest {
     clientStream.flush();
     clientStream.halfClose();
     doPingPong(serverListener);
-    assertFalse(serverStreamListener.awaitHalfClosed(TIMEOUT_MS, TimeUnit.MILLISECONDS));
+    assertFalse(serverStreamListener.isHalfClosed());
 
     serverStream.request(1);
     serverReceived += verifyMessageCountAndClose(serverStreamListener.messageQueue, 1);
@@ -1461,11 +1461,7 @@ public abstract class AbstractTransportTest {
     Status status = Status.OK.withDescription("... quite a lengthy discussion");
     serverStream.close(status, new Metadata());
     doPingPong(serverListener);
-    try {
-      clientStreamListener.awaitClose(TIMEOUT_MS, TimeUnit.MILLISECONDS);
-      fail("Expected TimeoutException");
-    } catch (TimeoutException expectedException) {
-    }
+    assertFalse(clientStreamListener.isClosed());
 
     clientStream.request(1);
     clientReceived += verifyMessageCountAndClose(clientStreamListener.messageQueue, 1);

--- a/core/src/testFixtures/java/io/grpc/internal/ClientStreamListenerBase.java
+++ b/core/src/testFixtures/java/io/grpc/internal/ClientStreamListenerBase.java
@@ -44,6 +44,13 @@ public class ClientStreamListenerBase implements ClientStreamListener {
   }
 
   /**
+   * Return {@code true} if {@code #awaitClose} would return immediately with a status.
+   */
+  public boolean isClosed() {
+    return status.isDone();
+  }
+
+  /**
    * Returns response headers from the server or throws {@link
    * java.util.concurrent.TimeoutException} if they aren't delivered before the timeout.
    *

--- a/core/src/testFixtures/java/io/grpc/internal/ServerStreamListenerBase.java
+++ b/core/src/testFixtures/java/io/grpc/internal/ServerStreamListenerBase.java
@@ -54,6 +54,10 @@ public class ServerStreamListenerBase implements ServerStreamListener {
     return halfClosedLatch.await(timeout, unit);
   }
 
+  public boolean isHalfClosed() {
+    return halfClosedLatch.getCount() == 0;
+  }
+
   public Status awaitClose(int timeout, TimeUnit unit) throws Exception {
     return status.get(timeout, unit);
   }


### PR DESCRIPTION
The previous code did a ping-pong to make sure the transport had enough time to process, but then proceeded to sleep 5 seconds. That sleep would have been needed without the ping-pong, but with the ping-pong we are confident all events have been drained from the transport. Deleting the unnecessary sleeps saves 10 seconds, for each of the 9 instances of this test.