### PR TITLE
binder: Introduce server authorization strategy v2

### DIFF
--- a/binder/src/main/java/io/grpc/binder/internal/Bindable.java
+++ b/binder/src/main/java/io/grpc/binder/internal/Bindable.java
@@ -54,8 +54,11 @@ interface Bindable {
    * before giving them a chance to run. However, note that the identity/existence of the resolved
    * Service can change between the time this method returns and the time you actually bind/connect
    * to it. For example, suppose the target package gets uninstalled or upgraded right after this
-   * method returns. In {@link Observer#onBound}, you should verify that the server you resolved is
-   * the same one you connected to.
+   * method returns.
+   *
+   * <p>Compare with {@link #getConnectedServiceInfo()}, which can only be called after {@link
+   * Observer#onBound(IBinder)} but can be used to learn about the service you actually connected
+   * to.
    */
   @AnyThread
   ServiceInfo resolve() throws StatusException;
@@ -67,6 +70,21 @@ interface Bindable {
    */
   @AnyThread
   void bind();
+
+  /**
+   * Asks PackageManager for details about the remote Service we *actually* connected to.
+   *
+   * <p>Can only be called after {@link Observer#onBound}.
+   *
+   * <p>Compare with {@link #resolve()}, which reports which service would be selected as of now but
+   * *without* connecting.
+   *
+   * @throws StatusException UNIMPLEMENTED if the connected service isn't found (an {@link
+   *     Observer#onUnbound} callback has likely already happened or is on its way!)
+   * @throws IllegalStateException if {@link Observer#onBound} has not "happened-before" this call
+   */
+  @AnyThread
+  ServiceInfo getConnectedServiceInfo() throws StatusException;
 
   /**
    * Unbind from the remote service if connected.

--- a/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderClientTransportFactory.java
@@ -53,6 +53,7 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
   final OneWayBinderProxy.Decorator binderDecorator;
   final long readyTimeoutMillis;
   final boolean preAuthorizeServers; // TODO(jdcormie): Default to true.
+  final boolean useLegacyAuthStrategy;
 
   ScheduledExecutorService executorService;
   Executor offloadExecutor;
@@ -73,6 +74,7 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
     binderDecorator = checkNotNull(builder.binderDecorator);
     readyTimeoutMillis = builder.readyTimeoutMillis;
     preAuthorizeServers = builder.preAuthorizeServers;
+    useLegacyAuthStrategy = builder.useLegacyAuthStrategy;
 
     executorService = scheduledExecutorPool.getObject();
     offloadExecutor = offloadExecutorPool.getObject();
@@ -126,6 +128,7 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
     OneWayBinderProxy.Decorator binderDecorator = OneWayBinderProxy.IDENTITY_DECORATOR;
     long readyTimeoutMillis = 60_000;
     boolean preAuthorizeServers;
+    boolean useLegacyAuthStrategy = true; // TODO(jdcormie): Default to false.
 
     @Override
     public BinderClientTransportFactory buildClientTransportFactory() {
@@ -217,6 +220,12 @@ public final class BinderClientTransportFactory implements ClientTransportFactor
     /** Whether to check server addresses against the SecurityPolicy *before* binding to them. */
     public Builder setPreAuthorizeServers(boolean preAuthorizeServers) {
       this.preAuthorizeServers = preAuthorizeServers;
+      return this;
+    }
+
+    /** Specifies which version of the client handshake to use. */
+    public Builder setUseLegacyAuthStrategy(boolean useLegacyAuthStrategy) {
+      this.useLegacyAuthStrategy = useLegacyAuthStrategy;
       return this;
     }
   }


### PR DESCRIPTION
Adds support for `android:isolatedProcess` Services (fixing #12293) and moves all security checks to the handshake, making subsequent transactions more efficient.
