### PR TITLE
stub: remove unnecessary condition in if statement

### DIFF
--- a/stub/src/main/java/io/grpc/stub/BlockingClientCall.java
+++ b/stub/src/main/java/io/grpc/stub/BlockingClientCall.java
@@ -225,7 +225,7 @@ public final class BlockingClientCall<ReqT, RespT> {
         (x) -> x.call.isReady() || x.closeState.get() != null;
     executor.waitAndDrainWithTimeout(waitForever, endNanoTime, predicate, this);
     CloseState savedCloseState = closeState.get();
-    if (savedCloseState == null || savedCloseState.status == null) {
+    if (savedCloseState == null) {
       call.sendMessage(request);
       return true;
     } else if (savedCloseState.status.isOk()) {


### PR DESCRIPTION
This PR removes unnecessary condition inside an `if` statement in BlockingClientCall class.
There is no functional change.

Ref #12425 