### PR TITLE
Fix name resolver bridge listener handling

### DIFF
--- a/api/src/main/java/io/grpc/NameResolver.java
+++ b/api/src/main/java/io/grpc/NameResolver.java
@@ -97,14 +97,14 @@ public abstract class NameResolver {
 
           @Override
           public void onResult(ResolutionResult resolutionResult) {
-              StatusOr<List<EquivalentAddressGroup>> addressesOrError =
-                      resolutionResult.getAddressesOrError();
-              if (addressesOrError.hasValue()) {
-                  listener.onAddresses(addressesOrError.getValue(),
-                          resolutionResult.getAttributes());
-              } else {
-                  listener.onError(addressesOrError.getStatus());
-              }
+            StatusOr<List<EquivalentAddressGroup>> addressesOrError =
+                resolutionResult.getAddressesOrError();
+            if (addressesOrError.hasValue()) {
+              listener.onAddresses(addressesOrError.getValue(),
+                  resolutionResult.getAttributes());
+            } else {
+              listener.onError(addressesOrError.getStatus());
+            }
           }
       });
     }

--- a/api/src/test/java/io/grpc/NameResolverTest.java
+++ b/api/src/test/java/io/grpc/NameResolverTest.java
@@ -192,52 +192,55 @@ public class NameResolverTest {
         Objects.hashCode(StatusOr.fromValue(ADDRESSES), ATTRIBUTES, CONFIG));
   }
 
-    @Test
-    public void startOnOldListener_resolverReportsError() {
-        final boolean[] errorCalled = new boolean[1];
-        final Status[] receivedError = new Status[1];
+  @Test
+  public void startOnOldListener_resolverReportsError() {
+    final boolean[] onErrorCalled = new boolean[1];
+    final Status[] receivedError = new Status[1];
 
-        NameResolver resolver = new NameResolver() {
-            @Override
-            public String getServiceAuthority() {
-                return "example.com";
-            }
+    NameResolver resolver = new NameResolver() {
+      @Override
+      public String getServiceAuthority() {
+        return "example.com";
+      }
 
-            @Override
-            public void shutdown() {}
+      @Override
+      public void shutdown() {
+      }
 
-            @Override
-            public void start(Listener2 listener) {
-                ResolutionResult errorResult = ResolutionResult.newBuilder()
-                        .setAddressesOrError(StatusOr.fromStatus(
-                                Status.UNAVAILABLE.withDescription("DNS resolution failed")))
-                        .build();
+      @Override
+      public void start(Listener2 listener2) {
+        ResolutionResult errorResult = ResolutionResult.newBuilder()
+            .setAddressesOrError(StatusOr.fromStatus(
+                Status.UNAVAILABLE
+                    .withDescription("DNS resolution failed with UNAVAILABLE")))
+            .build();
 
-                listener.onResult(errorResult);
-            }
-        };
+        listener2.onResult(errorResult);
+      }
+    };
 
-        NameResolver.Listener oldListener = new NameResolver.Listener() {
-            @Override
-            public void onAddresses(
-                    List<EquivalentAddressGroup> servers,
-                    Attributes attributes) {
-                throw new AssertionError("Should not get addresses on error");
-            }
+    NameResolver.Listener listener = new NameResolver.Listener() {
+      @Override
+      public void onAddresses(
+          List<EquivalentAddressGroup> servers,
+          Attributes attributes) {
+        throw new AssertionError("Called onAddresses on error");
+      }
 
-            @Override
-            public void onError(Status error) {
-                errorCalled[0] = true;
-                receivedError[0] = error;
-            }
-        };
+      @Override
+      public void onError(Status error) {
+        onErrorCalled[0] = true;
+        receivedError[0] = error;
+      }
+    };
 
-        resolver.start(oldListener);
+    resolver.start(listener);
 
-        assertThat(errorCalled[0]).isTrue();
-        assertThat(receivedError[0].getCode()).isEqualTo(Status.Code.UNAVAILABLE);
-        assertThat(receivedError[0].getDescription()).isEqualTo("DNS resolution failed");
-    }
+    assertThat(onErrorCalled[0]).isTrue();
+    assertThat(receivedError[0].getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+    assertThat(receivedError[0].getDescription()).isEqualTo(
+        "DNS resolution failed with UNAVAILABLE");
+  }
 
   private static class FakeSocketAddress extends SocketAddress {
     final String name;


### PR DESCRIPTION
Fixes https://github.com/grpc/grpc-java/issues/12444

This PR addresses a bug in the `NameResolver.Listener` to `NameResolver.Listener2` bridge affecting custom NameResolver implementations using Listener. 

The bridge in `NameResolver.start(Listener)` at https://github.com/grpc/grpc-java/blob/master/api/src/main/java/io/grpc/NameResolver.java#L100 unconditionally calls `getValue()` on the `StatusOr`, throwing `java.lang.IllegalStateException: No value present.` when the result contains an error. 

This was identified when upgrading from gRPC `v1.63.3` to `v1.75.0`. 

The bug occurs due to `DnsNameResolver`'s error handling changes between versions:

- `v1.63.3`: Errors reported via `Listener.onError()` (https://github.com/grpc/grpc-java/blob/v1.63.x/core/src/main/java/io/grpc/internal/DnsNameResolver.java#L319)
- `v1.75.0`: Errors passed via `Listener2.onResult2()` with a ResolutionResult containing either addresses OR an error (https://github.com/grpc/grpc-java/blob/master/core/src/main/java/io/grpc/internal/DnsNameResolver.java#L322) 

This PR updates the bridge to check whether `ResolutionResult` contains addresses or an error. It passes the error via `onError` and addresses via `onAddresses`. 

**Reproducing the Issue**
The `startOnOldListener_resolverReportsError` test reproduces a similar issue. It creates a custom `NameResolver` that reports errors through the `ResolutionResult` like the `DNSNameResolver` in `v1.75.0`, passes an old Listener to `resolver.start`, which triggers the bridge code path. 

Without the fix, the bridge calls `getValue()` on the error containing `StatusOr`, throwing `IllegalStateException: No value present`. 

With the fix, the bridge checks `hasValue()` first and correctly routes to `listener.onError()` when appropriate. This ensures backward compatibility for `Listener` implementations when resolvers report errors via `ResolutionResult`. 