### PR TITLE
Implement otel retry metrics (v1.76.x backport)

### DIFF
--- a/api/src/main/java/io/grpc/ClientStreamTracer.java
+++ b/api/src/main/java/io/grpc/ClientStreamTracer.java
@@ -132,12 +132,15 @@ public abstract class ClientStreamTracer extends StreamTracer {
     private final CallOptions callOptions;
     private final int previousAttempts;
     private final boolean isTransparentRetry;
+    private final boolean isHedging;
 
     StreamInfo(
-        CallOptions callOptions, int previousAttempts, boolean isTransparentRetry) {
+        CallOptions callOptions, int previousAttempts, boolean isTransparentRetry,
+        boolean isHedging) {
       this.callOptions = checkNotNull(callOptions, "callOptions");
       this.previousAttempts = previousAttempts;
       this.isTransparentRetry = isTransparentRetry;
+      this.isHedging = isHedging;
     }
 
     /**
@@ -166,6 +169,15 @@ public abstract class ClientStreamTracer extends StreamTracer {
     }
 
     /**
+     * Whether the stream is hedging.
+     *
+     * @since 1.74.0
+     */
+    public boolean isHedging() {
+      return isHedging;
+    }
+
+    /**
      * Converts this StreamInfo into a new Builder.
      *
      * @since 1.21.0
@@ -174,7 +186,9 @@ public abstract class ClientStreamTracer extends StreamTracer {
       return new Builder()
           .setCallOptions(callOptions)
           .setPreviousAttempts(previousAttempts)
-          .setIsTransparentRetry(isTransparentRetry);
+          .setIsTransparentRetry(isTransparentRetry)
+          .setIsHedging(isHedging);
+
     }
 
     /**
@@ -192,6 +206,7 @@ public abstract class ClientStreamTracer extends StreamTracer {
           .add("callOptions", callOptions)
           .add("previousAttempts", previousAttempts)
           .add("isTransparentRetry", isTransparentRetry)
+          .add("isHedging", isHedging)
           .toString();
     }
 
@@ -204,6 +219,7 @@ public abstract class ClientStreamTracer extends StreamTracer {
       private CallOptions callOptions = CallOptions.DEFAULT;
       private int previousAttempts;
       private boolean isTransparentRetry;
+      private boolean isHedging;
 
       Builder() {
       }
@@ -237,10 +253,20 @@ public abstract class ClientStreamTracer extends StreamTracer {
       }
 
       /**
+       * Sets whether the stream is hedging.
+       *
+       * @since 1.74.0
+       */
+      public Builder setIsHedging(boolean isHedging) {
+        this.isHedging = isHedging;
+        return this;
+      }
+
+      /**
        * Builds a new StreamInfo.
        */
       public StreamInfo build() {
-        return new StreamInfo(callOptions, previousAttempts, isTransparentRetry);
+        return new StreamInfo(callOptions, previousAttempts, isTransparentRetry, isHedging);
       }
     }
   }

--- a/core/src/main/java/io/grpc/internal/ClientCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ClientCallImpl.java
@@ -250,7 +250,8 @@ final class ClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
       stream = clientStreamProvider.newStream(method, callOptions, headers, context);
     } else {
       ClientStreamTracer[] tracers =
-          GrpcUtil.getClientStreamTracers(callOptions, headers, 0, false);
+          GrpcUtil.getClientStreamTracers(callOptions, headers, 0,
+              false, false);
       String deadlineName = contextIsDeadlineSource ? "Context" : "CallOptions";
       Long nameResolutionDelay = callOptions.getOption(NAME_RESOLUTION_DELAYED);
       String description = String.format(

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -759,13 +759,15 @@ public final class GrpcUtil {
 
   /** Gets stream tracers based on CallOptions. */
   public static ClientStreamTracer[] getClientStreamTracers(
-      CallOptions callOptions, Metadata headers, int previousAttempts, boolean isTransparentRetry) {
+      CallOptions callOptions, Metadata headers, int previousAttempts, boolean isTransparentRetry,
+      boolean isHedging) {
     List<ClientStreamTracer.Factory> factories = callOptions.getStreamTracerFactories();
     ClientStreamTracer[] tracers = new ClientStreamTracer[factories.size() + 1];
     StreamInfo streamInfo = StreamInfo.newBuilder()
         .setCallOptions(callOptions)
         .setPreviousAttempts(previousAttempts)
         .setIsTransparentRetry(isTransparentRetry)
+        .setIsHedging(isHedging)
         .build();
     for (int i = 0; i < factories.size(); i++) {
       tracers[i] = factories.get(i).newClientStreamTracer(streamInfo, headers);

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -479,7 +479,8 @@ final class ManagedChannelImpl extends ManagedChannel implements
       // the delayed transport or a real transport will go in-use and cancel the idle timer.
       if (!retryEnabled) {
         ClientStreamTracer[] tracers = GrpcUtil.getClientStreamTracers(
-            callOptions, headers, 0, /* isTransparentRetry= */ false);
+            callOptions, headers, 0, /* isTransparentRetry= */ false,
+            /* isHedging= */false);
         Context origContext = context.attach();
         try {
           return delayedTransport.newStream(method, headers, callOptions, tracers);
@@ -519,10 +520,10 @@ final class ManagedChannelImpl extends ManagedChannel implements
           @Override
           ClientStream newSubstream(
               Metadata newHeaders, ClientStreamTracer.Factory factory, int previousAttempts,
-              boolean isTransparentRetry) {
+              boolean isTransparentRetry, boolean isHedgedStream) {
             CallOptions newOptions = callOptions.withStreamTracerFactory(factory);
             ClientStreamTracer[] tracers = GrpcUtil.getClientStreamTracers(
-                newOptions, newHeaders, previousAttempts, isTransparentRetry);
+                newOptions, newHeaders, previousAttempts, isTransparentRetry, isHedgedStream);
             Context origContext = context.attach();
             try {
               return delayedTransport.newStream(method, newHeaders, newOptions, tracers);

--- a/core/src/main/java/io/grpc/internal/OobChannel.java
+++ b/core/src/main/java/io/grpc/internal/OobChannel.java
@@ -88,7 +88,8 @@ final class OobChannel extends ManagedChannel implements InternalInstrumented<Ch
     public ClientStream newStream(MethodDescriptor<?, ?> method,
         CallOptions callOptions, Metadata headers, Context context) {
       ClientStreamTracer[] tracers = GrpcUtil.getClientStreamTracers(
-          callOptions, headers, 0, /* isTransparentRetry= */ false);
+          callOptions, headers, 0, /* isTransparentRetry= */ false,
+          /* isHedging= */ false);
       Context origContext = context.attach();
       // delayed transport's newStream() always acquires a lock, but concurrent performance doesn't
       // matter here because OOB communication should be sparse, and it's not on application RPC's

--- a/core/src/main/java/io/grpc/internal/SubchannelChannel.java
+++ b/core/src/main/java/io/grpc/internal/SubchannelChannel.java
@@ -59,7 +59,8 @@ final class SubchannelChannel extends Channel {
           transport = notReadyTransport;
         }
         ClientStreamTracer[] tracers = GrpcUtil.getClientStreamTracers(
-            callOptions, headers, 0, /* isTransparentRetry= */ false);
+            callOptions, headers, 0, /* isTransparentRetry= */ false,
+            /* isHedging= */ false);
         Context origContext = context.attach();
         try {
           return transport.newStream(method, headers, callOptions, tracers);

--- a/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/RetriableStreamTest.java
@@ -186,7 +186,8 @@ public class RetriableStreamTest {
         Metadata metadata,
         ClientStreamTracer.Factory tracerFactory,
         int previousAttempts,
-        boolean isTransparentRetry) {
+        boolean isTransparentRetry,
+        boolean isHedgedStream) {
       bufferSizeTracer =
           tracerFactory.newClientStreamTracer(STREAM_INFO, metadata);
       int actualPreviousRpcAttemptsInHeader = metadata.get(GRPC_PREVIOUS_RPC_ATTEMPTS) == null

--- a/opentelemetry/src/main/java/io/grpc/opentelemetry/OpenTelemetryMetricsResource.java
+++ b/opentelemetry/src/main/java/io/grpc/opentelemetry/OpenTelemetryMetricsResource.java
@@ -41,6 +41,17 @@ abstract class OpenTelemetryMetricsResource {
   @Nullable
   abstract LongHistogram clientTotalReceivedCompressedMessageSizeCounter();
 
+  @Nullable
+  abstract LongHistogram clientCallRetriesCounter();
+
+  @Nullable
+  abstract LongHistogram clientCallTransparentRetriesCounter();
+
+  @Nullable
+  abstract LongHistogram clientCallHedgesCounter();
+
+  @Nullable
+  abstract DoubleHistogram clientCallRetryDelayCounter();
 
   /* Server Metrics */
   @Nullable
@@ -72,6 +83,14 @@ abstract class OpenTelemetryMetricsResource {
 
     abstract Builder clientTotalReceivedCompressedMessageSizeCounter(
         LongHistogram counter);
+
+    abstract Builder clientCallRetriesCounter(LongHistogram counter);
+
+    abstract Builder clientCallTransparentRetriesCounter(LongHistogram counter);
+
+    abstract Builder clientCallHedgesCounter(LongHistogram counter);
+
+    abstract Builder clientCallRetryDelayCounter(DoubleHistogram counter);
 
     abstract Builder serverCallCountCounter(LongCounter counter);
 

--- a/opentelemetry/src/main/java/io/grpc/opentelemetry/internal/OpenTelemetryConstants.java
+++ b/opentelemetry/src/main/java/io/grpc/opentelemetry/internal/OpenTelemetryConstants.java
@@ -55,6 +55,13 @@ public final class OpenTelemetryConstants {
           0L, 1024L, 2048L, 4096L, 16384L, 65536L, 262144L, 1048576L, 4194304L, 16777216L,
           67108864L, 268435456L, 1073741824L, 4294967296L);
 
+  public static final List<Long> RETRY_BUCKETS = ImmutableList.of(1L, 2L, 3L, 4L, 5L);
+
+  public static final List<Long> TRANSPARENT_RETRY_BUCKETS =
+      ImmutableList.of(1L, 2L, 3L, 4L, 5L, 10L);
+
+  public static final List<Long> HEDGE_BUCKETS = ImmutableList.of(1L, 2L, 3L, 4L, 5L);
+
   private OpenTelemetryConstants() {
   }
 }

--- a/opentelemetry/src/test/java/io/grpc/opentelemetry/OpenTelemetryMetricsModuleTest.java
+++ b/opentelemetry/src/test/java/io/grpc/opentelemetry/OpenTelemetryMetricsModuleTest.java
@@ -54,11 +54,14 @@ import io.grpc.testing.GrpcServerRule;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
+import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
@@ -94,6 +97,11 @@ public class OpenTelemetryMetricsModuleTest {
   private static final String CLIENT_ATTEMPT_RECV_TOTAL_COMPRESSED_MESSAGE_SIZE
       = "grpc.client.attempt.rcvd_total_compressed_message_size";
   private static final String CLIENT_CALL_DURATION = "grpc.client.call.duration";
+  private static final String CLIENT_CALL_RETRIES = "grpc.client.call.retries";
+  private static final String CLIENT_CALL_TRANSPARENT_RETRIES =
+      "grpc.client.call.transparent_retries";
+  private static final String CLIENT_CALL_HEDGES = "grpc.client.call.hedges";
+  private static final String CLIENT_CALL_RETRY_DELAY = "grpc.client.call.retry_delay";
   private static final String SERVER_CALL_COUNT = "grpc.server.call.started";
   private static final String SERVER_CALL_DURATION = "grpc.server.call.duration";
   private static final String SERVER_CALL_SENT_TOTAL_COMPRESSED_MESSAGE_SIZE
@@ -194,7 +202,7 @@ public class OpenTelemetryMetricsModuleTest {
             }).build());
 
     final AtomicReference<CallOptions> capturedCallOptions = new AtomicReference<>();
-    ClientInterceptor callOptionsCatureInterceptor = new ClientInterceptor() {
+    ClientInterceptor callOptionsCaptureInterceptor = new ClientInterceptor() {
       @Override
       public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
           MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
@@ -204,7 +212,7 @@ public class OpenTelemetryMetricsModuleTest {
     };
     Channel interceptedChannel =
         ClientInterceptors.intercept(
-            grpcServerRule.getChannel(), callOptionsCatureInterceptor,
+            grpcServerRule.getChannel(), callOptionsCaptureInterceptor,
             module.getClientInterceptor("target:///"));
     ClientCall<String, String> call;
     call = interceptedChannel.newCall(method, CALL_OPTIONS);
@@ -378,6 +386,88 @@ public class OpenTelemetryMetricsModuleTest {
                                         .hasBucketCounts(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0,
                                             0, 0, 0, 0, 0, 0, 0, 0, 0))));
+
+    assertThat(openTelemetryTesting.getMetrics())
+        .extracting("name")
+        .doesNotContain(
+            CLIENT_CALL_RETRIES,
+            CLIENT_CALL_TRANSPARENT_RETRIES,
+            CLIENT_CALL_HEDGES,
+            CLIENT_CALL_RETRY_DELAY);
+  }
+
+  @Test
+  public void clientBasicMetrics_withRetryMetricsEnabled_shouldRecordZeroOrBeAbsent() {
+    // Explicitly enable the retry metrics
+    Map<String, Boolean> enabledMetrics = ImmutableMap.of(
+        CLIENT_CALL_RETRIES, true,
+        CLIENT_CALL_TRANSPARENT_RETRIES, true,
+        CLIENT_CALL_HEDGES, true,
+        CLIENT_CALL_RETRY_DELAY, true
+    );
+
+    String target = "target:///";
+    OpenTelemetryMetricsResource resource = GrpcOpenTelemetry.createMetricInstruments(testMeter,
+        enabledMetrics, disableDefaultMetrics);
+    OpenTelemetryMetricsModule module = newOpenTelemetryMetricsModule(resource);
+    OpenTelemetryMetricsModule.CallAttemptsTracerFactory callAttemptsTracerFactory =
+        new CallAttemptsTracerFactory(module, target, method.getFullMethodName(), emptyList());
+    ClientStreamTracer tracer =
+        callAttemptsTracerFactory.newClientStreamTracer(STREAM_INFO, new Metadata());
+
+    fakeClock.forwardTime(30, TimeUnit.MILLISECONDS);
+    tracer.outboundHeaders();
+    fakeClock.forwardTime(100, TimeUnit.MILLISECONDS);
+    tracer.outboundMessage(0);
+    tracer.streamClosed(Status.OK);
+    callAttemptsTracerFactory.callEnded(Status.OK);
+
+    io.opentelemetry.api.common.Attributes finalAttributes
+        = io.opentelemetry.api.common.Attributes.of(
+        TARGET_KEY, target,
+        METHOD_KEY, method.getFullMethodName());
+
+    assertThat(openTelemetryTesting.getMetrics())
+        .satisfiesExactlyInAnyOrder(
+            metric -> assertThat(metric).hasName(CLIENT_ATTEMPT_COUNT_INSTRUMENT_NAME),
+            metric -> assertThat(metric).hasName(CLIENT_ATTEMPT_DURATION_INSTRUMENT_NAME),
+            metric -> assertThat(metric).hasName(CLIENT_ATTEMPT_SENT_TOTAL_COMPRESSED_MESSAGE_SIZE),
+            metric -> assertThat(metric).hasName(CLIENT_ATTEMPT_RECV_TOTAL_COMPRESSED_MESSAGE_SIZE),
+            metric -> assertThat(metric).hasName(CLIENT_CALL_DURATION),
+            metric -> assertThat(metric)
+                .hasName(CLIENT_CALL_RETRY_DELAY)
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasSum(0)
+                                    .hasCount(1)
+                                    .hasAttributes(finalAttributes)))
+
+        );
+
+    List<String> optionalMetricNames = Arrays.asList(
+        CLIENT_CALL_RETRIES,
+        CLIENT_CALL_TRANSPARENT_RETRIES,
+        CLIENT_CALL_HEDGES);
+
+    for (String metricName : optionalMetricNames) {
+      Optional<MetricData> metric = openTelemetryTesting.getMetrics().stream()
+          .filter(m -> m.getName().equals(metricName))
+          .findFirst();
+      if (metric.isPresent()) {
+        assertThat(metric.get())
+            .hasHistogramSatisfying(
+                histogram ->
+                    histogram.hasPointsSatisfying(
+                        point ->
+                            point
+                                .hasSum(0)
+                                .hasCount(1)
+                                .hasAttributes(finalAttributes)));
+      }
+    }
   }
 
   // This test is only unit-testing the metrics recording logic. The retry behavior is faked.
@@ -829,6 +919,182 @@ public class OpenTelemetryMetricsModuleTest {
                                             .hasSum(33D)
                                             .hasAttributes(clientAttributes2)
                                             .hasBucketBoundaries(sizeBuckets))));
+  }
+
+  @Test
+  public void recordAttemptMetrics_withRetryMetricsEnabled() {
+    Map<String, Boolean> enabledMetrics = ImmutableMap.of(
+        CLIENT_CALL_RETRIES, true,
+        CLIENT_CALL_TRANSPARENT_RETRIES, true,
+        CLIENT_CALL_HEDGES, true,
+        CLIENT_CALL_RETRY_DELAY, true
+    );
+
+    String target = "dns:///example.com";
+    OpenTelemetryMetricsResource resource = GrpcOpenTelemetry.createMetricInstruments(testMeter,
+        enabledMetrics, disableDefaultMetrics);
+    OpenTelemetryMetricsModule module = newOpenTelemetryMetricsModule(resource);
+    OpenTelemetryMetricsModule.CallAttemptsTracerFactory callAttemptsTracerFactory =
+        new OpenTelemetryMetricsModule.CallAttemptsTracerFactory(module, target,
+            method.getFullMethodName(), emptyList());
+
+    ClientStreamTracer tracer =
+        callAttemptsTracerFactory.newClientStreamTracer(STREAM_INFO, new Metadata());
+    fakeClock.forwardTime(154, TimeUnit.MILLISECONDS);
+    tracer.streamClosed(Status.UNAVAILABLE);
+
+    fakeClock.forwardTime(1000, TimeUnit.MILLISECONDS);
+    tracer = callAttemptsTracerFactory.newClientStreamTracer(STREAM_INFO, new Metadata());
+    fakeClock.forwardTime(100, TimeUnit.MILLISECONDS);
+    tracer.streamClosed(Status.NOT_FOUND);
+
+    fakeClock.forwardTime(10, TimeUnit.MILLISECONDS);
+    tracer = callAttemptsTracerFactory.newClientStreamTracer(
+        STREAM_INFO.toBuilder().setIsTransparentRetry(true).build(), new Metadata());
+    fakeClock.forwardTime(32, MILLISECONDS);
+    tracer.streamClosed(Status.UNAVAILABLE);
+
+    fakeClock.forwardTime(10, MILLISECONDS);
+    tracer = callAttemptsTracerFactory.newClientStreamTracer(
+        STREAM_INFO.toBuilder().setIsTransparentRetry(true).build(), new Metadata());
+    tracer.inboundWireSize(33);
+    fakeClock.forwardTime(24, MILLISECONDS);
+    tracer.streamClosed(Status.OK); // RPC succeeded
+
+    // --- The overall call ends ---
+    callAttemptsTracerFactory.callEnded(Status.OK);
+
+    // Define attributes for assertions
+    io.opentelemetry.api.common.Attributes finalAttributes
+        = io.opentelemetry.api.common.Attributes.of(
+        TARGET_KEY, target,
+        METHOD_KEY, method.getFullMethodName());
+
+    // FINAL ASSERTION BLOCK
+    assertThat(openTelemetryTesting.getMetrics())
+        .satisfiesExactlyInAnyOrder(
+            // Default metrics
+            metric -> assertThat(metric).hasName(CLIENT_ATTEMPT_COUNT_INSTRUMENT_NAME),
+            metric -> assertThat(metric).hasName(CLIENT_ATTEMPT_DURATION_INSTRUMENT_NAME),
+            metric -> assertThat(metric).hasName(CLIENT_ATTEMPT_SENT_TOTAL_COMPRESSED_MESSAGE_SIZE),
+            metric -> assertThat(metric).hasName(CLIENT_ATTEMPT_RECV_TOTAL_COMPRESSED_MESSAGE_SIZE),
+            metric -> assertThat(metric).hasName(CLIENT_CALL_DURATION),
+
+            // --- Assertions for the retry metrics ---
+            metric -> assertThat(metric)
+                .hasName(CLIENT_CALL_RETRIES)
+                .hasUnit("{retry}")
+                .hasHistogramSatisfying(histogram -> histogram.hasPointsSatisfying(
+                    point -> point
+                        .hasCount(1)
+                        .hasSum(1) // We faked one standard retry
+                        .hasAttributes(finalAttributes))),
+            metric -> assertThat(metric)
+                .hasName(CLIENT_CALL_TRANSPARENT_RETRIES)
+                .hasUnit("{transparent_retry}")
+                .hasHistogramSatisfying(histogram -> histogram.hasPointsSatisfying(
+                    point -> point
+                        .hasCount(1)
+                        .hasSum(2) // We faked two transparent retries
+                        .hasAttributes(finalAttributes))),
+            metric -> assertThat(metric)
+                .hasName(CLIENT_CALL_RETRY_DELAY)
+                .hasUnit("s")
+                .hasHistogramSatisfying(histogram -> histogram.hasPointsSatisfying(
+                    point -> point
+                        .hasCount(1)
+                        .hasSum(1.02) // 1000ms + 10ms + 10ms
+                        .hasAttributes(finalAttributes)))
+        );
+  }
+
+  @Test
+  public void recordAttemptMetrics_withHedgedCalls() {
+    // Enable the retry metrics, including hedges
+    Map<String, Boolean> enabledMetrics = ImmutableMap.of(
+        CLIENT_CALL_RETRIES, true,
+        CLIENT_CALL_TRANSPARENT_RETRIES, true,
+        CLIENT_CALL_HEDGES, true,
+        CLIENT_CALL_RETRY_DELAY, true
+    );
+
+    String target = "dns:///example.com";
+    OpenTelemetryMetricsResource resource = GrpcOpenTelemetry.createMetricInstruments(testMeter,
+        enabledMetrics, disableDefaultMetrics);
+    OpenTelemetryMetricsModule module = newOpenTelemetryMetricsModule(resource);
+    OpenTelemetryMetricsModule.CallAttemptsTracerFactory callAttemptsTracerFactory =
+        new OpenTelemetryMetricsModule.CallAttemptsTracerFactory(module, target,
+            method.getFullMethodName(), emptyList());
+
+    // Create a StreamInfo specifically for hedged attempts
+    final ClientStreamTracer.StreamInfo hedgedStreamInfo =
+        STREAM_INFO.toBuilder().setIsHedging(true).build();
+
+    // --- First attempt starts ---
+    ClientStreamTracer tracer =
+        callAttemptsTracerFactory.newClientStreamTracer(STREAM_INFO, new Metadata());
+
+    // --- Faking a hedged attempt ---
+    fakeClock.forwardTime(10, TimeUnit.MILLISECONDS); // Hedging delay
+    ClientStreamTracer hedgeTracer1 =
+        callAttemptsTracerFactory.newClientStreamTracer(hedgedStreamInfo, new Metadata());
+
+    // --- Faking a second hedged attempt ---
+    fakeClock.forwardTime(20, TimeUnit.MILLISECONDS); // Another hedging delay
+    ClientStreamTracer hedgeTracer2 =
+        callAttemptsTracerFactory.newClientStreamTracer(hedgedStreamInfo, new Metadata());
+
+    // --- Let the attempts resolve ---
+    fakeClock.forwardTime(50, TimeUnit.MILLISECONDS);
+    // Initial attempt is cancelled because a hedge will succeed
+    tracer.streamClosed(Status.CANCELLED);
+    hedgeTracer1.streamClosed(Status.UNAVAILABLE); // First hedge fails
+
+    fakeClock.forwardTime(30, TimeUnit.MILLISECONDS);
+    hedgeTracer2.streamClosed(Status.OK); // Second hedge succeeds
+
+    // --- The overall call ends ---
+    callAttemptsTracerFactory.callEnded(Status.OK);
+
+    // Define attributes for assertions
+    io.opentelemetry.api.common.Attributes finalAttributes
+        = io.opentelemetry.api.common.Attributes.of(
+        TARGET_KEY, target,
+        METHOD_KEY, method.getFullMethodName());
+
+    // FINAL ASSERTION BLOCK
+    // We expect 7 metrics: 5 default + hedges + retry_delay.
+    // Retries and transparent_retries are 0 and will not be reported.
+    assertThat(openTelemetryTesting.getMetrics())
+        .satisfiesExactlyInAnyOrder(
+            // Default metrics
+            metric -> assertThat(metric).hasName(CLIENT_ATTEMPT_COUNT_INSTRUMENT_NAME),
+            metric -> assertThat(metric).hasName(CLIENT_ATTEMPT_DURATION_INSTRUMENT_NAME),
+            metric -> assertThat(metric).hasName(CLIENT_ATTEMPT_SENT_TOTAL_COMPRESSED_MESSAGE_SIZE),
+            metric -> assertThat(metric).hasName(CLIENT_ATTEMPT_RECV_TOTAL_COMPRESSED_MESSAGE_SIZE),
+            metric -> assertThat(metric).hasName(CLIENT_CALL_DURATION),
+
+            // --- Assertions for the NEW metrics ---
+            metric -> assertThat(metric)
+                .hasName(CLIENT_CALL_HEDGES)
+                .hasUnit("{hedge}")
+                .hasHistogramSatisfying(histogram -> histogram.hasPointsSatisfying(
+                    point -> point
+                        .hasCount(1)
+                        .hasSum(2)
+                        .hasAttributes(finalAttributes))),
+            metric -> assertThat(metric)
+                .hasName(CLIENT_CALL_RETRY_DELAY)
+                .hasUnit("s")
+                .hasHistogramSatisfying(
+                    histogram ->
+                        histogram.hasPointsSatisfying(
+                            point ->
+                                point
+                                    .hasCount(1)
+                                    .hasSum(0)
+                                    .hasAttributes(finalAttributes)))
+        );
   }
 
   @Test


### PR DESCRIPTION
Backport of #12064 to v1.76.x.
---
implements [A96](https://github.com/grpc/proposal/pull/488/files)
