### PR TITLE
servlet: fix threadingTest and update lincheck

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -238,7 +238,7 @@ subprojects {
 
         // At a test failure, log the stack trace to the console so that we don't
         // have to open the HTML in a browser.
-        tasks.named("test").configure {
+        tasks.withType(Test).configureEach {
             testLogging {
                 exceptionFormat = 'full'
                 showExceptions = true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,8 +69,7 @@ jetty-servlet = "org.eclipse.jetty.ee10:jetty-ee10-servlet:12.0.16"
 jetty-servlet10 = "org.eclipse.jetty:jetty-servlet:10.0.20"
 jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
 junit = "junit:junit:4.13.2"
-# 2.17+ require Java 11+ (not mentioned in release notes)
-lincheck = "org.jetbrains.kotlinx:lincheck-jvm:2.16"
+lincheck = "org.jetbrains.lincheck:lincheck:3.2"
 # Update notes / 2023-07-19 sergiitk:
 #    Couldn't update to 5.4.0, updated to the last in 4.x line. Version 5.x breaks some tests.
 #    Error log: https://github.com/grpc/grpc-java/pull/10359#issuecomment-1632834435

--- a/servlet/build.gradle
+++ b/servlet/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     testImplementation libraries.javax.servlet.api
 
     threadingTestImplementation project(':grpc-servlet'),
-        libraries.truth,
+        libraries.junit,
         libraries.javax.servlet.api,
         libraries.lincheck
 
@@ -69,19 +69,12 @@ dependencies {
             libraries.protobuf.java
 }
 
-tasks.named("test").configure {
-    if (JavaVersion.current().isJava9Compatible()) {
-        jvmArgs += [
-                // required for Lincheck
-                '--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED',
-                '--add-exports=java.base/jdk.internal.util=ALL-UNNAMED',
-        ]
-    }
-}
-
 tasks.register('threadingTest', Test) {
     classpath = sourceSets.threadingTest.runtimeClasspath
     testClassesDirs = sourceSets.threadingTest.output.classesDirs
+    jacoco {
+        enabled = false
+    }
 }
 
 tasks.named("assemble").configure {


### PR DESCRIPTION
Seems like previously it was not testing all the flows but only:  the write/flush calls are added to the queue by `runOrBuffer` because `readyAndDrained` is initially `false`.

So,
* `isReady()` is never called
* `isReadyReturnedFalse` never set to true
* `maybeOnWritePossible()` does nothing

All that makes me think that #9917 is caused by some bugs in older versions of llincheck, can be closed now.

A more real simulation happens if calling `onWritePossible` first via `initialOnWritePossible`, and then it has found a race condition in `AsyncServletOutputStreamWriterConcurrencyTest.isReady()`, if `maybeOnWritePossible()` is executed before `return isReady`.

Additionally updated lincheck, 
* it does not need jvmArgs now 
* is compatible with java 8 again
* changed asserts from Truth to junit, as lincheck was trying to use `com.google.common.truth.Subject.equals(Object)`

It still does not detect #12268, but might be needs more time.