### PR TITLE
binder: Avoid potential deadlock when canceling AsyncSecurityPolicy futures

### DIFF
--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -813,14 +813,21 @@ public abstract class BinderTransport implements IBinder.DeathRecipient {
         readyTimeoutFuture.cancel(false);
         readyTimeoutFuture = null;
       }
-      if (preAuthResultFuture != null) {
-        preAuthResultFuture.cancel(false); // No effect if already complete.
-      }
-      if (authResultFuture != null) {
-        authResultFuture.cancel(false);  // No effect if already complete.
-      }
+
+      ListenableFuture<Status> preAuthFuture = preAuthResultFuture;
+      ListenableFuture<Status> authFuture = authResultFuture;
+      preAuthResultFuture = null;
+      authResultFuture = null;
+
       serviceBinding.unbind();
       clientTransportListener.transportTerminated();
+
+      if (preAuthFuture != null) {
+        preAuthFuture.cancel(false); // No effect if already complete.
+      }
+      if (authFuture != null) {
+        authFuture.cancel(false);  // No effect if already complete.
+      }
     }
 
     @Override


### PR DESCRIPTION
Move future cancellation outside of synchronized block in `BinderClientTransport.notifyTerminated()` to prevent deadlock if `AsyncSecurityPolicy` uses `directExecutor()` for callbacks.

Fixes grpc#12190