### PR TITLE
servlet: add extra 5s to AsyncContext timeout

### DIFF
--- a/servlet/src/main/java/io/grpc/servlet/ServletAdapter.java
+++ b/servlet/src/main/java/io/grpc/servlet/ServletAdapter.java
@@ -128,10 +128,9 @@ public final class ServletAdapter {
     }
 
     Long timeoutNanos = headers.get(TIMEOUT_KEY);
-    if (timeoutNanos == null) {
-      timeoutNanos = 0L;
-    }
-    asyncCtx.setTimeout(TimeUnit.NANOSECONDS.toMillis(timeoutNanos));
+    asyncCtx.setTimeout(timeoutNanos != null
+        ? TimeUnit.NANOSECONDS.toMillis(timeoutNanos) + ASYNC_TIMEOUT_SAFETY_MARGIN
+        : 0);
     StatsTraceContext statsTraceCtx =
         StatsTraceContext.newServerContext(streamTracerFactories, method, headers);
 
@@ -157,6 +156,11 @@ public final class ServletAdapter {
         .setReadListener(new GrpcReadListener(stream, asyncCtx, logId));
     asyncCtx.addListener(new GrpcAsyncListener(stream, logId));
   }
+
+  /**
+   * Deadlines are managed via Context, servlet async timeout is not supposed to happen.
+   */
+  private static final long ASYNC_TIMEOUT_SAFETY_MARGIN = 5_000;
 
   // This method must use Enumeration and its members, since that is the only way to read headers
   // from the servlet api.

--- a/servlet/src/main/java/io/grpc/servlet/ServletAdapter.java
+++ b/servlet/src/main/java/io/grpc/servlet/ServletAdapter.java
@@ -22,6 +22,7 @@ import static io.grpc.internal.GrpcUtil.TIMEOUT_KEY;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINEST;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.BaseEncoding;
 import io.grpc.Attributes;
 import io.grpc.ExperimentalApi;
@@ -160,7 +161,8 @@ public final class ServletAdapter {
   /**
    * Deadlines are managed via Context, servlet async timeout is not supposed to happen.
    */
-  private static final long ASYNC_TIMEOUT_SAFETY_MARGIN = 5_000;
+  @VisibleForTesting
+  static final long ASYNC_TIMEOUT_SAFETY_MARGIN = 5_000;
 
   // This method must use Enumeration and its members, since that is the only way to read headers
   // from the servlet api.

--- a/servlet/src/test/java/io/grpc/servlet/ServletServerBuilderTest.java
+++ b/servlet/src/test/java/io/grpc/servlet/ServletServerBuilderTest.java
@@ -80,7 +80,7 @@ public class ServletServerBuilderTest {
     ServletAdapter servletAdapter = serverBuilder.buildServletAdapter();
     servletAdapter.doPost(request, response);
 
-    verify(asyncContext).setTimeout(1);
+    verify(asyncContext).setTimeout(1 + ServletAdapter.ASYNC_TIMEOUT_SAFETY_MARGIN);
 
     // The following just verifies that scheduler is populated to the transport.
     // It doesn't matter what tasks (such as handshake timeout and request deadline) are actually


### PR DESCRIPTION
Currently there is a race between 2 tasks scheduled to handle request timeout
* servlet AsyncContext timeout
* gRPC Context

which can cause instability