### PR TITLE
binder: Fix synchronization instead of suppressing GuardedBy

### DIFF
--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -574,8 +574,7 @@ public abstract class BinderTransport implements IBinder.DeathRecipient {
   }
 
   @VisibleForTesting
-  @SuppressWarnings("GuardedBy")
-  LeakSafeOneWayBinder getIncomingBinderForTesting() {
+  synchronized LeakSafeOneWayBinder getIncomingBinderForTesting() {
     return this.incomingBinder;
   }
 


### PR DESCRIPTION
There's no reason why we shouldn't just have proper synchronization here, even if only used in tests. We shouldn't get into the habit of suppressing them.

CC @kannanjgithub, @jdcormie 