### PR TITLE
xds: Use `unused` variable to ignore the return value

### DIFF
--- a/xds/src/test/java/io/grpc/xds/internal/security/trust/XdsTrustManagerFactoryTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/trust/XdsTrustManagerFactoryTest.java
@@ -189,7 +189,7 @@ public class XdsTrustManagerFactoryTest {
         new XdsTrustManagerFactory(new X509Certificate[] {x509Cert}, certValidationContext, false);
     XdsX509TrustManager xdsX509TrustManager = (XdsX509TrustManager) factory.getTrustManagers()[0];
     assertThat(xdsX509TrustManager.getAcceptedIssuers()).isNotNull();
-    assertThat(xdsX509TrustManager.getAcceptedIssuers()).hasLength(2);
+    assertThat(xdsX509TrustManager.getAcceptedIssuers()).hasLength(1);
     assertThat(xdsX509TrustManager.getAcceptedIssuers()[0].getIssuerX500Principal().getName())
         .isEqualTo("CN=testca,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU");
     assertThat(xdsX509TrustManager.getAcceptedIssuers()[1].getIssuerX500Principal().getName())

--- a/xds/src/test/java/io/grpc/xds/internal/security/trust/XdsTrustManagerFactoryTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/trust/XdsTrustManagerFactoryTest.java
@@ -185,8 +185,15 @@ public class XdsTrustManagerFactoryTest {
             DataSource.newBuilder().setFilename(TestUtils.loadCert(CA_PEM_FILE).getAbsolutePath()))
         .setSystemRootCerts(CertificateValidationContext.SystemRootCerts.getDefaultInstance())
         .build();
-    new XdsTrustManagerFactory(
-        new X509Certificate[] {x509Cert}, certValidationContext, false);
+    XdsTrustManagerFactory factory =
+        new XdsTrustManagerFactory(new X509Certificate[] {x509Cert}, certValidationContext, false);
+    XdsX509TrustManager xdsX509TrustManager = (XdsX509TrustManager) factory.getTrustManagers()[0];
+    assertThat(xdsX509TrustManager.getAcceptedIssuers()).isNotNull();
+    assertThat(xdsX509TrustManager.getAcceptedIssuers()).hasLength(2);
+    assertThat(xdsX509TrustManager.getAcceptedIssuers()[0].getIssuerX500Principal().getName())
+        .isEqualTo("CN=testca,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU");
+    assertThat(xdsX509TrustManager.getAcceptedIssuers()[1].getIssuerX500Principal().getName())
+        .isEqualTo("CN=testca,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU");
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/internal/security/trust/XdsTrustManagerFactoryTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/trust/XdsTrustManagerFactoryTest.java
@@ -185,15 +185,8 @@ public class XdsTrustManagerFactoryTest {
             DataSource.newBuilder().setFilename(TestUtils.loadCert(CA_PEM_FILE).getAbsolutePath()))
         .setSystemRootCerts(CertificateValidationContext.SystemRootCerts.getDefaultInstance())
         .build();
-    XdsTrustManagerFactory factory =
+    XdsTrustManagerFactory unused =
         new XdsTrustManagerFactory(new X509Certificate[] {x509Cert}, certValidationContext, false);
-    XdsX509TrustManager xdsX509TrustManager = (XdsX509TrustManager) factory.getTrustManagers()[0];
-    assertThat(xdsX509TrustManager.getAcceptedIssuers()).isNotNull();
-    assertThat(xdsX509TrustManager.getAcceptedIssuers()).hasLength(1);
-    assertThat(xdsX509TrustManager.getAcceptedIssuers()[0].getIssuerX500Principal().getName())
-        .isEqualTo("CN=testca,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU");
-    assertThat(xdsX509TrustManager.getAcceptedIssuers()[1].getIssuerX500Principal().getName())
-        .isEqualTo("CN=testca,O=Internet Widgits Pty Ltd,ST=Some-State,C=AU");
   }
 
   @Test


### PR DESCRIPTION
Internal: cl/813142534