### PR TITLE
SECURITY.md: Mention gcompat for Alpine

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -330,14 +330,10 @@ is an option](#tls-with-conscrypt). Otherwise you need to [build your own 32-bit
 version of
 `netty-tcnative`](https://netty.io/wiki/forked-tomcat-native.html#wiki-h2-6).
 
-If on Alpine Linux and you see "Error loading shared library libcrypt.so.1: No
-such file or directory". Run `apk update && apk add libc6-compat` to install the
-necessary dependency.
-
-If on Alpine Linux, try to use `grpc-netty-shaded` instead of `grpc-netty` or
-(if you need `grpc-netty`) `netty-tcnative-boringssl-static` instead of
-`netty-tcnative`. If those are not an option, you may consider using
-[netty-tcnative-alpine](https://github.com/pires/netty-tcnative-alpine).
+If on Alpine Linux, depending on your specific JDK you may see a crash in
+netty_tcnative. This is generally caused by a missing symbol. Run `apk install
+gcompat` and use the environment variable `LD_PRELOAD=/lib/libgcompat.so.0` when
+executing Java.
 
 If on Fedora 30 or later and you see "libcrypt.so.1: cannot open shared object
 file: No such file or directory". Run `dnf -y install libxcrypt-compat` to


### PR DESCRIPTION
In the olden days Alpine didn't work at all. Then it worked. And then sometime in 2021 it started failing (#8751) because of missing __strndup. The most recent deep investigation showed it is missing __strdup these days https://github.com/grpc/grpc-java/issues/11660#issuecomment-2469284111 .

I'm not expecting too many people to find this themselves, but we can link to it when they experience problems.