### PR TITLE
[DO NOT MERGE] Verifying xds legacy setup script

### DIFF
--- a/buildscripts/kokoro/xds_v3.sh
+++ b/buildscripts/kokoro/xds_v3.sh
@@ -12,7 +12,7 @@ GRADLE_OPTS="-Dorg.gradle.jvmargs='-Xmx1g'" \
   ../gradlew installDist -x test -PskipCodegen=true -PskipAndroid=true
 popd
 
-git clone -b master --single-branch --depth=1 https://github.com/grpc/grpc.git
+git clone -b fix/psm/legacy/pip-freeze --single-branch --depth=1 https://github.com/sergiitk/grpc.git
 
 grpc/tools/run_tests/helper_scripts/prep_xds.sh
 


### PR DESCRIPTION
To verify the change to `tools/run_tests/helper_scripts/prep_xds.sh` https://github.com/grpc/grpc/pull/40438.