### PR TITLE
core: simplify DnsNameResolver.resolveAddresses()

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -104,8 +104,8 @@ signature-java = "org.codehaus.mojo.signature:java18:1.0"
 tomcat-embed-core = "org.apache.tomcat.embed:tomcat-embed-core:10.1.31"
 tomcat-embed-core9 = "org.apache.tomcat.embed:tomcat-embed-core:9.0.89"
 truth = "com.google.truth:truth:1.4.4"
-undertow-servlet22 = "io.undertow:undertow-servlet:2.2.38.Final"
-undertow-servlet = "io.undertow:undertow-servlet:2.3.20.Final"
+undertow-servlet22 = "io.undertow:undertow-servlet:2.2.37.Final"
+undertow-servlet = "io.undertow:undertow-servlet:2.3.18.Final"
 
 # Do not update: Pinned to the last version supporting Java 8.
 # See https://checkstyle.sourceforge.io/releasenotes.html#Release_10.1


### PR DESCRIPTION
`resolveAddresses()` is a private method, called only once. There is no need to handle exceptions in multiple places.

The reason for creating this PR:
I have noticed an exception like this in the logs
```
2025-10-16 13:09:33.141 WARN  [grpc-default-executor-222]    ManagedChannelImpl            [Channel<47>: (x.y.com:443)] Failed to resolve name. status=Status{code=UNAVAILABLE, 
description=Unable to resolve host x.y.com, 
cause=java.lang.RuntimeException: java.net.UnknownHostException: x.y.com: nodename nor servname provided, or not known
...
Caused by: java.net.UnknownHostException: x.y.com: nodename nor servname provided, or not known
...
}
```