### PR TITLE
stub: remove interrupt checking from ThreadSafeThreadlessExecutor.drain (1.76.x backport)

### DIFF
--- a/stub/src/main/java/io/grpc/stub/BlockingClientCall.java
+++ b/stub/src/main/java/io/grpc/stub/BlockingClientCall.java
@@ -273,7 +273,7 @@ public final class BlockingClientCall<ReqT, RespT> {
    */
   @VisibleForTesting
   Status getClosedStatus() {
-    drainQuietly();
+    executor.drain();
     CloseState state = closeState.get();
     return (state == null) ? null : state.status;
   }
@@ -295,7 +295,7 @@ public final class BlockingClientCall<ReqT, RespT> {
    */
   @VisibleForTesting
   boolean isReadReady() {
-    drainQuietly();
+    executor.drain();
 
     return !buffer.isEmpty();
   }
@@ -308,7 +308,7 @@ public final class BlockingClientCall<ReqT, RespT> {
    */
   @VisibleForTesting
   boolean isWriteReady() {
-    drainQuietly();
+    executor.drain();
 
     return isWriteLegal() && call.isReady();
   }
@@ -323,14 +323,6 @@ public final class BlockingClientCall<ReqT, RespT> {
 
   ClientCall.Listener<RespT> getListener() {
     return new QueuingListener();
-  }
-
-  private void drainQuietly() {
-    try {
-      executor.drain();
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-    }
   }
 
   private final class QueuingListener extends ClientCall.Listener<RespT> {

--- a/stub/src/main/java/io/grpc/stub/ClientCalls.java
+++ b/stub/src/main/java/io/grpc/stub/ClientCalls.java
@@ -935,11 +935,8 @@ public final class ClientCalls {
       }
     }
 
-    /**
-     * Executes all queued Runnables and if there were any wakes up any waiting threads.
-     */
-    public void drain() throws InterruptedException {
-      throwIfInterrupted();
+    /** Executes all queued Runnables and if there were any wakes up any waiting threads. */
+    void drain() {
       Runnable runnable;
       boolean didWork = false;
 


### PR DESCRIPTION
The only caller of `drain()` just reset the interrupt flag. So, we can avoid the whole exception dance.

Backport of #12358

CC @benjaminp, FYI