### PR TITLE
OpenTelemetryMetricsModule : Ensure method name is recorded instead of "other" in OpenTelemetry metrics.

### DIFF
--- a/opentelemetry/src/main/java/io/grpc/opentelemetry/OpenTelemetryMetricsModule.java
+++ b/opentelemetry/src/main/java/io/grpc/opentelemetry/OpenTelemetryMetricsModule.java
@@ -466,6 +466,7 @@ final class OpenTelemetryMetricsModule {
       this.fullMethodName = fullMethodName;
       this.streamPlugins = checkNotNull(streamPlugins, "streamPlugins");
       this.stopwatch = module.stopwatchSupplier.get().start();
+      isGeneratedMethod = fullMethodName != null;
     }
 
     @Override


### PR DESCRIPTION
Fixes:  https://github.com/grpc/grpc-java/issues/12117
current change sets isGenerated = true whenever fullMethodName != null in ServerTracer. This ensures OpenTelemetry metrics don’t fall back to "other" in early-cancel cases.