### PR TITLE
xds: Remove verify TODO for onResult2 error status

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -331,7 +331,6 @@ final class XdsNameResolver extends NameResolver {
             .setServiceConfig(parsedServiceConfig)
             .build();
     if (!listener.onResult2(result).isOk()) {
-      // TODO: check if this is right
       resolveState.xdsDependencyManager.requestReresolution();
     }
   }


### PR DESCRIPTION
This had been accidentally left in 0c179e3f9.

Requesting a refresh is pretty close to RetryingNameResolver's behavior of exponential backoff. While not identical, it is the closest we can get easily.