### PR TITLE
netty: Support BCJSSE provider in GrpcSslContexts

### DIFF
--- a/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
@@ -84,6 +84,7 @@ public class GrpcSslContexts {
   private static final String SUN_PROVIDER_NAME = "SunJSSE";
   private static final String IBM_PROVIDER_NAME = "IBMJSSE2";
   private static final String OPENJSSE_PROVIDER_NAME = "OpenJSSE";
+  private static final String BCJSSE_PROVIDER_NAME = "BCJSSE";
 
   /**
    * Creates an SslContextBuilder with ciphers and APN appropriate for gRPC.
@@ -199,7 +200,8 @@ public class GrpcSslContexts {
             jdkProvider.getName() + " selected, but Java 9+ and Jetty NPN/ALPN unavailable");
       }
     } else if (IBM_PROVIDER_NAME.equals(jdkProvider.getName())
-        || OPENJSSE_PROVIDER_NAME.equals(jdkProvider.getName())) {
+        || OPENJSSE_PROVIDER_NAME.equals(jdkProvider.getName())
+        || BCJSSE_PROVIDER_NAME.equals(jdkProvider.getName())) {
       if (JettyTlsUtil.isJava9AlpnAvailable()) {
         apc = ALPN;
       } else {
@@ -255,7 +257,8 @@ public class GrpcSslContexts {
           return provider;
         }
       } else if (IBM_PROVIDER_NAME.equals(provider.getName())
-          || OPENJSSE_PROVIDER_NAME.equals(provider.getName())) {
+          || OPENJSSE_PROVIDER_NAME.equals(provider.getName())
+          || BCJSSE_PROVIDER_NAME.equals(provider.getName())) {
         if (JettyTlsUtil.isJava9AlpnAvailable()) {
           return provider;
         }


### PR DESCRIPTION
This PR is related to https://github.com/grpc/grpc-java/issues/12227. 

With the proposed change, the GrpcSslContext was able to create SslContext with BCJSSE provider. I didn't find problems with this setup in our app and in example-tls, therefore raising a PR. My findings are described in aforementioned issue as comment https://github.com/grpc/grpc-java/issues/12227#issuecomment-3127857981. 

@ejona86 letting you know since your comments in the issue