### PR TITLE
interop-testing: make soak test use logger rather than writing to stderr directly

### DIFF
--- a/interop-testing/src/main/java/io/grpc/testing/integration/SoakClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/SoakClient.java
@@ -37,9 +37,9 @@ import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.logging.Logger;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
 import org.HdrHistogram.Histogram;
 
 /**


### PR DESCRIPTION
Avoid hypothetical races b/t writes to stderr and other logging