### PR TITLE
Start moving PendingAuthListener away from mocking ServerCall.

### DIFF
--- a/binder/src/test/java/io/grpc/binder/internal/PendingAuthListenerTest.java
+++ b/binder/src/test/java/io/grpc/binder/internal/PendingAuthListenerTest.java
@@ -1,15 +1,40 @@
 package io.grpc.binder.internal;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import androidx.annotation.Nullable;
+
+import com.google.common.io.ByteStreams;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.Server;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.ServiceDescriptor;
 import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.ClientCalls;
+import io.grpc.stub.ServerCalls;
+import io.grpc.testing.GrpcCleanupRule;
+
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -23,15 +48,26 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 @RunWith(JUnit4.class)
 public final class PendingAuthListenerTest {
 
-  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+  @Rule
+  public final MockitoRule mocks = MockitoJUnit.rule();
+  @Rule
+  public final GrpcCleanupRule grpcCleanupRule = new GrpcCleanupRule();
 
-  @Mock ServerCallHandler<Object, Object> next;
-  @Mock ServerCall<Object, Object> call;
-  @Mock ServerCall.Listener<Object> delegate;
-  @Captor ArgumentCaptor<Status> statusCaptor;
+  @Mock
+  ServerCallHandler<Object, Object> next;
+  @Mock
+  ServerCall<Object, Object> call;
+  @Mock
+  ServerCall.Listener<Object> delegate;
 
   private final Metadata headers = new Metadata();
   private final PendingAuthListener<Object, Object> listener = new PendingAuthListener<>();
@@ -86,16 +122,117 @@ public final class PendingAuthListenerTest {
   }
 
   @Test
-  public void whenStartCallFails_closesTheCallWithInternalStatus() {
-    IllegalStateException exception = new IllegalStateException("oops");
-    when(next.startCall(any(), any())).thenThrow(exception);
+  public void whenStartCallFails_closesTheCallWithInternalStatus() throws Exception {
+    // Arrange
+    String name = "test_server";
+    AtomicBoolean closed = new AtomicBoolean(false);
+    MethodDescriptor<String, String> method =
+        MethodDescriptor
+            .newBuilder(StringMarshaller.INSTANCE, StringMarshaller.INSTANCE)
+            .setFullMethodName("test_server/method")
+            .setType(MethodDescriptor.MethodType.UNARY)
+            .build();
+    ServerCallHandler<String, String> callHandler =
+        ServerCalls.asyncUnaryCall((req, respObserver) -> {
+          throw new IllegalStateException("ooops");
+        });
+    ServerServiceDefinition serviceDef =
+        ServerServiceDefinition.builder(name).addMethod(method, callHandler).build();
+    Server server =
+        InProcessServerBuilder.forName(name).addService(serviceDef).intercept(
+            new ServerInterceptor() {
+              @SuppressWarnings("unchecked")
+              @Override
+              public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+                  ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
 
-    listener.onReady();
-    listener.startCall(call, headers, next);
+                listener.startCall((ServerCall<Object, Object>) call, headers, (ServerCallHandler<Object,
+                    Object>) next);
+                return (ServerCall.Listener<ReqT>) listener;
+              }
+          }).build().start();
+    ManagedChannel channel =
+        InProcessChannelBuilder.forName(name).intercept(new ClientInterceptor() {
+      @Override
+      public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+          MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+        ClientCall<ReqT, RespT> delegate = next.newCall(method, callOptions);
+        return new ClientCall<ReqT, RespT>() {
+          @Override
+          public void start(Listener<RespT> responseListener, Metadata headers) {
+            Listener<RespT> listenerWrapper = new Listener<RespT>() {
+              @Override
+              public void onHeaders(Metadata headers) {
+                responseListener.onHeaders(headers);
+              }
 
-    verify(call).close(statusCaptor.capture(), any());
-    Status status = statusCaptor.getValue();
-    assertThat(status.getCode()).isEqualTo(Status.Code.INTERNAL);
-    assertThat(status.getCause()).isSameInstanceAs(exception);
+              @Override
+              public void onMessage(RespT message) {
+                responseListener.onMessage(message);
+              }
+
+              @Override
+              public void onReady() {
+                responseListener.onReady();
+              }
+
+              @Override
+              public void onClose(Status status, Metadata trailers) {
+                responseListener.onClose(status, trailers);
+                closed.set(true);
+              }
+            };
+            delegate.start(listenerWrapper, headers);
+          }
+
+          @Override
+          public void request(int numMessages) {
+            delegate.request(numMessages);
+          }
+
+          @Override
+          public void cancel(@Nullable String message, @Nullable Throwable cause) {
+            delegate.cancel(message, cause);
+          }
+
+          @Override
+          public void halfClose() {
+            delegate.halfClose();
+          }
+
+          @Override
+          public void sendMessage(ReqT message) {
+            delegate.sendMessage(message);
+          }
+        };
+      }
+    }).build();
+    grpcCleanupRule.register(server);
+    grpcCleanupRule.register(channel);
+
+    // Act
+    assertThrows(StatusRuntimeException.class, () -> ClientCalls.blockingUnaryCall(channel,
+        method, CallOptions.DEFAULT.withDeadlineAfter(Duration.ofSeconds(5)), "foo"));
+
+    // Assert
+    assertThat(closed.get()).isTrue();
+  }
+
+  private static class StringMarshaller implements MethodDescriptor.Marshaller<String> {
+    public static final StringMarshaller INSTANCE = new StringMarshaller();
+
+    @Override
+    public InputStream stream(String value) {
+      return new ByteArrayInputStream(value.getBytes(UTF_8));
+    }
+
+    @Override
+    public String parse(InputStream stream) {
+      try {
+        return new String(ByteStreams.toByteArray(stream), UTF_8);
+      } catch (IOException ex) {
+        throw new RuntimeException(ex);
+      }
+    }
   }
 }

--- a/binder/src/test/java/io/grpc/binder/internal/PendingAuthListenerTest.java
+++ b/binder/src/test/java/io/grpc/binder/internal/PendingAuthListenerTest.java
@@ -2,16 +2,8 @@ package io.grpc.binder.internal;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-import androidx.annotation.Nullable;
-
-import com.google.common.io.ByteStreams;
 
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -27,7 +19,6 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerServiceDefinition;
-import io.grpc.ServiceDescriptor;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.inprocess.InProcessChannelBuilder;
@@ -36,41 +27,28 @@ import io.grpc.stub.ClientCalls;
 import io.grpc.stub.ServerCalls;
 import io.grpc.testing.GrpcCleanupRule;
 import io.grpc.testing.TestMethodDescriptors;
-
-import org.junit.Assert;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.time.Duration;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 @RunWith(JUnit4.class)
 public final class PendingAuthListenerTest {
 
-  @Rule
-  public final MockitoRule mocks = MockitoJUnit.rule();
-  @Rule
-  public final GrpcCleanupRule grpcCleanupRule = new GrpcCleanupRule();
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+  @Rule public final GrpcCleanupRule grpcCleanupRule = new GrpcCleanupRule();
 
-  @Mock
-  ServerCallHandler<Object, Object> next;
-  @Mock
-  ServerCall<Object, Object> call;
-  @Mock
-  ServerCall.Listener<Object> delegate;
+  @Mock ServerCallHandler<Object, Object> next;
+  @Mock ServerCall<Object, Object> call;
+  @Mock ServerCall.Listener<Object> delegate;
 
   private final Metadata headers = new Metadata();
   private final PendingAuthListener<Object, Object> listener = new PendingAuthListener<>();
@@ -131,55 +109,76 @@ public final class PendingAuthListenerTest {
     AtomicBoolean closed = new AtomicBoolean(false);
     MethodDescriptor<Void, Void> method = TestMethodDescriptors.voidMethod();
     ServerCallHandler<Void, Void> callHandler =
-        ServerCalls.asyncUnaryCall((req, respObserver) -> {
-          throw new IllegalStateException("ooops");
-        });
+        ServerCalls.asyncUnaryCall(
+            (req, respObserver) -> {
+              throw new IllegalStateException("ooops");
+            });
     ServerServiceDefinition serviceDef =
         ServerServiceDefinition.builder(name).addMethod(method, callHandler).build();
     Server server =
-        InProcessServerBuilder.forName(name).addService(serviceDef).intercept(
-            new ServerInterceptor() {
-              @SuppressWarnings("unchecked")
-              @Override
-              public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
-                  ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+        InProcessServerBuilder.forName(name)
+            .addService(serviceDef)
+            .intercept(
+                new ServerInterceptor() {
+                  @SuppressWarnings("unchecked")
+                  @Override
+                  public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+                      ServerCall<ReqT, RespT> call,
+                      Metadata headers,
+                      ServerCallHandler<ReqT, RespT> next) {
 
-                listener.startCall((ServerCall<Object, Object>) call, headers, (ServerCallHandler<Object,
-                    Object>) next);
-                return (ServerCall.Listener<ReqT>) listener;
-              }
-          }).build().start();
+                    listener.startCall(
+                        (ServerCall<Object, Object>) call,
+                        headers,
+                        (ServerCallHandler<Object, Object>) next);
+                    return (ServerCall.Listener<ReqT>) listener;
+                  }
+                })
+            .build()
+            .start();
     ManagedChannel channel =
-        InProcessChannelBuilder.forName(name).intercept(new ClientInterceptor() {
-      @Override
-      public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
-          MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
-        ClientCall<ReqT, RespT> delegate = next.newCall(method, callOptions);
-        return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(delegate){
-          @Override
-          public void start(Listener<RespT> responseListener, Metadata headers) {
-            ClientCall.Listener<RespT> wrappedListener =
-                new ForwardingClientCallListener.SimpleForwardingClientCallListener<RespT>(
-                    responseListener){
+        InProcessChannelBuilder.forName(name)
+            .intercept(
+                new ClientInterceptor() {
+                  @Override
+                  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+                      MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+                    ClientCall<ReqT, RespT> delegate = next.newCall(method, callOptions);
+                    return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+                        delegate) {
                       @Override
-                      public void onClose(Status status, Metadata trailers) {
-                        super.onClose(status, trailers);
-                        closed.set(true);
+                      public void start(Listener<RespT> responseListener, Metadata headers) {
+                        ClientCall.Listener<RespT> wrappedListener =
+                            new ForwardingClientCallListener.SimpleForwardingClientCallListener<
+                                RespT>(responseListener) {
+                              @Override
+                              public void onClose(Status status, Metadata trailers) {
+                                super.onClose(status, trailers);
+                                closed.set(true);
+                              }
+                            };
+                        super.start(wrappedListener, headers);
                       }
                     };
-            super.start(wrappedListener, headers);
-          }
-        };
-      }
-    }).build();
+                  }
+                })
+            .build();
     grpcCleanupRule.register(server);
     grpcCleanupRule.register(channel);
 
     // Act
-    assertThrows(StatusRuntimeException.class, () -> ClientCalls.blockingUnaryCall(channel,
-        method, CallOptions.DEFAULT.withDeadlineAfter(Duration.ofSeconds(5)), /* request= */ (Void)null));
+    StatusRuntimeException ex =
+        assertThrows(
+            StatusRuntimeException.class,
+            () ->
+                ClientCalls.blockingUnaryCall(
+                    channel,
+                    method,
+                    CallOptions.DEFAULT.withDeadlineAfter(Duration.ofSeconds(5)),
+                    /* request= */ null));
 
     // Assert
+    assertThat(ex.getStatus().getCode()).isEqualTo(Status.Code.INTERNAL);
     assertThat(closed.get()).isTrue();
   }
 }

--- a/testing/src/main/java/io/grpc/testing/TestMethodDescriptors.java
+++ b/testing/src/main/java/io/grpc/testing/TestMethodDescriptors.java
@@ -30,16 +30,19 @@ import java.io.InputStream;
 public final class TestMethodDescriptors {
   private TestMethodDescriptors() {}
 
+  /** The name of the service that the method returned by {@link #voidMethod()} uses. */
+  public static final String SERVICE_NAME = "service_foo";
+
   /**
    * Creates a new method descriptor that always creates zero length messages, and always parses to
-   * null objects.
+   * null objects. It is part of the service named {@link #SERVICE_NAME}.
    *
    * @since 1.1.0
    */
   public static MethodDescriptor<Void, Void> voidMethod() {
     return MethodDescriptor.<Void, Void>newBuilder()
         .setType(MethodType.UNARY)
-        .setFullMethodName(MethodDescriptor.generateFullMethodName("service_foo", "method_bar"))
+        .setFullMethodName(MethodDescriptor.generateFullMethodName(SERVICE_NAME, "method_bar"))
         .setRequestMarshaller(TestMethodDescriptors.voidMarshaller())
         .setResponseMarshaller(TestMethodDescriptors.voidMarshaller())
         .build();


### PR DESCRIPTION
Initial attempt to use a real in-process service to reduce the mocking of ServerCall in preparation to run the tests in the internal Google infrastructure.