### PR TITLE
Netty & OkHttp : Added Allow header on 405, include Allow: POST http: added Allow header for 405

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -60,6 +60,7 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http2.DecoratingHttp2ConnectionEncoder;
 import io.netty.handler.codec.http2.DecoratingHttp2FrameWriter;
 import io.netty.handler.codec.http2.DefaultHttp2Connection;
@@ -70,6 +71,7 @@ import io.netty.handler.codec.http2.DefaultHttp2FrameWriter;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.DefaultHttp2LocalFlowController;
 import io.netty.handler.codec.http2.DefaultHttp2RemoteFlowController;
+import io.netty.handler.codec.http2.EmptyHttp2Headers;
 import io.netty.handler.codec.http2.Http2Connection;
 import io.netty.handler.codec.http2.Http2ConnectionAdapter;
 import io.netty.handler.codec.http2.Http2ConnectionDecoder;
@@ -480,8 +482,15 @@ class NettyServerHandler extends AbstractNettyHandler {
       }
 
       if (!HTTP_METHOD.contentEquals(headers.method())) {
-        respondWithHttpError(ctx, streamId, 405, Status.Code.INTERNAL,
-            String.format("Method '%s' is not supported", headers.method()));
+        Http2Headers allowHeaders = new DefaultHttp2Headers();
+        allowHeaders.add(HttpHeaderNames.ALLOW, HTTP_METHOD);
+        respondWithHttpError(
+            ctx,
+            streamId,
+            405,
+            Status.Code.INTERNAL,
+            String.format("Method '%s' is not supported", headers.method()),
+            allowHeaders);
         return;
       }
 
@@ -869,6 +878,16 @@ class NettyServerHandler extends AbstractNettyHandler {
 
   private void respondWithHttpError(
       ChannelHandlerContext ctx, int streamId, int code, Status.Code statusCode, String msg) {
+    respondWithHttpError(ctx, streamId, code, statusCode, msg, EmptyHttp2Headers.INSTANCE);
+  }
+
+  private void respondWithHttpError(
+      ChannelHandlerContext ctx,
+      int streamId,
+      int code,
+      Status.Code statusCode,
+      String msg,
+      Http2Headers allowHeaders) {
     Metadata metadata = new Metadata();
     metadata.put(InternalStatus.CODE_KEY, statusCode.toStatus());
     metadata.put(InternalStatus.MESSAGE_KEY, msg);
@@ -880,6 +899,7 @@ class NettyServerHandler extends AbstractNettyHandler {
     for (int i = 0; i < serialized.length; i += 2) {
       headers.add(new AsciiString(serialized[i], false), new AsciiString(serialized[i + 1], false));
     }
+    headers.add(allowHeaders);
     encoder().writeHeaders(ctx, streamId, headers, 0, false, ctx.newPromise());
     ByteBuf msgBuf = ByteBufUtil.writeUtf8(ctx.alloc(), msg);
     encoder().writeData(ctx, streamId, msgBuf, 0, true, ctx.newPromise());

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -78,6 +78,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http2.DefaultHttp2Headers;
 import io.netty.handler.codec.http2.Http2CodecUtil;
 import io.netty.handler.codec.http2.Http2Error;
@@ -538,11 +539,13 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
         .path(new AsciiString("/foo/bar"));
     ByteBuf headersFrame = headersFrame(STREAM_ID, headers);
     channelRead(headersFrame);
-    Http2Headers responseHeaders = new DefaultHttp2Headers()
-        .set(InternalStatus.CODE_KEY.name(), String.valueOf(Code.INTERNAL.value()))
-        .set(InternalStatus.MESSAGE_KEY.name(), "Method 'FAKE' is not supported")
-        .status("" + 405)
-        .set(CONTENT_TYPE_HEADER, "text/plain; charset=utf-8");
+    Http2Headers responseHeaders =
+        new DefaultHttp2Headers()
+            .set(InternalStatus.CODE_KEY.name(), String.valueOf(Code.INTERNAL.value()))
+            .set(InternalStatus.MESSAGE_KEY.name(), "Method 'FAKE' is not supported")
+            .status("" + 405)
+            .set(HttpHeaderNames.ALLOW, "POST")
+            .set(CONTENT_TYPE_HEADER, "text/plain; charset=utf-8");
 
     verifyWrite()
         .writeHeaders(

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpServerTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpServerTransportTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
+import com.google.common.collect.Lists;
 import com.google.common.io.ByteStreams;
 import io.grpc.Attributes;
 import io.grpc.InternalChannelz.SocketStats;
@@ -62,6 +63,7 @@ import java.net.Socket;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -920,7 +922,9 @@ public class OkHttpServerTransportTest {
         TE_HEADER));
     clientFrameWriter.flush();
 
-    verifyHttpError(1, 405, Status.Code.INTERNAL, "HTTP Method is not supported: GET");
+    List<Header> extraHeaders = Lists.newArrayList(new Header("allow", "POST"));
+    verifyHttpError(
+        1, 405, Status.Code.INTERNAL, "HTTP Method is not supported: GET", extraHeaders);
 
     shutdownAndTerminate(/*lastStreamId=*/ 1);
   }
@@ -972,11 +976,13 @@ public class OkHttpServerTransportTest {
     clientFrameWriter.flush();
 
     String errorDescription = "HTTP Method is not supported: GET";
-    List<Header> responseHeaders = Arrays.asList(
-        new Header(":status", "405"),
-        new Header("content-type", "text/plain; charset=utf-8"),
-        new Header("grpc-status", "" + Status.Code.INTERNAL.value()),
-        new Header("grpc-message", errorDescription));
+    List<Header> responseHeaders =
+        Arrays.asList(
+            new Header(":status", "405"),
+            new Header("content-type", "text/plain; charset=utf-8"),
+            new Header("grpc-status", "" + Status.Code.INTERNAL.value()),
+            new Header("grpc-message", errorDescription),
+            new Header("allow", "POST"));
     assertThat(clientFrameReader.nextFrame(clientFramesRead)).isTrue();
     verify(clientFramesRead)
         .headers(false, false, 1, -1, responseHeaders, HeadersMode.HTTP_20_HEADERS);
@@ -1398,11 +1404,18 @@ public class OkHttpServerTransportTest {
 
   private void verifyHttpError(
       int streamId, int httpCode, Status.Code grpcCode, String errorDescription) throws Exception {
-    List<Header> responseHeaders = Arrays.asList(
-        new Header(":status", "" + httpCode),
-        new Header("content-type", "text/plain; charset=utf-8"),
-        new Header("grpc-status", "" + grpcCode.value()),
-        new Header("grpc-message", errorDescription));
+    verifyHttpError(streamId, httpCode, grpcCode, errorDescription, Collections.emptyList());
+  }
+
+  private void verifyHttpError(
+      int streamId, int httpCode, Status.Code grpcCode, String errorDescription,
+      List<Header> extraHeaders) throws Exception {
+    List<Header> responseHeaders = Lists.newArrayList(
+          new Header(":status", "" + httpCode),
+          new Header("content-type", "text/plain; charset=utf-8"),
+          new Header("grpc-status", "" + grpcCode.value()),
+          new Header("grpc-message", errorDescription));
+    responseHeaders.addAll(extraHeaders);
     assertThat(clientFrameReader.nextFrame(clientFramesRead)).isTrue();
     verify(clientFramesRead)
         .headers(false, false, streamId, -1, responseHeaders, HeadersMode.HTTP_20_HEADERS);


### PR DESCRIPTION
fixed:  https://github.com/grpc/grpc-java/issues/12329
Added Allow header on 405
405 response: include Allow: POST
http: added Allow header for 405