### PR TITLE
alts: Metadata Server Address Override with Environment Variable

### DIFF
--- a/alts/src/main/java/io/grpc/alts/HandshakerServiceChannel.java
+++ b/alts/src/main/java/io/grpc/alts/HandshakerServiceChannel.java
@@ -40,9 +40,9 @@ import java.util.concurrent.TimeUnit;
 final class HandshakerServiceChannel {
 
   static final Resource<Channel> SHARED_HANDSHAKER_CHANNEL =
-    new ChannelResource(
-        MoreObjects.firstNonNull(
-            System.getenv("GCE_METADATA_HOST"), "metadata.google.internal.:8080"));
+      new ChannelResource(
+          MoreObjects.firstNonNull(
+              System.getenv("GCE_METADATA_HOST"), "metadata.google.internal.:8080"));
 
 
   /** Returns a resource of handshaker service channel for testing only. */


### PR DESCRIPTION
Adding an option to override "metadata.google.internal.:8080" by setting a value for GCE_METADATA_HOST environment variable.

b/451639946

cc: @apolcyn , @anicr7 