### PR TITLE
Clarify requirements for creating a cross-user Channel.

### DIFF
--- a/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
+++ b/binder/src/main/java/io/grpc/binder/AndroidComponentAddress.java
@@ -250,7 +250,22 @@ public final class AndroidComponentAddress extends SocketAddress {
       return this;
     }
 
-    /** See {@link AndroidComponentAddress#getTargetUser()}. */
+    /**
+     * Specifies the Android user in which the built Address' bind Intent will be evaluated.
+     *
+     * <p>Connecting to a server in a different Android user is uncommon and requires the client app
+     * have runtime visibility of &#064;SystemApi's and hold certain &#064;SystemApi permissions.
+     * The device must also be running Android SDK version 30 or higher.
+     *
+     * <p>See https://developer.android.com/guide/app-compatibility/restrictions-non-sdk-interfaces
+     * for details on which apps can call the underlying &#064;SystemApi's needed to make this type
+     * of connection.
+     *
+     * <p>One of the "android.permission.INTERACT_ACROSS_XXX" permissions is required. The exact one
+     * depends on the calling user's relationship to the target user, whether client and server are
+     * in the same or different apps, and the version of Android in use. See {@link
+     * Context#bindServiceAsUser}, the essential underlying Android API, for details.
+     */
     @ExperimentalApi("https://github.com/grpc/grpc-java/issues/10173")
     public Builder setTargetUser(@Nullable UserHandle targetUser) {
       this.targetUser = targetUser;

--- a/binder/src/main/java/io/grpc/binder/ApiConstants.java
+++ b/binder/src/main/java/io/grpc/binder/ApiConstants.java
@@ -35,12 +35,15 @@ public final class ApiConstants {
   /**
    * Specifies the Android user in which target URIs should be resolved.
    *
-   * <p>{@link UserHandle} can't reasonably be encoded in a target URI string. Instead, all
-   * {@link io.grpc.NameResolverProvider}s producing {@link AndroidComponentAddress}es should let
-   * clients address servers in another Android user using this argument.
+   * <p>{@link UserHandle} can't reasonably be encoded in a target URI string. Instead, all {@link
+   * io.grpc.NameResolverProvider}s producing {@link AndroidComponentAddress}es should let clients
+   * address servers in another Android user using this argument.
    *
-   * <p>See also {@link AndroidComponentAddress#getTargetUser()}.
+   * <p>Connecting to a server in a different Android user is uncommon and can only be done by a
+   * "system app" client. See {@link AndroidComponentAddress.Builder#setTargetUser(UserHandle)} for
+   * details.
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/10173")
   public static final NameResolver.Args.Key<UserHandle> TARGET_ANDROID_USER =
       NameResolver.Args.Key.create("target-android-user");
 }

--- a/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
+++ b/binder/src/main/java/io/grpc/binder/BinderChannelBuilder.java
@@ -242,8 +242,8 @@ public final class BinderChannelBuilder extends ForwardingChannelBuilder<BinderC
    * specify a {@link UserHandle}. If neither the Channel nor the {@link AndroidComponentAddress}
    * specifies a target user, the {@link UserHandle} of the current process will be used.
    *
-   * <p>Targeting a Service in a different Android user is uncommon and requires special permissions
-   * normally reserved for system apps. See {@link android.content.Context#bindServiceAsUser} for
+   * <p>Connecting to a server in a different Android user is uncommon and can only be done by a
+   * "system app" client. See {@link AndroidComponentAddress.Builder#setTargetUser(UserHandle)} for
    * details.
    *
    * @deprecated This method's name is misleading because it implies an impersonated client identity

--- a/buildscripts/grpc-java-artifacts/Dockerfile
+++ b/buildscripts/grpc-java-artifacts/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -Ls https://github.com/Kitware/CMake/releases/download/v3.26.3/cmake-3.
     tar xz -C /var/local    
     
 # Install Maven
-RUN curl -Ls https://dlcdn.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz | \
+RUN curl -Ls https://dlcdn.apache.org/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.tar.gz | \
     tar xz -C /var/local
-ENV PATH /var/local/cmake-3.26.3-linux-x86_64/bin:/var/local/apache-maven-3.8.8/bin:$PATH
+ENV PATH /var/local/cmake-3.26.3-linux-x86_64/bin:/var/local/apache-maven-3.9.10/bin:$PATH
 

--- a/buildscripts/grpc-java-artifacts/Dockerfile
+++ b/buildscripts/grpc-java-artifacts/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -Ls https://github.com/Kitware/CMake/releases/download/v3.26.3/cmake-3.
     tar xz -C /var/local    
     
 # Install Maven
-RUN curl -Ls https://dlcdn.apache.org/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.tar.gz | \
+RUN curl -Ls https://dlcdn.apache.org/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz | \
     tar xz -C /var/local
-ENV PATH /var/local/cmake-3.26.3-linux-x86_64/bin:/var/local/apache-maven-3.9.10/bin:$PATH
+ENV PATH /var/local/cmake-3.26.3-linux-x86_64/bin:/var/local/apache-maven-3.8.8/bin:$PATH
 


### PR DESCRIPTION
The `@SystemApi` runtime visibility requirement isn't really new. It has always been implicit in the required INTERACT_ACROSS_USERS permission, which can only be held by system apps in production.

Now deprecated `BinderChannelBuilder#bindAsUser` has always required SDK_INT >= 30. This change just copies that requirement forward to its replacement APIs in `AndroidComponentAddress` and the `TARGET_ANDROID_USER` `NameResolver.Args`.