### PR TITLE
core: Don't pre-compute DEADLINE_EXCEEDED message for delayed calls

### DIFF
--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -2239,7 +2239,7 @@ public class XdsNameResolverTest {
     assertThat(testCall).isNull();
     verifyRpcDelayedThenAborted(observer, 4000L, Status.DEADLINE_EXCEEDED.withDescription(
         "Deadline exceeded after up to 5000 ns of fault-injected delay:"
-            + " Deadline CallOptions will be exceeded in 0.000004000s. "));
+            + " Deadline CallOptions was exceeded after 0.000004000s"));
   }
 
   @Test


### PR DESCRIPTION
The main reason I made a change here was to fix the tense from the deadline "will be exceeded in" to "was exceeded after". But we really don't want to be doing the string formatting unless the deadline is actually exceeded. There were a few more changes to make some variables effectively final.