### PR TITLE
xds: Check isHttp11ProxyAvailable in equals()

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterResolverLoadBalancerProvider.java
@@ -89,7 +89,7 @@ public final class ClusterResolverLoadBalancerProvider extends LoadBalancerProvi
 
     @Override
     public int hashCode() {
-      return Objects.hash(discoveryMechanisms, lbConfig);
+      return Objects.hash(discoveryMechanisms, lbConfig, isHttp11ProxyAvailable);
     }
 
     @Override
@@ -102,7 +102,8 @@ public final class ClusterResolverLoadBalancerProvider extends LoadBalancerProvi
       }
       ClusterResolverConfig that = (ClusterResolverConfig) o;
       return discoveryMechanisms.equals(that.discoveryMechanisms)
-          && lbConfig.equals(that.lbConfig);
+          && lbConfig.equals(that.lbConfig)
+          && isHttp11ProxyAvailable == that.isHttp11ProxyAvailable;
     }
 
     @Override
@@ -110,6 +111,7 @@ public final class ClusterResolverLoadBalancerProvider extends LoadBalancerProvi
       return MoreObjects.toStringHelper(this)
           .add("discoveryMechanisms", discoveryMechanisms)
           .add("lbConfig", lbConfig)
+          .add("isHttp11ProxyAvailable", isHttp11ProxyAvailable)
           .toString();
     }
 

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -32,6 +32,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
+import com.google.common.testing.EqualsTester;
 import io.grpc.Attributes;
 import io.grpc.ChannelLogger;
 import io.grpc.ConnectivityState;
@@ -1197,6 +1198,27 @@ public class ClusterResolverLoadBalancerTest {
     assertThat(childBalancer.upstreamError.getDescription()).isEqualTo("unreachable");
     verify(helper, never()).updateBalancingState(
         any(ConnectivityState.class), any(SubchannelPicker.class));
+  }
+
+  @Test
+  public void config_equalsTester() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new ClusterResolverConfig(
+                Collections.singletonList(edsDiscoveryMechanism1), leastRequest, false),
+            new ClusterResolverConfig(
+                Collections.singletonList(edsDiscoveryMechanism1), leastRequest, false))
+        .addEqualityGroup(new ClusterResolverConfig(
+            Collections.singletonList(edsDiscoveryMechanism1), roundRobin, false))
+        .addEqualityGroup(new ClusterResolverConfig(
+            Collections.singletonList(edsDiscoveryMechanism1), leastRequest, true))
+        .addEqualityGroup(new ClusterResolverConfig(
+            Collections.singletonList(edsDiscoveryMechanismWithOutlierDetection),
+            leastRequest,
+            false))
+        .addEqualityGroup(new ClusterResolverConfig(
+            Arrays.asList(edsDiscoveryMechanism1, edsDiscoveryMechanism2), leastRequest, false))
+        .testEquals();
   }
 
   private void deliverLbConfig(ClusterResolverConfig config) {


### PR DESCRIPTION
This fixes an equals/hashCode bug introduced in 12197065fe.

Discovered when investigating b/430347751

CC @kannanjgithub 