### PR TITLE
xds: Make cluster selection interceptor run before other filters

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -525,7 +525,7 @@ final class XdsNameResolver extends NameResolver {
           Result.newBuilder()
               .setConfig(config)
               .setInterceptor(combineInterceptors(
-                  ImmutableList.of(filters, new ClusterSelectionInterceptor())))
+                  ImmutableList.of(new ClusterSelectionInterceptor(), filters)))
               .build();
     }
 


### PR DESCRIPTION
Needed for `GcpAuthenticationFilter` to retrieve the cluster key set into the `CallOptions`.