### PR TITLE
feat(proctoc): Adds support for building protoc-gen-grpc-java on the RISC-V platform and provides protoc-gen-grpc-java prebuilt binaries

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -58,6 +58,10 @@ model {
                 cppCompiler.executable = 'aarch64-linux-gnu-g++'
                 linker.executable = 'aarch64-linux-gnu-g++'
             }
+            target("riscv64") {
+                cppCompiler.executable = 'riscv64-openEuler-linux-g++'
+                linker.executable = 'riscv64-openEuler-linux-g++'
+            }
             target("s390_64") {
                 cppCompiler.executable = 's390x-linux-gnu-g++'
                 linker.executable = 's390x-linux-gnu-g++'
@@ -74,6 +78,7 @@ model {
         x86_64 { architecture "x86_64" }
         ppcle_64 { architecture "ppcle_64" }
         aarch_64 { architecture "aarch_64" }
+        riscv64 { architecture "riscv64" }
         s390_64 { architecture "s390_64" }
         loongarch_64 { architecture "loongarch_64" }
     }
@@ -85,6 +90,7 @@ model {
                 'x86_64',
                 'ppcle_64',
                 'aarch_64',
+                'riscv64',
                 's390_64',
                 'loongarch_64'
             ]) {

--- a/compiler/check-artifact.sh
+++ b/compiler/check-artifact.sh
@@ -61,6 +61,8 @@ checkArch ()
         assertEq "$format" "elf64-x86-64" $LINENO
       elif [[ "$ARCH" == aarch_64 ]]; then
         assertEq "$format" "elf64-little" $LINENO
+      elif [[ "$ARCH" == riscv64 ]]; then
+        assertEq "$format" "elf64-littleriscv" $LINENO
       elif [[ "$ARCH" == loongarch_64 ]]; then
         echo $format
 	assertEq "$format" "elf64-loongarch" $LINENO
@@ -121,6 +123,9 @@ checkDependencies ()
       white_list="${white_list}\|libm\.so\.6"
     elif [[ "$ARCH" == aarch_64 ]]; then
       white_list="${white_list}\|ld-linux-aarch64\.so\.1"
+    elif [[ "$ARCH" == riscv64 ]]; then
+      dump_cmd='riscv64-linux-gnu-objdump -x '"$1"' |grep "NEEDED"'
+      white_list="libatomic\.so\.1\|libm\.so\.6\|libc\.so\.6\|ld-linux-riscv64-lp64d\.so\.1"
     fi
   elif [[ "$OS" == osx ]]; then
     dump_cmd='otool -L '"$1"' | fgrep dylib'


### PR DESCRIPTION
**Summary**

This PR adds support for building protoc-gen-grpc-java on the RISC-V platform and provides prebuilt binaries, addressing the lack of official RISC-V support and prebuilts for protoc-gen-grpc-java.

**Changes**

Updated build scripts to detect and recognize riscv64 as a supported target platform.
Extended architecture-specific logic in compiler/build.gradle  and compiler/check-artifact.sh to include the riscv64 architecture, enabling proper compilation for RISC-V.
Ensured all newly added code paths are conditionally compiled—this modification does not impact existing supported architectures (e.g., x86_64, ARM).

**Motivation**

RISC-V is an open, rapidly evolving CPU architecture with growing adoption. Prior to this PR:
protoc-gen-grpc-java lacked official build support for RISC-V, leading to compilation failures when attempting to build natively or cross-compile for the platform.
No protoc-gen-grpc-java prebuilt binaries for RISC-V exist in Maven Central Repository (https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/), which blocked direct use of protoc-gen-grpc-java prebuilts for Maven-based projects (e.g., Hadoop, Spark, and related plugins) on RISC-V.
This PR resolves both gaps to unblock RISC-V adoption for protoc-gen-grpc-java dependent projects.

**Testing**

Successfully built protoc-gen-grpc-java natively on a Sophgo SG2042 RISC-V CPU running Linux.
Used the RISC-V-built protoc-gen-grpc-java to compile Spark on riscv64 successfully.

Additional Notes
protoc prebuilt binaries:https://github.com/zhanchangbao-sanechips/plugin-repo/protoc-gen-grpc-java-1.47.0-linux-riscv64.exe.