### PR TITLE
binder: Let the server know when the client fails to authorize it.

### DIFF
--- a/binder/src/testFixtures/java/io/grpc/binder/FakeDeadBinder.java
+++ b/binder/src/testFixtures/java/io/grpc/binder/FakeDeadBinder.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.binder;
+
+import android.os.DeadObjectException;
+import android.os.IBinder;
+import android.os.IInterface;
+import android.os.Parcel;
+import android.os.RemoteException;
+import java.io.FileDescriptor;
+
+/** An {@link IBinder} that behaves as if its hosting process has died, for testing. */
+public class FakeDeadBinder implements IBinder {
+  @Override
+  public boolean isBinderAlive() {
+    return false;
+  }
+
+  @Override
+  public IInterface queryLocalInterface(String descriptor) {
+    return null;
+  }
+
+  @Override
+  public String getInterfaceDescriptor() throws RemoteException {
+    throw new DeadObjectException();
+  }
+
+  @Override
+  public boolean pingBinder() {
+    return false;
+  }
+
+  @Override
+  public void dump(FileDescriptor fd, String[] args) throws RemoteException {
+    throw new DeadObjectException();
+  }
+
+  @Override
+  public void dumpAsync(FileDescriptor fd, String[] args) throws RemoteException {
+    throw new DeadObjectException();
+  }
+
+  @Override
+  public boolean transact(int code, Parcel data, Parcel reply, int flags) throws RemoteException {
+    throw new DeadObjectException();
+  }
+
+  @Override
+  public void linkToDeath(DeathRecipient r, int flags) throws RemoteException {
+    throw new DeadObjectException();
+  }
+
+  @Override
+  public boolean unlinkToDeath(DeathRecipient deathRecipient, int flags) {
+    // No need to check whether 'deathRecipient' was ever actually passed to linkToDeath(): Per our
+    // API contract, if "the IBinder has already died" we never throw and always return false.
+    return false;
+  }
+}


### PR DESCRIPTION
Avoids waiting for the handshake timeout on the server side in this case.

I also add test coverage for the `!setOutgoingBinder()` case to make sure it works in the new location.

My ulterior motive for this change is simplifying the client handshake code in preparation for #12398 -- An (impossible) !isShutdown() clause goes away for easy to understand reasons and I'll no longer have to pass the server's binder as an arg from async function to function in two separate handshake impls.

TGP passes: fusion2/OCL:823722865:BASE:823829545:1761379767122:2d595b69

Fixes #12438