### PR TITLE
binder: Hold lock when calling setOutgoingBinder()

### DIFF
--- a/binder/src/main/java/io/grpc/binder/internal/BinderServerTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderServerTransport.java
@@ -68,8 +68,10 @@ public final class BinderServerTransport extends BinderTransport implements Serv
     // TODO(jdcormie): Plumb in the Server's executor() and use it here instead.
     // No need to handle failure here because if 'callbackBinder' is already dead, we'll notice it
     // again in start() when we send the first transaction.
-    transport.setOutgoingBinder(
-        OneWayBinderProxy.wrap(callbackBinder, transport.getScheduledExecutorService()));
+    synchronized (transport) {
+      transport.setOutgoingBinder(
+          OneWayBinderProxy.wrap(callbackBinder, transport.getScheduledExecutorService()));
+    }
     return transport;
   }
 


### PR DESCRIPTION
setOutgoingBinder() has `@GuardedBy` for the transport.

```
binder/src/main/java/io/grpc/binder/internal/BinderServerTransport.java:71: error: [GuardedBy] This access should be guarded by 'transport', which is not currently held
    transport.setOutgoingBinder(
             ^
```