### PR TITLE
xds: Detect negative ref count for xds client

### DIFF
--- a/xds/src/main/java/io/grpc/xds/SharedXdsClientPoolProvider.java
+++ b/xds/src/main/java/io/grpc/xds/SharedXdsClientPoolProvider.java
@@ -202,6 +202,10 @@ final class SharedXdsClientPoolProvider implements XdsClientPoolFactory {
           metricReporter = null;
           targetToXdsClientMap.remove(target);
           scheduler = SharedResourceHolder.release(GrpcUtil.TIMER_SERVICE, scheduler);
+        } else if (refCount < 0) {
+          assert false; // We want our tests to fail
+          log.log(Level.SEVERE, "Negative reference count. File a bug", new Exception());
+          refCount = 0;
         }
         return null;
       }

--- a/xds/src/test/java/io/grpc/xds/XdsClientFallbackTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsClientFallbackTest.java
@@ -186,8 +186,8 @@ public class XdsClientFallbackTest {
 
   @After
   public void cleanUp() {
-    if (xdsClientPool != null) {
-      xdsClientPool.returnObject(xdsClient);
+    if (xdsClient != null) {
+      xdsClient = xdsClientPool.returnObject(xdsClient);
     }
     CommonBootstrapperTestUtils.setEnableXdsFallback(originalEnableXdsFallback);
   }


### PR DESCRIPTION
If the refcount goes negative, then the next getObject() will return null. This was noticed during code inspection when investigating a NullPointerException in b/454396128, although it is unclear if this is actually happening.

CC @kannanjgithub 