### PR TITLE
Metadata server address modification to account for port

### DIFF
--- a/alts/src/main/java/io/grpc/alts/HandshakerServiceChannel.java
+++ b/alts/src/main/java/io/grpc/alts/HandshakerServiceChannel.java
@@ -39,11 +39,24 @@ import java.util.concurrent.TimeUnit;
  */
 final class HandshakerServiceChannel {
 
-  static final Resource<Channel> SHARED_HANDSHAKER_CHANNEL =
-      new ChannelResource(
-          MoreObjects.firstNonNull(
-              System.getenv("GCE_METADATA_HOST"), "metadata.google.internal.:8080"));
+  private static final int ALTS_PORT = 8080;
+  private static final String DEFAULT_TARGET = "metadata.google.internal.:8080";
+  private static final String METADATA_HOST_ENV_VAR = System.getenv("GCE_METADATA_HOST");
 
+  static final Resource<Channel> SHARED_HANDSHAKER_CHANNEL =
+       new ChannelResource(getHandshakerTarget(METADATA_HOST_ENV_VAR));
+ 
+  static String getHandshakerTarget(String envValue) {
+     if (envValue == null || envValue.isEmpty()) {
+       return DEFAULT_TARGET;
+     }
+     int colonIndex = envValue.lastIndexOf(':');
+     if (colonIndex != -1) {
+       return envValue;
+     } else {
+       return envValue + ":" + ALTS_PORT;
+     }
+   }
 
   /** Returns a resource of handshaker service channel for testing only. */
   static Resource<Channel> getHandshakerChannelForTesting(String handshakerAddress) {

--- a/alts/src/test/java/io/grpc/alts/HandshakerServiceChannelTest.java
+++ b/alts/src/test/java/io/grpc/alts/HandshakerServiceChannelTest.java
@@ -67,6 +67,24 @@ public final class HandshakerServiceChannelTest {
     }
   }
 
+   @Test
+   public void getHandshakerTarget_nullEnvVar() {
+     assertThat(HandshakerServiceChannel.getHandshakerTarget(null)).isEqualTo("metadata.google.internal.:8080");
+   }
+
+   @Test
+   public void getHandshakerTarget_envVarWithPort() {
+     assertThat(HandshakerServiceChannel.getHandshakerTarget("169.254.169.254:80"))
+         .isEqualTo("169.254.169.254:80");
+   }
+
+   @Test
+   public void getHandshakerTarget_envVarWithHostOnly() {
+     assertThat(HandshakerServiceChannel.getHandshakerTarget("169.254.169.254"))
+         .isEqualTo("169.254.169.254:8080");
+   }
+
+   
   @Test
   public void resource_works() {
     Channel channel = resource.create();


### PR DESCRIPTION
Fixing the utilization of the GCE Metadata host server address environment variable to account for the case where the user does not specify a port (defaults to port 8080)