### PR TITLE
alts: Remove dep on grpclb

### DIFF
--- a/alts/BUILD.bazel
+++ b/alts/BUILD.bazel
@@ -13,7 +13,6 @@ java_library(
         ":handshaker_java_proto",
         "//api",
         "//core:internal",
-        "//grpclb",
         "//netty",
         "//stub",
         "@com_google_protobuf//:protobuf_java",

--- a/alts/build.gradle
+++ b/alts/build.gradle
@@ -14,12 +14,10 @@ dependencies {
     implementation project(':grpc-auth'),
             project(':grpc-core'),
             project(":grpc-context"), // Override google-auth dependency with our newer version
-            project(':grpc-grpclb'),
             project(':grpc-protobuf'),
             project(':grpc-stub'),
             libraries.protobuf.java,
             libraries.conscrypt,
-            libraries.guava.jre, // JRE required by protobuf-java-util from grpclb
             libraries.google.auth.oauth2Http
     def nettyDependency = implementation project(':grpc-netty')
 

--- a/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
+++ b/alts/src/main/java/io/grpc/alts/internal/AltsProtocolNegotiator.java
@@ -30,7 +30,6 @@ import io.grpc.InternalChannelz.Security;
 import io.grpc.SecurityLevel;
 import io.grpc.Status;
 import io.grpc.alts.internal.RpcProtocolVersionsUtil.RpcVersionsCheckResult;
-import io.grpc.grpclb.GrpclbConstants;
 import io.grpc.internal.ObjectPool;
 import io.grpc.netty.GrpcHttp2ConnectionHandler;
 import io.grpc.netty.InternalProtocolNegotiator;
@@ -299,9 +298,7 @@ public final class AltsProtocolNegotiator {
         isXdsDirectPath = isDirectPathCluster(
             grpcHandler.getEagAttributes().get(clusterNameAttrKey));
       }
-      if (grpcHandler.getEagAttributes().get(GrpclbConstants.ATTR_LB_ADDR_AUTHORITY) != null
-          || grpcHandler.getEagAttributes().get(GrpclbConstants.ATTR_LB_PROVIDED_BACKEND) != null
-          || isXdsDirectPath) {
+      if (isXdsDirectPath) {
         TsiHandshaker handshaker =
             handshakerFactory.newHandshaker(grpcHandler.getAuthority(), negotiationLogger); 
         NettyTsiHandshaker nettyHandshaker = new NettyTsiHandshaker(handshaker);

--- a/alts/src/test/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiatorTest.java
+++ b/alts/src/test/java/io/grpc/alts/internal/GoogleDefaultProtocolNegotiatorTest.java
@@ -29,7 +29,6 @@ import io.grpc.Channel;
 import io.grpc.ChannelLogger;
 import io.grpc.ChannelLogger.ChannelLogLevel;
 import io.grpc.ManagedChannel;
-import io.grpc.grpclb.GrpclbConstants;
 import io.grpc.inprocess.InProcessChannelBuilder;
 import io.grpc.internal.ObjectPool;
 import io.grpc.netty.GrpcHttp2ConnectionHandler;
@@ -94,13 +93,6 @@ public final class GoogleDefaultProtocolNegotiatorTest {
 
     @Nullable
     abstract Attributes.Key<String> getClusterNameAttrKey();
-
-    @Test
-    public void altsHandler_lbProvidedBackend() {
-      Attributes attrs =
-          Attributes.newBuilder().set(GrpclbConstants.ATTR_LB_PROVIDED_BACKEND, true).build();
-      subtest_altsHandler(attrs);
-    }
 
     @Test
     public void tlsHandler_emptyAttributes() {

--- a/gcp-observability/build.gradle
+++ b/gcp-observability/build.gradle
@@ -59,7 +59,6 @@ dependencies {
             project(path: ':grpc-alts', configuration: 'shadow'),
             project(':grpc-auth'), // Align grpc versions
             project(':grpc-core'), // Align grpc versions
-            project(':grpc-grpclb'), // Align grpc versions
             project(':grpc-services'), // Align grpc versions
             libraries.animalsniffer.annotations, // Use our newer version
             libraries.auto.value.annotations, // Use our newer version


### PR DESCRIPTION
There are no longer any users of grpclb on directpath, so remove the special-casing logic to choose between TLS and ALTS for grpclb-provided backends.

Removing the grpclb dep can speed channel startup, as grpclb's DNS resolver does SRV lookups which are no longer needed.

CC @apolcyn 