### PR TITLE
Update macos.cfg

### DIFF
--- a/buildscripts/kokoro/macos.cfg
+++ b/buildscripts/kokoro/macos.cfg
@@ -2,7 +2,7 @@
 
 # Location of the continuous shell script in repository.
 build_file: "grpc-java/buildscripts/kokoro/macos.sh"
-timeout_mins: 45
+timeout_mins: 60
 
 # We always build mvn artifacts.
 action {


### PR DESCRIPTION
We are seeing frequent Kokoro VM timeouts with the 45 minute setting. Even successful builds take 38 mins which is close, so increasing the timeout to 1 hour.