### PR TITLE
xds: Use a different log name for XdsClientImpl and ControlPlaneClient

### DIFF
--- a/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
+++ b/xds/src/main/java/io/grpc/xds/client/ControlPlaneClient.java
@@ -109,7 +109,7 @@ final class ControlPlaneClient {
     this.backoffPolicyProvider = checkNotNull(backoffPolicyProvider, "backoffPolicyProvider");
     this.messagePrinter = checkNotNull(messagePrinter, "messagePrinter");
     stopwatch = checkNotNull(stopwatchSupplier, "stopwatchSupplier").get();
-    logId = InternalLogId.allocate("xds-client", serverInfo.target());
+    logId = InternalLogId.allocate("xds-cp-client", serverInfo.target());
     logger = XdsLogger.withLogId(logId);
     logger.log(XdsLogLevel.INFO, "Created");
   }


### PR DESCRIPTION
Seems like a good time to stop hating ourselves, as that seems to be the only reason to use the same string.