### PR TITLE
Javadoc and rename BinderServerTransport's init method.

### DIFF
--- a/binder/src/main/java/io/grpc/binder/internal/BinderServer.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderServer.java
@@ -185,7 +185,7 @@ public final class BinderServer implements InternalServer, LeakSafeOneWayBinder.
                   streamTracerFactories,
                   OneWayBinderProxy.IDENTITY_DECORATOR,
                   callbackBinder);
-          transport.setServerTransportListener(listener.transportCreated(transport));
+          transport.start(listener.transportCreated(transport));
           return true;
         }
       }

--- a/binder/src/main/java/io/grpc/binder/internal/BinderServerTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderServerTransport.java
@@ -15,6 +15,9 @@
  */
 package io.grpc.binder.internal;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
 import android.os.IBinder;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.grpc.Attributes;
@@ -57,9 +60,17 @@ public final class BinderServerTransport extends BinderTransport implements Serv
     setOutgoingBinder(OneWayBinderProxy.wrap(callbackBinder, getScheduledExecutorService()));
   }
 
-  public synchronized void setServerTransportListener(
-      ServerTransportListener serverTransportListener) {
-    this.serverTransportListener = serverTransportListener;
+  /**
+   * Initializes this transport instance.
+   *
+   * <p>Must be called exactly once, even if {@link #shutdown} or {@link #shutdownNow} was called
+   * first.
+   *
+   * @param serverTransportListener where this transport will report events
+   */
+  public synchronized void start(ServerTransportListener serverTransportListener) {
+    checkState(this.serverTransportListener == null, "Already started!");
+    this.serverTransportListener = checkNotNull(serverTransportListener, "serverTransportListener");
     if (isShutdown()) {
       setState(TransportState.SHUTDOWN_TERMINATED);
       notifyTerminated();

--- a/binder/src/test/java/io/grpc/binder/internal/BinderServerTransportTest.java
+++ b/binder/src/test/java/io/grpc/binder/internal/BinderServerTransportTest.java
@@ -74,7 +74,7 @@ public final class BinderServerTransportTest {
   public void testSetupTransactionFailureCausesMultipleShutdowns_b153460678() throws Exception {
     // Make the binder fail the setup transaction.
     when(mockBinder.transact(anyInt(), any(Parcel.class), isNull(), anyInt())).thenReturn(false);
-    transport.setServerTransportListener(transportListener);
+    transport.start(transportListener);
 
     // Now shut it down.
     transport.shutdownNow(Status.UNKNOWN.withDescription("reasons"));


### PR DESCRIPTION
Call this `start()` to match the other transports and so readers know this is way more than a setter.