### PR TITLE
Remove org.apache.tomcat:annotations-api dep

### DIFF
--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -22,7 +22,6 @@ dependencies {
             libraries.guava.jre, // JRE required by protobuf-java-util from grpclb
             libraries.google.auth.oauth2Http
     def nettyDependency = implementation project(':grpc-netty')
-    compileOnly libraries.javax.annotation
 
     shadow configurations.implementation.getDependencies().minus(nettyDependency)
     shadow project(path: ':grpc-netty-shaded', configuration: 'shadow')

--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -83,8 +83,6 @@ dependencies {
         exclude group: 'com.google.guava'
     }
 
-    compileOnly libraries.javax.annotation
-
     androidTestImplementation 'androidx.test.ext:junit:1.1.3',
             'androidx.test:runner:1.4.0'
 }

--- a/authz/build.gradle
+++ b/authz/build.gradle
@@ -15,7 +15,6 @@ dependencies {
             libraries.guava.jre // JRE required by transitive protobuf-java-util
 
     annotationProcessor libraries.auto.value
-    compileOnly libraries.javax.annotation
 
     testImplementation project(':grpc-testing'),
             project(':grpc-testing-proto'),

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -38,7 +38,6 @@ dependencies {
             classifier = "linux-x86_64"
         }
     }
-    compileOnly libraries.javax.annotation
 
     testImplementation libraries.junit,
             libraries.mockito.core

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -147,11 +147,9 @@ sourceSets {
 
 dependencies {
     testImplementation project(':grpc-protobuf'),
-            project(':grpc-stub'),
-            libraries.javax.annotation
+            project(':grpc-stub')
     testLiteImplementation project(':grpc-protobuf-lite'),
-            project(':grpc-stub'),
-            libraries.javax.annotation
+            project(':grpc-stub')
 }
 
 tasks.named("compileTestJava").configure {

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -57,7 +57,6 @@ dependencies {
     implementation 'io.grpc:grpc-okhttp:1.76.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'io.grpc:grpc-protobuf-lite:1.76.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'io.grpc:grpc-stub:1.76.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'org.apache.tomcat:annotations-api:6.0.53'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.google.truth:truth:1.1.5'

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -55,5 +55,4 @@ dependencies {
     implementation 'io.grpc:grpc-okhttp:1.76.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'io.grpc:grpc-protobuf-lite:1.76.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'io.grpc:grpc-stub:1.76.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'org.apache.tomcat:annotations-api:6.0.53'
 }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -55,5 +55,4 @@ dependencies {
     implementation 'io.grpc:grpc-okhttp:1.76.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'io.grpc:grpc-protobuf-lite:1.76.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'io.grpc:grpc-stub:1.76.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'org.apache.tomcat:annotations-api:6.0.53'
 }

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -56,5 +56,4 @@ dependencies {
     implementation 'io.grpc:grpc-okhttp:1.76.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'io.grpc:grpc-protobuf-lite:1.76.0-SNAPSHOT' // CURRENT_GRPC_VERSION
     implementation 'io.grpc:grpc-stub:1.76.0-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'org.apache.tomcat:annotations-api:6.0.53'
 }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
     implementation "io.grpc:grpc-services:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
-    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
 
     // examples/advanced need this for JsonFormat
     implementation "com.google.protobuf:protobuf-java-util:${protobufVersion}"

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -27,7 +27,6 @@ def protocVersion = '3.25.8'
 dependencies {
     // grpc-alts transitively depends on grpc-netty-shaded, grpc-protobuf, and grpc-stub
     implementation "io.grpc:grpc-alts:${grpcVersion}"
-    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
 }
 
 protobuf {

--- a/examples/example-debug/build.gradle
+++ b/examples/example-debug/build.gradle
@@ -30,7 +30,6 @@ dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-services:${grpcVersion}"
-    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
     testImplementation 'junit:junit:4.13.2'

--- a/examples/example-debug/pom.xml
+++ b/examples/example-debug/pom.xml
@@ -45,12 +45,6 @@
       <artifactId>grpc-stub</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.tomcat</groupId>
-      <artifactId>annotations-api</artifactId>
-      <version>6.0.53</version>
-      <scope>provided</scope> <!-- not needed at runtime -->
-    </dependency>
-    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
       <scope>runtime</scope>

--- a/examples/example-dualstack/build.gradle
+++ b/examples/example-dualstack/build.gradle
@@ -31,7 +31,6 @@ dependencies {
     implementation "io.grpc:grpc-netty:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-services:${grpcVersion}"
-    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
 }
 
 protobuf {

--- a/examples/example-dualstack/pom.xml
+++ b/examples/example-dualstack/pom.xml
@@ -49,12 +49,6 @@
       <artifactId>grpc-netty</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.tomcat</groupId>
-      <artifactId>annotations-api</artifactId>
-      <version>6.0.53</version>
-      <scope>provided</scope> <!-- not needed at runtime -->
-    </dependency>
-    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
       <scope>runtime</scope>

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -30,7 +30,6 @@ dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-auth:${grpcVersion}"
-    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
     implementation "com.google.auth:google-auth-library-oauth2-http:1.23.0"
     implementation "com.google.api.grpc:grpc-google-cloud-pubsub-v1:0.1.24"
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -50,12 +50,6 @@
       <artifactId>grpc-auth</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.tomcat</groupId>
-      <artifactId>annotations-api</artifactId>
-      <version>6.0.53</version>
-      <scope>provided</scope> <!-- not needed at runtime -->
-    </dependency>
-    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-testing</artifactId>
       <scope>test</scope>

--- a/examples/example-gcp-csm-observability/build.gradle
+++ b/examples/example-gcp-csm-observability/build.gradle
@@ -35,7 +35,6 @@ dependencies {
     implementation "io.opentelemetry:opentelemetry-sdk:${openTelemetryVersion}"
     implementation "io.opentelemetry:opentelemetry-sdk-metrics:${openTelemetryVersion}"
     implementation "io.opentelemetry:opentelemetry-exporter-prometheus:${openTelemetryPrometheusVersion}"
-    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
     runtimeOnly "io.grpc:grpc-xds:${grpcVersion}"
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 }

--- a/examples/example-gcp-observability/build.gradle
+++ b/examples/example-gcp-observability/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-gcp-observability:${grpcVersion}"
-    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 }
 

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -28,7 +28,6 @@ dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-services:${grpcVersion}"
-    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
     testImplementation 'junit:junit:4.13.2'

--- a/examples/example-hostname/pom.xml
+++ b/examples/example-hostname/pom.xml
@@ -45,12 +45,6 @@
       <artifactId>grpc-stub</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.tomcat</groupId>
-      <artifactId>annotations-api</artifactId>
-      <version>6.0.53</version>
-      <scope>provided</scope> <!-- not needed at runtime -->
-    </dependency>
-    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
       <scope>runtime</scope>

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -31,8 +31,6 @@ dependencies {
     implementation "io.jsonwebtoken:jjwt:0.9.1"
     implementation "javax.xml.bind:jaxb-api:2.3.1"
 
-    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
-
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
     testImplementation "io.grpc:grpc-testing:${grpcVersion}"

--- a/examples/example-jwt-auth/pom.xml
+++ b/examples/example-jwt-auth/pom.xml
@@ -58,12 +58,6 @@
       <version>2.3.1</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.tomcat</groupId>
-      <artifactId>annotations-api</artifactId>
-      <version>6.0.53</version>
-      <scope>provided</scope> <!-- not needed at runtime -->
-    </dependency>
-    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-testing</artifactId>
       <scope>test</scope>

--- a/examples/example-oauth/build.gradle
+++ b/examples/example-oauth/build.gradle
@@ -31,8 +31,6 @@ dependencies {
     implementation "io.grpc:grpc-auth:${grpcVersion}"
     implementation "com.google.auth:google-auth-library-oauth2-http:1.23.0"
 
-    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
-
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 
     testImplementation "io.grpc:grpc-testing:${grpcVersion}"

--- a/examples/example-oauth/pom.xml
+++ b/examples/example-oauth/pom.xml
@@ -63,12 +63,6 @@
       <version>1.23.0</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.tomcat</groupId>
-      <artifactId>annotations-api</artifactId>
-      <version>6.0.53</version>
-      <scope>provided</scope> <!-- not needed at runtime -->
-    </dependency>
-    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-testing</artifactId>
       <scope>test</scope>

--- a/examples/example-opentelemetry/build.gradle
+++ b/examples/example-opentelemetry/build.gradle
@@ -34,7 +34,6 @@ dependencies {
     implementation "io.opentelemetry:opentelemetry-sdk-metrics:${openTelemetryVersion}"
     implementation "io.opentelemetry:opentelemetry-exporter-logging:${openTelemetryVersion}"
     implementation "io.opentelemetry:opentelemetry-exporter-prometheus:${openTelemetryPrometheusVersion}"
-    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 }
 

--- a/examples/example-orca/build.gradle
+++ b/examples/example-orca/build.gradle
@@ -24,8 +24,6 @@ dependencies {
     implementation "io.grpc:grpc-services:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-xds:${grpcVersion}"
-    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
-
 }
 
 protobuf {

--- a/examples/example-reflection/build.gradle
+++ b/examples/example-reflection/build.gradle
@@ -24,8 +24,6 @@ dependencies {
     implementation "io.grpc:grpc-services:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-netty-shaded:${grpcVersion}"
-    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
-
 }
 
 protobuf {

--- a/examples/example-servlet/build.gradle
+++ b/examples/example-servlet/build.gradle
@@ -23,8 +23,7 @@ dependencies {
             "io.grpc:grpc-servlet:${grpcVersion}",
             "io.grpc:grpc-stub:${grpcVersion}"
 
-    compileOnly "javax.servlet:javax.servlet-api:4.0.1",
-            "org.apache.tomcat:annotations-api:6.0.53"
+    compileOnly "javax.servlet:javax.servlet-api:4.0.1"
 }
 
 protobuf {

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -27,7 +27,6 @@ def protocVersion = '3.25.8'
 dependencies {
     implementation "io.grpc:grpc-protobuf:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
-    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 }
 

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -41,12 +41,6 @@
       <artifactId>grpc-stub</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.tomcat</groupId>
-      <artifactId>annotations-api</artifactId>
-      <version>6.0.53</version>
-      <scope>provided</scope> <!-- not needed at runtime -->
-    </dependency>
-    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-netty-shaded</artifactId>
     </dependency>

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -29,7 +29,6 @@ dependencies {
     implementation "io.grpc:grpc-services:${grpcVersion}"
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-xds:${grpcVersion}"
-    compileOnly "org.apache.tomcat:annotations-api:6.0.53"
 
     runtimeOnly "io.grpc:grpc-netty-shaded:${grpcVersion}"
 }

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -61,12 +61,6 @@
       <version>3.0.0</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.tomcat</groupId>
-      <artifactId>annotations-api</artifactId>
-      <version>6.0.53</version>
-      <scope>provided</scope> <!-- not needed at runtime -->
-    </dependency>
-    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-testing</artifactId>
       <scope>test</scope>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,9 +53,6 @@ guava-jre = "com.google.guava:guava:33.4.8-jre"
 hdrhistogram = "org.hdrhistogram:HdrHistogram:2.2.2"
 # 6.0.0+ use java.lang.Deprecated forRemoval and since from Java 9
 jakarta-servlet-api = "jakarta.servlet:jakarta.servlet-api:5.0.0"
-# Using javax.annotation is fine as it is part of the JDK, we don't want to depend on J2EE
-# where it is relocated to as org.apache.tomcat:tomcat-annotations-api. See issue #9179.
-javax-annotation = "org.apache.tomcat:annotations-api:6.0.53"
 javax-servlet-api = "javax.servlet:javax.servlet-api:4.0.1"
 # 12.0.0+ require Java 17+
 jetty-client = "org.eclipse.jetty:jetty-client:11.0.24"

--- a/grpclb/build.gradle
+++ b/grpclb/build.gradle
@@ -23,7 +23,6 @@ dependencies {
             libraries.protobuf.java,
             libraries.protobuf.java.util
     runtimeOnly libraries.errorprone.annotations
-    compileOnly libraries.javax.annotation
     testImplementation libraries.truth,
             project(':grpc-inprocess'),
             testFixtures(project(':grpc-core'))

--- a/interop-testing/build.gradle
+++ b/interop-testing/build.gradle
@@ -31,7 +31,6 @@ dependencies {
             project(':grpc-stub'),
             project(':grpc-protobuf'),
             libraries.junit
-    compileOnly libraries.javax.annotation
     // TODO(sergiitk): replace with com.google.cloud:google-cloud-logging
     // Used instead of google-cloud-logging because it's failing
     // due to a circular dependency on grpc.

--- a/istio-interop-testing/build.gradle
+++ b/istio-interop-testing/build.gradle
@@ -18,8 +18,6 @@ dependencies {
             project(':grpc-testing'),
             project(':grpc-xds')
 
-    compileOnly libraries.javax.annotation
-
     runtimeOnly libraries.netty.tcnative,
             libraries.netty.tcnative.classes
     testImplementation testFixtures(project(':grpc-api')),

--- a/rls/build.gradle
+++ b/rls/build.gradle
@@ -22,7 +22,6 @@ dependencies {
             libraries.auto.value.annotations,
             libraries.guava
     annotationProcessor libraries.auto.value
-    compileOnly libraries.javax.annotation
     testImplementation libraries.truth,
             project(':grpc-grpclb'),
             project(':grpc-inprocess'),

--- a/s2a/build.gradle
+++ b/s2a/build.gradle
@@ -21,7 +21,6 @@ dependencies {
             libraries.protobuf.java,
             libraries.guava.jre // JRE required by protobuf-java-util from grpclb
     def nettyDependency = implementation project(':grpc-netty')
-    compileOnly libraries.javax.annotation
 
     shadow configurations.implementation.getDependencies().minus(nettyDependency)
     shadow project(path: ':grpc-netty-shaded', configuration: 'shadow')

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -32,13 +32,11 @@ dependencies {
 
     runtimeOnly libraries.errorprone.annotations,
             libraries.gson  // to fix checkUpperBoundDeps error here
-    compileOnly libraries.javax.annotation
     testImplementation project(':grpc-testing'),
             project(':grpc-inprocess'),
             libraries.netty.transport.epoll, // for DomainSocketAddress
             testFixtures(project(':grpc-core')),
             testFixtures(project(':grpc-api'))
-    testCompileOnly libraries.javax.annotation
     signature (libraries.signature.java) {
         artifact {
             extension = "signature"

--- a/servlet/build.gradle
+++ b/servlet/build.gradle
@@ -34,8 +34,7 @@ tasks.named("jar").configure {
 
 dependencies {
     api project(':grpc-api')
-    compileOnly libraries.javax.servlet.api,
-            libraries.javax.annotation // java 9, 10 needs it
+    compileOnly libraries.javax.servlet.api
 
     implementation project(':grpc-core'),
             libraries.guava

--- a/servlet/jakarta/build.gradle
+++ b/servlet/jakarta/build.gradle
@@ -85,8 +85,7 @@ tasks.named("jar").configure {
 
 dependencies {
     api project(':grpc-api')
-    compileOnly libraries.jakarta.servlet.api,
-            libraries.javax.annotation
+    compileOnly libraries.jakarta.servlet.api
 
     implementation project(':grpc-util'),
             project(':grpc-core'),

--- a/testing-proto/build.gradle
+++ b/testing-proto/build.gradle
@@ -17,9 +17,7 @@ tasks.named("jar").configure {
 dependencies {
     api project(':grpc-protobuf'),
             project(':grpc-stub')
-    compileOnly libraries.javax.annotation
     testImplementation libraries.truth
-    testRuntimeOnly libraries.javax.annotation
     signature (libraries.signature.java) {
         artifact {
             extension = "signature"

--- a/xds/build.gradle
+++ b/xds/build.gradle
@@ -41,7 +41,6 @@ configurations {
 }
 
 dependencies {
-    thirdpartyCompileOnly libraries.javax.annotation
     thirdpartyImplementation project(':grpc-protobuf'),
             project(':grpc-stub')
     compileOnly sourceSets.thirdparty.output


### PR DESCRIPTION
f8700a1 stopped using the dependency in our generated code and removed the dependency the Bazel build. 4f6948f removed mention of the dependency in our README. This deletes it from our Gradle build and the examples.