### PR TITLE
Trigger R8's ServiceLoader optimization

### DIFF
--- a/api/src/main/java/io/grpc/InternalServiceProviders.java
+++ b/api/src/main/java/io/grpc/InternalServiceProviders.java
@@ -38,7 +38,7 @@ public final class InternalServiceProviders {
     return loadAll(
         klass,
         ServiceLoader.load(klass, classLoader).iterator(),
-        hardCodedClasses,
+        () -> hardCodedClasses,
         priorityAccessor);
   }
 
@@ -48,9 +48,9 @@ public final class InternalServiceProviders {
   public static <T> List<T> loadAll(
       Class<T> klass,
       Iterator<T> serviceLoader,
-      Iterable<Class<?>> hardCodedClasses,
+      Supplier<Iterable<Class<?>>> hardCodedClasses,
       PriorityAccessor<T> priorityAccessor) {
-    return ServiceProviders.loadAll(klass, serviceLoader, hardCodedClasses, priorityAccessor);
+    return ServiceProviders.loadAll(klass, serviceLoader, hardCodedClasses::get, priorityAccessor);
   }
 
   /**
@@ -78,4 +78,8 @@ public final class InternalServiceProviders {
   }
 
   public interface PriorityAccessor<T> extends ServiceProviders.PriorityAccessor<T> {}
+
+  public interface Supplier<T> {
+    T get();
+  }
 }

--- a/api/src/main/java/io/grpc/InternalServiceProviders.java
+++ b/api/src/main/java/io/grpc/InternalServiceProviders.java
@@ -17,7 +17,9 @@
 package io.grpc;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.util.Iterator;
 import java.util.List;
+import java.util.ServiceLoader;
 
 @Internal
 public final class InternalServiceProviders {
@@ -27,12 +29,28 @@ public final class InternalServiceProviders {
   /**
    * Accessor for method.
    */
+  @Deprecated
   public static <T> List<T> loadAll(
       Class<T> klass,
       Iterable<Class<?>> hardCodedClasses,
       ClassLoader classLoader,
       PriorityAccessor<T> priorityAccessor) {
-    return ServiceProviders.loadAll(klass, hardCodedClasses, classLoader, priorityAccessor);
+    return loadAll(
+        klass,
+        ServiceLoader.load(klass, classLoader).iterator(),
+        hardCodedClasses,
+        priorityAccessor);
+  }
+
+  /**
+   * Accessor for method.
+   */
+  public static <T> List<T> loadAll(
+      Class<T> klass,
+      Iterator<T> serviceLoader,
+      Iterable<Class<?>> hardCodedClasses,
+      PriorityAccessor<T> priorityAccessor) {
+    return ServiceProviders.loadAll(klass, serviceLoader, hardCodedClasses, priorityAccessor);
   }
 
   /**

--- a/api/src/main/java/io/grpc/LoadBalancerRegistry.java
+++ b/api/src/main/java/io/grpc/LoadBalancerRegistry.java
@@ -26,6 +26,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.ServiceLoader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
@@ -101,8 +102,10 @@ public final class LoadBalancerRegistry {
     if (instance == null) {
       List<LoadBalancerProvider> providerList = ServiceProviders.loadAll(
           LoadBalancerProvider.class,
+          ServiceLoader
+            .load(LoadBalancerProvider.class, LoadBalancerProvider.class.getClassLoader())
+            .iterator(),
           HARDCODED_CLASSES,
-          LoadBalancerProvider.class.getClassLoader(),
           new LoadBalancerPriorityAccessor());
       instance = new LoadBalancerRegistry();
       for (LoadBalancerProvider provider : providerList) {

--- a/api/src/main/java/io/grpc/LoadBalancerRegistry.java
+++ b/api/src/main/java/io/grpc/LoadBalancerRegistry.java
@@ -43,7 +43,6 @@ import javax.annotation.concurrent.ThreadSafe;
 public final class LoadBalancerRegistry {
   private static final Logger logger = Logger.getLogger(LoadBalancerRegistry.class.getName());
   private static LoadBalancerRegistry instance;
-  private static final Iterable<Class<?>> HARDCODED_CLASSES = getHardCodedClasses();
 
   private final LinkedHashSet<LoadBalancerProvider> allProviders =
       new LinkedHashSet<>();
@@ -105,7 +104,7 @@ public final class LoadBalancerRegistry {
           ServiceLoader
             .load(LoadBalancerProvider.class, LoadBalancerProvider.class.getClassLoader())
             .iterator(),
-          HARDCODED_CLASSES,
+          LoadBalancerRegistry::getHardCodedClasses,
           new LoadBalancerPriorityAccessor());
       instance = new LoadBalancerRegistry();
       for (LoadBalancerProvider provider : providerList) {

--- a/api/src/main/java/io/grpc/ManagedChannelRegistry.java
+++ b/api/src/main/java/io/grpc/ManagedChannelRegistry.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.ServiceLoader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.concurrent.ThreadSafe;
@@ -100,8 +101,10 @@ public final class ManagedChannelRegistry {
     if (instance == null) {
       List<ManagedChannelProvider> providerList = ServiceProviders.loadAll(
           ManagedChannelProvider.class,
+          ServiceLoader
+            .load(ManagedChannelProvider.class, ManagedChannelProvider.class.getClassLoader())
+            .iterator(),
           getHardCodedClasses(),
-          ManagedChannelProvider.class.getClassLoader(),
           new ManagedChannelPriorityAccessor());
       instance = new ManagedChannelRegistry();
       for (ManagedChannelProvider provider : providerList) {

--- a/api/src/main/java/io/grpc/ManagedChannelRegistry.java
+++ b/api/src/main/java/io/grpc/ManagedChannelRegistry.java
@@ -104,7 +104,7 @@ public final class ManagedChannelRegistry {
           ServiceLoader
             .load(ManagedChannelProvider.class, ManagedChannelProvider.class.getClassLoader())
             .iterator(),
-          getHardCodedClasses(),
+          ManagedChannelRegistry::getHardCodedClasses,
           new ManagedChannelPriorityAccessor());
       instance = new ManagedChannelRegistry();
       for (ManagedChannelProvider provider : providerList) {

--- a/api/src/main/java/io/grpc/NameResolverRegistry.java
+++ b/api/src/main/java/io/grpc/NameResolverRegistry.java
@@ -129,7 +129,7 @@ public final class NameResolverRegistry {
           ServiceLoader
             .load(NameResolverProvider.class, NameResolverProvider.class.getClassLoader())
             .iterator(),
-          getHardCodedClasses(),
+          NameResolverRegistry::getHardCodedClasses,
           new NameResolverPriorityAccessor());
       if (providerList.isEmpty()) {
         logger.warning("No NameResolverProviders found via ServiceLoader, including for DNS. This "

--- a/api/src/main/java/io/grpc/NameResolverRegistry.java
+++ b/api/src/main/java/io/grpc/NameResolverRegistry.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.ServiceLoader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
@@ -125,8 +126,10 @@ public final class NameResolverRegistry {
     if (instance == null) {
       List<NameResolverProvider> providerList = ServiceProviders.loadAll(
           NameResolverProvider.class,
+          ServiceLoader
+            .load(NameResolverProvider.class, NameResolverProvider.class.getClassLoader())
+            .iterator(),
           getHardCodedClasses(),
-          NameResolverProvider.class.getClassLoader(),
           new NameResolverPriorityAccessor());
       if (providerList.isEmpty()) {
         logger.warning("No NameResolverProviders found via ServiceLoader, including for DNS. This "

--- a/api/src/main/java/io/grpc/ServerRegistry.java
+++ b/api/src/main/java/io/grpc/ServerRegistry.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.ServiceLoader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.concurrent.ThreadSafe;
@@ -93,8 +94,9 @@ public final class ServerRegistry {
     if (instance == null) {
       List<ServerProvider> providerList = ServiceProviders.loadAll(
           ServerProvider.class,
+          ServiceLoader.load(ServerProvider.class, ServerProvider.class.getClassLoader())
+            .iterator(),
           getHardCodedClasses(),
-          ServerProvider.class.getClassLoader(),
           new ServerPriorityAccessor());
       instance = new ServerRegistry();
       for (ServerProvider provider : providerList) {

--- a/api/src/main/java/io/grpc/ServerRegistry.java
+++ b/api/src/main/java/io/grpc/ServerRegistry.java
@@ -96,7 +96,7 @@ public final class ServerRegistry {
           ServerProvider.class,
           ServiceLoader.load(ServerProvider.class, ServerProvider.class.getClassLoader())
             .iterator(),
-          getHardCodedClasses(),
+          ServerRegistry::getHardCodedClasses,
           new ServerPriorityAccessor());
       instance = new ServerRegistry();
       for (ServerProvider provider : providerList) {

--- a/api/src/main/java/io/grpc/ServiceProviders.java
+++ b/api/src/main/java/io/grpc/ServiceProviders.java
@@ -17,6 +17,7 @@
 package io.grpc;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Supplier;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -44,7 +45,7 @@ final class ServiceProviders {
   public static <T> List<T> loadAll(
       Class<T> klass,
       Iterator<T> serviceLoader,
-      Iterable<Class<?>> hardcoded,
+      Supplier<Iterable<Class<?>>> hardcoded,
       final PriorityAccessor<T> priorityAccessor) {
     Iterator<T> candidates;
     if (serviceLoader instanceof ListIterator) {
@@ -58,7 +59,7 @@ final class ServiceProviders {
       candidates = serviceLoader;
     } else if (isAndroid(klass.getClassLoader())) {
       // Avoid getResource() on Android, which must read from a zip which uses a lot of memory
-      candidates = getCandidatesViaHardCoded(klass, hardcoded).iterator();
+      candidates = getCandidatesViaHardCoded(klass, hardcoded.get()).iterator();
     } else if (!serviceLoader.hasNext()) {
       // Attempt to load using the context class loader and ServiceLoader.
       // This allows frameworks like http://aries.apache.org/modules/spi-fly.html to plug in.

--- a/xds/src/main/java/io/grpc/xds/XdsCredentialsRegistry.java
+++ b/xds/src/main/java/io/grpc/xds/XdsCredentialsRegistry.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.ServiceLoader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
@@ -109,8 +110,10 @@ final class XdsCredentialsRegistry {
     if (instance == null) {
       List<XdsCredentialsProvider> providerList = InternalServiceProviders.loadAll(
               XdsCredentialsProvider.class,
+              ServiceLoader
+                .load(XdsCredentialsProvider.class, XdsCredentialsProvider.class.getClassLoader())
+                .iterator(),
               getHardCodedClasses(),
-              XdsCredentialsProvider.class.getClassLoader(),
               new XdsCredentialsProviderPriorityAccessor());
       if (providerList.isEmpty()) {
         logger.warning("No XdsCredsRegistry found via ServiceLoader, including for GoogleDefault, "

--- a/xds/src/main/java/io/grpc/xds/XdsCredentialsRegistry.java
+++ b/xds/src/main/java/io/grpc/xds/XdsCredentialsRegistry.java
@@ -113,7 +113,7 @@ final class XdsCredentialsRegistry {
               ServiceLoader
                 .load(XdsCredentialsProvider.class, XdsCredentialsProvider.class.getClassLoader())
                 .iterator(),
-              getHardCodedClasses(),
+              XdsCredentialsRegistry::getHardCodedClasses,
               new XdsCredentialsProviderPriorityAccessor());
       if (providerList.isEmpty()) {
         logger.warning("No XdsCredsRegistry found via ServiceLoader, including for GoogleDefault, "


### PR DESCRIPTION
This simplifies R8 Full Mode's configuration when paired with R8
optimizations (which is made more difficult to avoid in AGP 9), as when
the optimization is triggered Full Mode will automatically keep the
constructor for the relevant classes.

android-interop-test doesn't currently enable R8 optimizations, so it
doesn't actually demonstrate the benefit, but I have manually confirmed
that enabling proguard-android-optimize.txt does cause the ServiceLoader
optimization in android-interop-test. Note that full mode is a separate
configuration and not necessary to get the ServiceLoader optimization.