### PR TITLE
Bump versions of dependencies (#12252) (v1.75.x)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ module(
 # GRPC_DEPS_START
 IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "com.google.android:annotations:4.1.1.4",
-    "com.google.api.grpc:proto-google-common-protos:2.51.0",
+    "com.google.api.grpc:proto-google-common-protos:2.59.2",
     "com.google.auth:google-auth-library-credentials:1.24.1",
     "com.google.auth:google-auth-library-oauth2-http:1.24.1",
     "com.google.auto.value:auto-value-annotations:1.11.0",
@@ -19,7 +19,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "com.google.guava:failureaccess:1.0.1",
     "com.google.guava:guava:33.3.1-android",
     "com.google.re2j:re2j:1.8",
-    "com.google.s2a.proto.v2:s2a-proto:0.1.1",
+    "com.google.s2a.proto.v2:s2a-proto:0.1.2",
     "com.google.truth:truth:1.4.2",
     "com.squareup.okhttp:okhttp:2.7.5",
     "com.squareup.okio:okio:2.10.0",  # 3.0+ needs swapping to -jvm; need work to avoid flag-day
@@ -50,7 +50,8 @@ bazel_dep(name = "bazel_jar_jar", version = "0.1.7")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "googleapis", repo_name = "com_google_googleapis", version = "0.0.0-20240326-1c8d509c5")
 bazel_dep(name = "grpc-proto", repo_name = "io_grpc_grpc_proto", version = "0.0.0-20240627-ec30f58")
-bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "23.1")
+# Protobuf 25.5+ is incompatible with Bazel 7 with bzlmod
+bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "24.4")
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "rules_java", version = "5.3.5")
 bazel_dep(name = "rules_jvm_external", version = "6.0")

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -1,4 +1,3 @@
-bazel_dep(name = "googleapis", repo_name = "com_google_googleapis", version = "0.0.0-20240326-1c8d509c5")
 bazel_dep(name = "grpc-java", repo_name = "io_grpc_grpc_java", version = "1.75.0-SNAPSHOT")  # CURRENT_GRPC_VERSION
 bazel_dep(name = "grpc-proto", repo_name = "io_grpc_grpc_proto", version = "0.0.0-20240627-ec30f58")
 bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "23.1")

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -22,7 +22,7 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.75.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.25.5'
+def protobufVersion = '3.25.8'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -22,7 +22,7 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.75.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.25.5'
+def protocVersion = '3.25.8'
 
 dependencies {
     // grpc-alts transitively depends on grpc-netty-shaded, grpc-protobuf, and grpc-stub

--- a/examples/example-debug/build.gradle
+++ b/examples/example-debug/build.gradle
@@ -24,7 +24,7 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.75.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.25.5'
+def protobufVersion = '3.25.8'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-debug/pom.xml
+++ b/examples/example-debug/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.75.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.25.5</protoc.version>
+    <protoc.version>3.25.8</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/examples/example-dualstack/build.gradle
+++ b/examples/example-dualstack/build.gradle
@@ -24,7 +24,7 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.75.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.25.5'
+def protobufVersion = '3.25.8'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-dualstack/pom.xml
+++ b/examples/example-dualstack/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.75.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.25.5</protoc.version>
+    <protoc.version>3.25.8</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -22,7 +22,7 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.75.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.25.5'
+def protobufVersion = '3.25.8'
 def protocVersion = protobufVersion
 
 

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.75.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.25.5</protobuf.version>
+    <protobuf.version>3.25.8</protobuf.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/examples/example-gcp-csm-observability/build.gradle
+++ b/examples/example-gcp-csm-observability/build.gradle
@@ -23,9 +23,9 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.75.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.25.5'
-def openTelemetryVersion = '1.40.0'
-def openTelemetryPrometheusVersion = '1.40.0-alpha'
+def protocVersion = '3.25.8'
+def openTelemetryVersion = '1.52.0'
+def openTelemetryPrometheusVersion = '1.52.0-alpha'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-gcp-observability/build.gradle
+++ b/examples/example-gcp-observability/build.gradle
@@ -23,7 +23,7 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.75.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.25.5'
+def protocVersion = '3.25.8'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -22,7 +22,7 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.75.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.25.5'
+def protobufVersion = '3.25.8'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-hostname/pom.xml
+++ b/examples/example-hostname/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.75.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.25.5</protoc.version>
+    <protoc.version>3.25.8</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -22,7 +22,7 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.75.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.25.5'
+def protobufVersion = '3.25.8'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/examples/example-jwt-auth/pom.xml
+++ b/examples/example-jwt-auth/pom.xml
@@ -14,8 +14,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.75.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.25.5</protobuf.version>
-    <protoc.version>3.25.5</protoc.version>
+    <protobuf.version>3.25.8</protobuf.version>
+    <protoc.version>3.25.8</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/examples/example-oauth/build.gradle
+++ b/examples/example-oauth/build.gradle
@@ -22,7 +22,7 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.75.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protobufVersion = '3.25.5'
+def protobufVersion = '3.25.8'
 def protocVersion = protobufVersion
 
 dependencies {

--- a/examples/example-oauth/pom.xml
+++ b/examples/example-oauth/pom.xml
@@ -14,8 +14,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.75.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.25.5</protobuf.version>
-    <protoc.version>3.25.5</protoc.version>
+    <protobuf.version>3.25.8</protobuf.version>
+    <protoc.version>3.25.8</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/examples/example-opentelemetry/build.gradle
+++ b/examples/example-opentelemetry/build.gradle
@@ -22,9 +22,9 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.75.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.25.5'
-def openTelemetryVersion = '1.40.0'
-def openTelemetryPrometheusVersion = '1.40.0-alpha'
+def protocVersion = '3.25.8'
+def openTelemetryVersion = '1.52.0'
+def openTelemetryPrometheusVersion = '1.52.0-alpha'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-orca/build.gradle
+++ b/examples/example-orca/build.gradle
@@ -17,7 +17,7 @@ java {
 }
 
 def grpcVersion = '1.75.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.25.5'
+def protocVersion = '3.25.8'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-reflection/build.gradle
+++ b/examples/example-reflection/build.gradle
@@ -17,7 +17,7 @@ java {
 }
 
 def grpcVersion = '1.75.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.25.5'
+def protocVersion = '3.25.8'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-servlet/build.gradle
+++ b/examples/example-servlet/build.gradle
@@ -16,7 +16,7 @@ java {
 }
 
 def grpcVersion = '1.75.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.25.5'
+def protocVersion = '3.25.8'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}",

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -22,7 +22,7 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.75.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.25.5'
+def protocVersion = '3.25.8'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -13,7 +13,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.75.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protoc.version>3.25.5</protoc.version>
+    <protoc.version>3.25.8</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -22,7 +22,7 @@ java {
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
 def grpcVersion = '1.75.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-def protocVersion = '3.25.5'
+def protocVersion = '3.25.8'
 
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -13,8 +13,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.75.0-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
-    <protobuf.version>3.25.5</protobuf.version>
-    <protoc.version>3.25.5</protoc.version>
+    <protobuf.version>3.25.8</protobuf.version>
+    <protoc.version>3.25.8</protoc.version>
     <!-- required for JDK 8 -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,14 +6,16 @@ nettytcnative = '2.0.70.Final'
 opencensus = "0.31.1"
 # Not upgrading to 4.x as it is not yet ABI compatible.
 # https://github.com/protocolbuffers/protobuf/issues/17247
-protobuf = "3.25.5"
+protobuf = "3.25.8"
 
 [libraries]
 android-annotations = "com.google.android:annotations:4.1.1.4"
+# androidx-annotation 1.9.1+ uses Kotlin and requires Android Gradle Plugin 9+
 androidx-annotation = "androidx.annotation:annotation:1.9.0"
 # 1.15.0 requires libraries and applications that depend on it to compile against
 # version 35 or later of the Android APIs.
 androidx-core = "androidx.core:core:1.13.1"
+# androidx-lifecycle 2.9+ requires Java 17
 androidx-lifecycle-common = "androidx.lifecycle:lifecycle-common:2.8.7"
 androidx-lifecycle-service = "androidx.lifecycle:lifecycle-service:2.8.7"
 androidx-test-core = "androidx.test:core:1.6.1"
@@ -36,13 +38,13 @@ cronet-embedded = "org.chromium.net:cronet-embedded:119.6045.31"
 errorprone-annotations = "com.google.errorprone:error_prone_annotations:2.30.0"
 # error-prone 2.32.0+ require Java 17+
 errorprone-core = "com.google.errorprone:error_prone_core:2.31.0"
-google-api-protos = "com.google.api.grpc:proto-google-common-protos:2.51.0"
+google-api-protos = "com.google.api.grpc:proto-google-common-protos:2.59.2"
 # google-auth-library 1.25.0+ requires error_prone_annotations 2.31.0+, which
 # breaks the Android build
 google-auth-credentials = "com.google.auth:google-auth-library-credentials:1.24.1"
 google-auth-oauth2Http = "com.google.auth:google-auth-library-oauth2-http:1.24.1"
 # Release notes: https://cloud.google.com/logging/docs/release-notes
-google-cloud-logging = "com.google.cloud:google-cloud-logging:3.21.2"
+google-cloud-logging = "com.google.cloud:google-cloud-logging:3.23.1"
 # 2.12.1 requires error_prone_annotations:2.36.0 but we are stuck with 2.30.0
 gson = "com.google.code.gson:gson:2.11.0"
 # 33.4.0 requires com.google.errorprone:error_prone_annotations:2.36.0 but we are stuck with 2.30.0 (see above)
@@ -61,7 +63,7 @@ javax-annotation = "org.apache.tomcat:annotations-api:6.0.53"
 javax-servlet-api = "javax.servlet:javax.servlet-api:4.0.1"
 # 12.0.0+ require Java 17+
 jetty-client = "org.eclipse.jetty:jetty-client:11.0.24"
-jetty-http2-server = "org.eclipse.jetty.http2:jetty-http2-server:12.0.16"
+jetty-http2-server = "org.eclipse.jetty.http2:jetty-http2-server:12.0.23"
 jetty-http2-server10 = "org.eclipse.jetty.http2:http2-server:10.0.20"
 jetty-servlet = "org.eclipse.jetty.ee10:jetty-ee10-servlet:12.0.16"
 jetty-servlet10 = "org.eclipse.jetty:jetty-servlet:10.0.20"
@@ -91,19 +93,19 @@ opencensus-contrib-grpc-metrics = { module = "io.opencensus:opencensus-contrib-g
 opencensus-exporter-stats-stackdriver = { module = "io.opencensus:opencensus-exporter-stats-stackdriver", version.ref = "opencensus" }
 opencensus-exporter-trace-stackdriver = { module = "io.opencensus:opencensus-exporter-trace-stackdriver", version.ref = "opencensus" }
 opencensus-impl = { module = "io.opencensus:opencensus-impl", version.ref = "opencensus" }
-opentelemetry-api = "io.opentelemetry:opentelemetry-api:1.46.0"
-opentelemetry-exporter-prometheus = "io.opentelemetry:opentelemetry-exporter-prometheus:1.46.0-alpha"
-opentelemetry-gcp-resources = "io.opentelemetry.contrib:opentelemetry-gcp-resources:1.43.0-alpha"
-opentelemetry-sdk-extension-autoconfigure = "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.46.0"
-opentelemetry-sdk-testing = "io.opentelemetry:opentelemetry-sdk-testing:1.46.0"
+opentelemetry-api = "io.opentelemetry:opentelemetry-api:1.52.0"
+opentelemetry-exporter-prometheus = "io.opentelemetry:opentelemetry-exporter-prometheus:1.52.0-alpha"
+opentelemetry-gcp-resources = "io.opentelemetry.contrib:opentelemetry-gcp-resources:1.48.0-alpha"
+opentelemetry-sdk-extension-autoconfigure = "io.opentelemetry:opentelemetry-sdk-extension-autoconfigure:1.52.0"
+opentelemetry-sdk-testing = "io.opentelemetry:opentelemetry-sdk-testing:1.52.0"
 perfmark-api = "io.perfmark:perfmark-api:0.27.0"
 protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "protobuf" }
 protobuf-java-util = { module = "com.google.protobuf:protobuf-java-util", version.ref = "protobuf" }
 protobuf-javalite = { module = "com.google.protobuf:protobuf-javalite", version.ref = "protobuf" }
 protobuf-protoc = { module = "com.google.protobuf:protoc", version.ref = "protobuf" }
 re2j = "com.google.re2j:re2j:1.8"
-robolectric = "org.robolectric:robolectric:4.14.1"
-s2a-proto = "com.google.s2a.proto.v2:s2a-proto:0.1.1"
+robolectric = "org.robolectric:robolectric:4.15.1"
+s2a-proto = "com.google.s2a.proto.v2:s2a-proto:0.1.2"
 signature-android = "net.sf.androidscents.signature:android-api-level-21:5.0.1_r2"
 signature-java = "org.codehaus.mojo.signature:java18:1.0"
 # 11.0.0+ require Java 17+

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -12,7 +12,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # GRPC_DEPS_START
 IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "com.google.android:annotations:4.1.1.4",
-    "com.google.api.grpc:proto-google-common-protos:2.51.0",
+    "com.google.api.grpc:proto-google-common-protos:2.59.2",
     "com.google.auth:google-auth-library-credentials:1.24.1",
     "com.google.auth:google-auth-library-oauth2-http:1.24.1",
     "com.google.auto.value:auto-value-annotations:1.11.0",
@@ -23,7 +23,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "com.google.guava:failureaccess:1.0.1",
     "com.google.guava:guava:33.3.1-android",
     "com.google.re2j:re2j:1.8",
-    "com.google.s2a.proto.v2:s2a-proto:0.1.1",
+    "com.google.s2a.proto.v2:s2a-proto:0.1.2",
     "com.google.truth:truth:1.4.2",
     "com.squareup.okhttp:okhttp:2.7.5",
     "com.squareup.okio:okio:2.10.0",  # 3.0+ needs swapping to -jvm; need work to avoid flag-day
@@ -116,9 +116,9 @@ def com_google_protobuf():
     # This statement defines the @com_google_protobuf repo.
     http_archive(
         name = "com_google_protobuf",
-        sha256 = "9bd87b8280ef720d3240514f884e56a712f2218f0d693b48050c836028940a42",
-        strip_prefix = "protobuf-25.1",
-        urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protobuf-25.1.tar.gz"],
+        sha256 = "3cf7d5b17c4ff04fe9f038104e9d0cae6da09b8ce271c13e44f8ac69f51e4e0f",
+        strip_prefix = "protobuf-25.5",
+        urls = ["https://github.com/protocolbuffers/protobuf/releases/download/v25.5/protobuf-25.5.tar.gz"],
     )
 
 def io_grpc_grpc_proto():


### PR DESCRIPTION
Notably, protobuf to 3.25.8, opentelemetry to 1.52.0. Protobuf in Bazel has 25.5 in the BCR and it seems better to align the WORKSPACE with that version. But we can't actually use 25.5 in BCR because it is incompatible with Bazel 7.

-------

This is a backport of #12252 (not created with the script; I just saved the old commits before I fixed all the conflicts on master)