### PR TITLE
servlet: simplify synchronization in AsyncServletOutputStreamWriter

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -112,7 +112,7 @@ signature-java = "org.codehaus.mojo.signature:java18:1.0"
 tomcat-embed-core = "org.apache.tomcat.embed:tomcat-embed-core:10.1.31"
 tomcat-embed-core9 = "org.apache.tomcat.embed:tomcat-embed-core:9.0.89"
 truth = "com.google.truth:truth:1.4.4"
-undertow-servlet22 = "io.undertow:undertow-servlet:2.2.32.Final"
+undertow-servlet22 = "io.undertow:undertow-servlet:2.2.37.Final"
 undertow-servlet = "io.undertow:undertow-servlet:2.3.18.Final"
 
 # Do not update: Pinned to the last version supporting Java 8.


### PR DESCRIPTION
Currently synchronization is too low level, seems like can be simplified by using standard lock implementation.