### PR TITLE
android: fix network change handling on API levels < 24

### DIFF
--- a/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
+++ b/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
@@ -323,7 +323,6 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
 
     /** Respond to network changes. Only used on API levels < 24. */
     private class NetworkReceiver extends BroadcastReceiver {
-      private boolean isConnected = false;
 
       @SuppressWarnings("deprecation")
       @Override
@@ -331,9 +330,8 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
         ConnectivityManager conn =
             (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);
         android.net.NetworkInfo networkInfo = conn.getActiveNetworkInfo();
-        boolean wasConnected = isConnected;
-        isConnected = networkInfo != null && networkInfo.isConnected();
-        if (isConnected && !wasConnected) {
+
+        if (networkInfo != null && networkInfo.isConnected()) {
           delegate.enterIdle();
         }
       }

--- a/android/src/test/java/io/grpc/android/AndroidChannelBuilderTest.java
+++ b/android/src/test/java/io/grpc/android/AndroidChannelBuilderTest.java
@@ -152,12 +152,6 @@ public final class AndroidChannelBuilderTest {
         .sendBroadcast(new Intent(ConnectivityManager.CONNECTIVITY_ACTION));
     assertThat(delegateChannel.enterIdleCount).isEqualTo(1);
 
-    // The broadcast receiver may fire when the active network status has not actually changed
-    ApplicationProvider
-        .getApplicationContext()
-        .sendBroadcast(new Intent(ConnectivityManager.CONNECTIVITY_ACTION));
-    assertThat(delegateChannel.enterIdleCount).isEqualTo(1);
-
     // Drop the connection
     shadowOf(connectivityManager).setActiveNetworkInfo(null);
     ApplicationProvider


### PR DESCRIPTION
Fixes : https://github.com/grpc/grpc-java/issues/12313

In case if VPN toggled on<->off `wasConnected` returns true and `delegate.enterIdle()` is skipped.


PS: Not using `android.net.ConnectivityManager.NetworkCallback#onCapabilitiesChanged` for API 24+ can also be an issue if capabilities change and user needs to receive updates.