### PR TITLE
android-interop-testing : working on clearing lint warnings

### DIFF
--- a/android-interop-testing/src/main/AndroidManifest.xml
+++ b/android-interop-testing/src/main/AndroidManifest.xml
@@ -5,7 +5,9 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <!-- For UDS -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
     <uses-sdk tools:overrideLibrary="io.grpc.android"/>
 
     <application
@@ -16,8 +18,7 @@
         android:name="androidx.multidex.MultiDexApplication">
         <activity
             android:name=".TesterActivity"
-            android:exported="true"
-            android:label="@string/app_name" >
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/android-interop-testing/src/main/java/io/grpc/android/integrationtest/TesterActivity.java
+++ b/android-interop-testing/src/main/java/io/grpc/android/integrationtest/TesterActivity.java
@@ -121,7 +121,7 @@ public class TesterActivity extends AppCompatActivity
     ((InputMethodManager) getSystemService(Context.INPUT_METHOD_SERVICE)).hideSoftInputFromWindow(
         hostEdit.getWindowToken(), 0);
     enableButtons(false);
-    resultText.setText("Testing...");
+    resultText.setText(R.string.testing_message);
 
     String host = hostEdit.getText().toString();
     String portStr = portEdit.getText().toString();

--- a/android-interop-testing/src/main/res/layout/activity_tester.xml
+++ b/android-interop-testing/src/main/res/layout/activity_tester.xml
@@ -16,6 +16,7 @@
         android:layout_weight="2"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:inputType="text"
         android:hint="Enter Host"
         />
     <EditText

--- a/android-interop-testing/src/main/res/values/strings.xml
+++ b/android-interop-testing/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">gRPC Integration Test</string>
+    <string name="testing_message">Testing…</string>
 </resources>

--- a/binder/src/main/AndroidManifest.xml
+++ b/binder/src/main/AndroidManifest.xml
@@ -1,8 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <queries>
+
         <intent>
             <action android:name="android.intent.action.VIEW" />
         </intent>
+
     </queries>
+
 </manifest>

--- a/binder/src/main/AndroidManifest.xml
+++ b/binder/src/main/AndroidManifest.xml
@@ -1,2 +1,8 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+        </intent>
+    </queries>
 </manifest>

--- a/lint.xml
+++ b/lint.xml
@@ -5,4 +5,10 @@
       Remove after AGP upgrade.
     -->
     <issue id="OldTargetApi" severity="ignore" />
+
+    <!--
+    Suppress 'VisibleForTests' warnings for now as these methods are intentionally
+    exposed for testing purposes and access across modules.
+    -->
+    <issue id="VisibleForTests" severity="ignore" />
 </lint>

--- a/lint.xml
+++ b/lint.xml
@@ -7,8 +7,7 @@
     <issue id="OldTargetApi" severity="ignore" />
 
     <!--
-    Suppress 'VisibleForTests' warnings for now as these methods are intentionally
-    exposed for testing purposes and access across modules.
+    Suppress temporarily 'VisibleForTests' warnings - exposed for testing purposes
     -->
     <issue id="VisibleForTests" severity="ignore" />
 </lint>


### PR DESCRIPTION
Fixes : https://github.com/grpc/grpc-java/issues/6868 
android-interop-testing : worked on clearing lint warnings in android-interop and binder module