### PR TITLE
xds: use UNKNOWN for auth algorithm type during per-rpc authority verification 

### DIFF
--- a/netty/src/main/java/io/grpc/netty/X509AuthorityVerifier.java
+++ b/netty/src/main/java/io/grpc/netty/X509AuthorityVerifier.java
@@ -103,6 +103,6 @@ final class X509AuthorityVerifier implements AuthorityVerifier {
       throw new IllegalStateException("checkServerTrustedMethod not found");
     }
     checkServerTrustedMethod.invoke(
-            x509ExtendedTrustManager, x509PeerCertificates, "RSA", sslEngineWrapper);
+            x509ExtendedTrustManager, x509PeerCertificates, "UNKNOWN", sslEngineWrapper);
   }
 }


### PR DESCRIPTION
While we can get the cipher suite name with `sslEngine.getHandshakeSession().getCipherSuite()`, for the `authType` to use in `X509ExtendedTrustManager.checkServerTrusted` it needs to go through a mapping, for example, for the cipher suite name "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256" the `authType` to use is actually `ECDHE_RSA`. (JDK code maintains such a [mapping](https://github.com/openjdk/jdk/blob/844118a9d854459778f88d299b148c2288131344/src/java.base/share/classes/sun/security/ssl/CipherSuite.java#L113)). Since we don't have all this information handy to use, and UNKNOWN for `authType` works and has actually been observed being used during Tls handshake, we are using the same during the per-rpc authority verification check as the Tls connection has already been established by then.