### PR TITLE
 android: fix network change handling on API levels 24+

### DIFF
--- a/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
+++ b/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
@@ -23,6 +23,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.Network;
+import android.net.NetworkCapabilities;
 import android.os.Build;
 import android.util.Log;
 import com.google.common.annotations.VisibleForTesting;
@@ -318,6 +319,18 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
         if (!blocked) {
           delegate.enterIdle();
         }
+      }
+
+      @Override
+      public void onCapabilitiesChanged(Network network, NetworkCapabilities networkCapabilities) {
+        if (isConnected(networkCapabilities)) {
+          delegate.enterIdle();
+        }
+      }
+
+      private boolean isConnected(NetworkCapabilities networkCapabilities) {
+        return networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                && networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED);
       }
     }
 


### PR DESCRIPTION
Relates to https://github.com/grpc/grpc-java/pull/12327

> PS: Not using android.net.ConnectivityManager.NetworkCallback#onCapabilitiesChanged for API 24+ can also be an issue if capabilities change and user needs to receive updates.

This PR should improve network change detection  for API levels 24+.
For example, in case of WI-FI -> Cellular transition and vice versa, `NetworkCapabilities` will change it's `transport`, resulting in `android.net.ConnectivityManager.NetworkCallback#onCapabilitiesChanged` invocation. 
We can check, if `NetworkCapabilities` contain needed `capabilities` after such transition.

For more detailed network change detection, something similar to [this](https://github.com/ProtonVPN/android-app/blob/master/app/src/main/java/com/protonvpn/android/vpn/ConnectivityMonitor.kt) can be done.