### PR TITLE
kokoro: add spiffe tests config (1.73.x backport)

### DIFF
--- a/buildscripts/kokoro/psm-spiffe.cfg
+++ b/buildscripts/kokoro/psm-spiffe.cfg
@@ -1,0 +1,17 @@
+# Config file for internal CI
+
+# Location of the continuous shell script in repository.
+build_file: "grpc-java/buildscripts/kokoro/psm-interop-test-java.sh"
+timeout_mins: 240
+
+action {
+  define_artifacts {
+    regex: "artifacts/**/*sponge_log.xml"
+    regex: "artifacts/**/*.log"
+    strip_prefix: "artifacts"
+  }
+}
+env_vars {
+  key: "PSM_TEST_SUITE"
+  value: "spiffe"
+}


### PR DESCRIPTION
Backport of #12133