### PR TITLE
java_grpc_library.bzl: Make warnings less noisy

### DIFF
--- a/java_grpc_library.bzl
+++ b/java_grpc_library.bzl
@@ -80,7 +80,7 @@ def _path_ignoring_repository(f):
 def _java_rpc_library_impl(ctx):
     if len(ctx.attr.srcs) != 1:
         fail("Exactly one src value supported", "srcs")
-    if ctx.attr.srcs[0].label.package != ctx.label.package:
+    if ctx.attr.srcs[0].label.package != ctx.label.package and (ctx.attr.srcs[0].label.workspace_name == "" or ctx.label.workspace_name == ""):
         print(("in srcs attribute of {0}: Proto source with label {1} should be in " +
                "same package as consuming rule").format(ctx.label, ctx.attr.srcs[0].label))
 


### PR DESCRIPTION
This is to partially address #11791.
The idea is to only inform the user if one of labels are in the root repository and therefore under the user's control.