### PR TITLE
xds: Avoid default bootstrap when global override in XdsNameResolver (1.77.x backport)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/GrpcBootstrapperImpl.java
+++ b/xds/src/main/java/io/grpc/xds/GrpcBootstrapperImpl.java
@@ -101,11 +101,21 @@ class GrpcBootstrapperImpl extends BootstrapperImpl {
   }
 
   @GuardedBy("GrpcBootstrapperImpl.class")
+  private static Map<String, ?> defaultBootstrapOverride;
+  @GuardedBy("GrpcBootstrapperImpl.class")
   private static BootstrapInfo defaultBootstrap;
+
+  static synchronized void setDefaultBootstrapOverride(Map<String, ?> rawBootstrap) {
+    defaultBootstrapOverride = rawBootstrap;
+  }
 
   static synchronized BootstrapInfo defaultBootstrap() throws XdsInitializationException {
     if (defaultBootstrap == null) {
-      defaultBootstrap = new GrpcBootstrapperImpl().bootstrap();
+      if (defaultBootstrapOverride == null) {
+        defaultBootstrap = new GrpcBootstrapperImpl().bootstrap();
+      } else {
+        defaultBootstrap = new GrpcBootstrapperImpl().bootstrap(defaultBootstrapOverride);
+      }
     }
     return defaultBootstrap;
   }

--- a/xds/src/main/java/io/grpc/xds/InternalSharedXdsClientPoolProvider.java
+++ b/xds/src/main/java/io/grpc/xds/InternalSharedXdsClientPoolProvider.java
@@ -41,7 +41,7 @@ public final class InternalSharedXdsClientPoolProvider {
    */
   @Deprecated
   public static void setDefaultProviderBootstrapOverride(Map<String, ?> bootstrap) {
-    SharedXdsClientPoolProvider.getDefaultProvider().setBootstrapOverride(bootstrap);
+    GrpcBootstrapperImpl.setDefaultBootstrapOverride(bootstrap);
   }
 
   /**


### PR DESCRIPTION
This fixes a regression with an internal API from 27d150890 where overridding the global bootstrap didn't impact parsing the default bootstrap. So if no global bootstrap was available XdsNameResolver would fail to start even though an override was in place in SharedXdsClientPoolProvider. Instead of dealing with the override in SharedXdsClientPoolProvider, do it in GrpcBootstrapperImpl so XdsNameResolver is ignorant of the source of the default bootstrap.

We want all of this to go away in favor of XDS_CLIENT_SUPPLIER injection, but there needs to be some overlap for migration.

cl/826085025

Backport of #12457