### PR TITLE
Add `setReadbufferSize` API to CronetChannelBuilder

### DIFF
--- a/cronet/src/main/java/io/grpc/cronet/InternalCronetCallOptions.java
+++ b/cronet/src/main/java/io/grpc/cronet/InternalCronetCallOptions.java
@@ -36,6 +36,18 @@ public final class InternalCronetCallOptions {
     return CronetClientStream.withAnnotation(callOptions, annotation);
   }
 
+  public static CallOptions withReadBufferSize(CallOptions callOptions, int size) {
+    return callOptions.withOption(CronetClientStream.CRONET_READ_BUFFER_SIZE_KEY, size);
+  }
+
+  /**
+   * Returns Cronet read buffer size for gRPC included in the given {@code callOptions}. Read
+   * buffer can be customized via {@link #withReadBufferSize(CallOptions, int)}.
+   */
+  public static int getReadBufferSize(CallOptions callOptions) {
+    return callOptions.getOption(CronetClientStream.CRONET_READ_BUFFER_SIZE_KEY);
+  }
+
   /**
    * Returns Cronet annotations for gRPC included in the given {@code callOptions}. Annotations
    * are attached via {@link #withAnnotation(CallOptions, Object)}.


### PR DESCRIPTION
By default, CronetClientStreams would use a 4KB buffer to read data from Cronet. This can be inefficient especially if the amount of data being read is huge (~MBs) as each read callback operation incur overhead from Cronet itself (e.g. Context switch, JNI calls). The alternative would be to immediately bump the default to a bigger number but that would incur an increase in memory usage.

If the API is not called then the default of 4KB is used.