### PR TITLE
Fix a BinderServerTransport crash in the rare shutdown-before-start case

### DIFF
--- a/binder/src/main/java/io/grpc/binder/internal/SimplePromise.java
+++ b/binder/src/main/java/io/grpc/binder/internal/SimplePromise.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.binder.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Placeholder for an object that will be provided later.
+ *
+ * <p>Similar to {@link com.google.common.util.concurrent.SettableFuture}, except it cannot fail or
+ * be cancelled. Most importantly, this class guarantees that {@link Listener}s run one-at-a-time
+ * and in the same order that they were scheduled. This conveniently matches the expectations of
+ * most listener interfaces in the io.grpc universe.
+ *
+ * <p>Not safe for concurrent use by multiple threads. Thread-compatible for callers that provide
+ * synchronization externally.
+ */
+public class SimplePromise<T> {
+  private T value;
+  private List<Listener<T>> pendingListeners; // Allocated lazily in the hopes it's never needed.
+
+  /**
+   * Provides the promised object and runs any pending listeners.
+   *
+   * @throws IllegalStateException if this method has already been called
+   * @throws RuntimeException if some pending listener threw when we tried to run it
+   */
+  public void set(T value) {
+    checkNotNull(value, "value");
+    checkState(this.value == null, "Already set!");
+    this.value = value;
+    if (pendingListeners != null) {
+      for (Listener<T> listener : pendingListeners) {
+        listener.notify(value);
+      }
+      pendingListeners = null;
+    }
+  }
+
+  /**
+   * Returns the promised object, under the assumption that it's already been set.
+   *
+   * <p>Compared to {@link #runWhenSet(Listener)}, this method may be a more efficient way to access
+   * the promised value in the case where you somehow know externally that {@link #set(T)} has
+   * "happened-before" this call.
+   *
+   * @throws IllegalStateException if {@link #set(T)} has not yet been called
+   */
+  public T get() {
+    checkState(value != null, "Not yet set!");
+    return value;
+  }
+
+  /**
+   * Runs the given listener when this promise is fulfilled, or immediately if already fulfilled.
+   *
+   * @throws RuntimeException if already fulfilled and 'listener' threw when we tried to run it
+   */
+  public void runWhenSet(Listener<T> listener) {
+    if (value != null) {
+      listener.notify(value);
+    } else {
+      if (pendingListeners == null) {
+        pendingListeners = new ArrayList<>();
+      }
+      pendingListeners.add(listener);
+    }
+  }
+
+  /**
+   * An object that wants to get notified when a SimplePromise has been fulfilled.
+   */
+  public interface Listener<T> {
+    /**
+     * Indicates that the associated SimplePromise has been fulfilled with the given `value`.
+     */
+    void notify(T value);
+  }
+}

--- a/binder/src/test/java/io/grpc/binder/internal/SimplePromiseTest.java
+++ b/binder/src/test/java/io/grpc/binder/internal/SimplePromiseTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2025 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.binder.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.grpc.binder.internal.SimplePromise.Listener;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public final class SimplePromiseTest {
+
+  private static final String FULFILLED_VALUE = "a fulfilled value";
+
+  @Mock private Listener<String> mockListener1;
+  @Mock private Listener<String> mockListener2;
+  @Rule public final MockitoRule mocks = MockitoJUnit.rule();
+
+  private SimplePromise<String> promise = new SimplePromise<>();
+
+  @Before
+  public void setUp() {
+  }
+
+  @Test
+  public void get_beforeFulfilled_throws() {
+    IllegalStateException e = assertThrows(IllegalStateException.class, () -> promise.get());
+    assertThat(e).hasMessageThat().isEqualTo("Not yet set!");
+  }
+
+  @Test
+  public void get_afterFulfilled_returnsValue() {
+    promise.set(FULFILLED_VALUE);
+    assertThat(promise.get()).isEqualTo(FULFILLED_VALUE);
+  }
+
+  @Test
+  public void set_withNull_throws() {
+    assertThrows(NullPointerException.class, () -> promise.set(null));
+  }
+
+  @Test
+  public void set_calledTwice_throws() {
+    promise.set(FULFILLED_VALUE);
+    IllegalStateException e =
+        assertThrows(IllegalStateException.class, () -> promise.set("another value"));
+    assertThat(e).hasMessageThat().isEqualTo("Already set!");
+  }
+
+  @Test
+  public void runWhenSet_beforeFulfill_listenerIsNotifiedUponSet() {
+    promise.runWhenSet(mockListener1);
+
+    // Should not have been called yet.
+    verify(mockListener1, never()).notify(FULFILLED_VALUE);
+
+    promise.set(FULFILLED_VALUE);
+
+    // Now it should be called.
+    verify(mockListener1, times(1)).notify(FULFILLED_VALUE);
+  }
+
+  @Test
+  public void runWhenSet_afterSet_listenerIsNotifiedImmediately() {
+    promise.set(FULFILLED_VALUE);
+    promise.runWhenSet(mockListener1);
+
+    // Should have been called immediately.
+    verify(mockListener1, times(1)).notify(FULFILLED_VALUE);
+  }
+
+  @Test
+  public void multipleListeners_addedBeforeSet_allNotifiedInOrder() {
+    promise.runWhenSet(mockListener1);
+    promise.runWhenSet(mockListener2);
+
+    promise.set(FULFILLED_VALUE);
+
+    InOrder inOrder = inOrder(mockListener1, mockListener2);
+    inOrder.verify(mockListener1).notify(FULFILLED_VALUE);
+    inOrder.verify(mockListener2).notify(FULFILLED_VALUE);
+  }
+
+  @Test
+  public void listenerThrows_duringSet_propagatesException() {
+    // A listener that will throw when notified.
+    Listener<String> throwingListener =
+        (value) -> {
+          throw new UnsupportedOperationException("Listener failed");
+        };
+
+    promise.runWhenSet(throwingListener);
+
+    // Fulfilling the promise should now throw the exception from the listener.
+    UnsupportedOperationException e =
+        assertThrows(UnsupportedOperationException.class, () -> promise.set(FULFILLED_VALUE));
+    assertThat(e).hasMessageThat().isEqualTo("Listener failed");
+  }
+
+  @Test
+  public void listenerThrows_whenAddedAfterSet_propagatesException() {
+    promise.set(FULFILLED_VALUE);
+
+    // A listener that will throw when notified.
+    Listener<String> throwingListener =
+        (value) -> {
+          throw new UnsupportedOperationException("Listener failed");
+        };
+
+    // Running the listener should throw immediately because the promise is already fulfilled.
+    UnsupportedOperationException e =
+        assertThrows(
+            UnsupportedOperationException.class, () -> promise.runWhenSet(throwingListener));
+    assertThat(e).hasMessageThat().isEqualTo("Listener failed");
+  }
+}


### PR DESCRIPTION
The following `BinderServerTransport#start()` code was completely untested and did not in fact work:
```
if (isShutdown()) {
      setState(TransportState.SHUTDOWN_TERMINATED);
      notifyTerminated();
      releaseExecutors();
```

The problem is that if the listener does in fact arrive via start() after shutdown, BinderTransport's `shutdownInternal()` has already set the state to `SHUTDOWN_TERMINATED` (which is not a valid transition from itself). It has also already scheduled a call to notifyTerminated() and releaseExecutors(). This causes a duplicate call to `transportTerminated` and releasing the same executor twice.

This PR changes `start()` to leave changing state and releasing executors to  `shutdownInternal()`'s.  `notifyTerminated()` either runs then (if already started) or from within `start()` (if not yet started)

Fixes #12439.