### PR TITLE
compiler: Mangle generated method names that conflict with java.lang.Object methods

### DIFF
--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -693,10 +693,11 @@ static void PrintStub(
     (*vars)["input_type"] = MessageFullJavaName(method->input_type());
     (*vars)["output_type"] = MessageFullJavaName(method->output_type());
     bool client_streaming = method->client_streaming();
-    bool mangle_object_methods = (call_type == BLOCKING_V2_CALL && client_streaming);
+    bool server_streaming = method->server_streaming();
+    bool mangle_object_methods = (call_type == BLOCKING_V2_CALL && client_streaming)
+      || (call_type == BLOCKING_CALL && client_streaming && server_streaming);
     (*vars)["lower_method_name"] = LowerMethodName(method, mangle_object_methods);
     (*vars)["method_method_name"] = MethodPropertiesGetterName(method);
-    bool server_streaming = method->server_streaming();
 
     if (call_type == BLOCKING_CALL && client_streaming) {
       // Blocking client interface with client streaming is not available


### PR DESCRIPTION
Generated gRPC method names in the BlockingV2Stub can conflict with
final methods on `java.lang.Object` (e.g., `toString()`, `hashCode()`)
for client-streaming and bidi-streaming RPCs. This occurs because
they are generated with no arguments, leading to a compilation error. One such case in #12331.

This change introduces a dedicated list of no-argument method names
from java.lang.Object and applies name-mangling (appending an
underscore) only when generating these specific methods in the
v2 blocking stub.

This resolves the compilation failure while ensuring that the behavior
for all other stubs remains unchanged.

Fixes: #12331