### PR TITLE
Stop leaking `this` from BinderServerTransport's ctor

### DIFF
--- a/binder/src/main/java/io/grpc/binder/internal/BinderServer.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderServer.java
@@ -179,7 +179,7 @@ public final class BinderServer implements InternalServer, LeakSafeOneWayBinder.
               checkNotNull(executor, "Not started?"));
           // Create a new transport and let our listener know about it.
           BinderServerTransport transport =
-              new BinderServerTransport(
+              BinderServerTransport.create(
                   executorServicePool,
                   attrsBuilder.build(),
                   streamTracerFactories,

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -159,6 +159,7 @@ public abstract class BinderTransport implements IBinder.DeathRecipient {
   private final ObjectPool<ScheduledExecutorService> executorServicePool;
   private final ScheduledExecutorService scheduledExecutorService;
   private final InternalLogId logId;
+
   @GuardedBy("this")
   private final LeakSafeOneWayBinder incomingBinder;
 
@@ -277,6 +278,14 @@ public abstract class BinderTransport implements IBinder.DeathRecipient {
     transportState = newState;
   }
 
+  /**
+   * Sets the binder to use for sending subsequent transactions to our peer.
+   *
+   * <p>Subclasses should call this as early as possible but not from a constructor.
+   *
+   * <p>Returns true for success, false if the process hosting 'binder' is already dead. Callers are
+   * responsible for handling this.
+   */
   @GuardedBy("this")
   protected boolean setOutgoingBinder(OneWayBinderProxy binder) {
     binder = binderDecorator.decorate(binder);


### PR DESCRIPTION
Accomplish this by splitting out the linkToDeath() part of setOutgoingBinder().

Also add a test for the DOA case and document why ignoring errors from linkToDeath() is ok.