### PR TITLE
xds: Avoid PriorityLb re-enabling timer on duplicate CONNECTING (v1.75.x backport)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/PriorityLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/PriorityLoadBalancer.java
@@ -320,13 +320,14 @@ final class PriorityLoadBalancer extends LoadBalancer {
         if (!children.containsKey(priority)) {
           return;
         }
+        ConnectivityState oldState = connectivityState;
         connectivityState = newState;
         picker = newPicker;
 
         if (deletionTimer != null && deletionTimer.isPending()) {
           return;
         }
-        if (newState.equals(CONNECTING)) {
+        if (newState.equals(CONNECTING) && !oldState.equals(newState)) {
           if (!failOverTimer.isPending() && seenReadyOrIdleSinceTransientFailure) {
             failOverTimer = syncContext.schedule(new FailOverTask(), 10, TimeUnit.SECONDS,
                 executor);


### PR DESCRIPTION
Backport of #12289 to v1.75.x.
---
Since c4256add4 we no longer fabricate a TRANSIENT_FAILURE update from children. However, previously that would have set
seenReadyOrIdleSinceTransientFailure = false and prevented future timer creation. If a LB policy gives extraneous updates with state CONNECTING, then it was possible to re-create failOverTimer which would then wait the 10 seconds for the child to finish CONNECTING. We only want to give the child one opportunity after transitioning out of READY/IDLE.

https://github.com/grpc/proposal/pull/509