### PR TITLE
xds: Remove feature guarding using env vars for Cloud run CSM

### DIFF
--- a/xds/src/main/java/io/grpc/xds/FilterRegistry.java
+++ b/xds/src/main/java/io/grpc/xds/FilterRegistry.java
@@ -17,7 +17,6 @@
 package io.grpc.xds;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.grpc.internal.GrpcUtil;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -33,18 +32,13 @@ final class FilterRegistry {
 
   private FilterRegistry() {}
 
-  static boolean isEnabledGcpAuthnFilter =
-      GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_GCP_AUTHENTICATION_FILTER", false);
-
   static synchronized FilterRegistry getDefaultRegistry() {
     if (instance == null) {
       instance = newRegistry().register(
               new FaultFilter.Provider(),
               new RouterFilter.Provider(),
-              new RbacFilter.Provider());
-      if (isEnabledGcpAuthnFilter) {
-        instance.register(new GcpAuthenticationFilter.Provider());
-      }
+              new RbacFilter.Provider(),
+              new GcpAuthenticationFilter.Provider());
     }
     return instance;
   }

--- a/xds/src/main/java/io/grpc/xds/GcpAuthenticationFilter.java
+++ b/xds/src/main/java/io/grpc/xds/GcpAuthenticationFilter.java
@@ -17,7 +17,6 @@
 package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.grpc.xds.FilterRegistry.isEnabledGcpAuthnFilter;
 import static io.grpc.xds.XdsNameResolver.CLUSTER_SELECTION_KEY;
 import static io.grpc.xds.XdsNameResolver.XDS_CONFIG_CALL_OPTION_KEY;
 
@@ -313,10 +312,6 @@ final class GcpAuthenticationFilter implements Filter {
     public AudienceWrapper parse(Any any) throws ResourceInvalidException {
       Audience audience;
       try {
-        if (!isEnabledGcpAuthnFilter) {
-          throw new InvalidProtocolBufferException("Environment variable for GCP Authentication "
-              + "Filter is Not Set");
-        }
         audience = any.unpack(Audience.class);
       } catch (InvalidProtocolBufferException ex) {
         throw new ResourceInvalidException("Invalid Resource in address proto", ex);

--- a/xds/src/main/java/io/grpc/xds/XdsClusterResource.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClusterResource.java
@@ -64,9 +64,6 @@ class XdsClusterResource extends XdsResourceType<CdsUpdate> {
           ? Boolean.parseBoolean(System.getenv("GRPC_EXPERIMENTAL_ENABLE_LEAST_REQUEST"))
           : Boolean.parseBoolean(
               System.getProperty("io.grpc.xds.experimentalEnableLeastRequest", "true"));
-  @VisibleForTesting
-  public static boolean enableSystemRootCerts =
-      GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_SYSTEM_ROOT_CERTS", false);
   static boolean isEnabledXdsHttpConnect =
       GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_HTTP_CONNECT", false);
 
@@ -486,8 +483,7 @@ class XdsClusterResource extends XdsResourceType<CdsUpdate> {
     }
     String rootCaInstanceName = getRootCertInstanceName(commonTlsContext);
     if (rootCaInstanceName == null) {
-      if (!server && (!enableSystemRootCerts
-          || !CommonTlsContextUtil.isUsingSystemRootCerts(commonTlsContext))) {
+      if (!server && !CommonTlsContextUtil.isUsingSystemRootCerts(commonTlsContext)) {
         throw new ResourceInvalidException(
             "ca_certificate_provider_instance or system_root_certs is required in "
                 + "upstream-tls-context");

--- a/xds/src/main/java/io/grpc/xds/XdsRouteConfigureResource.java
+++ b/xds/src/main/java/io/grpc/xds/XdsRouteConfigureResource.java
@@ -475,8 +475,7 @@ class XdsRouteConfigureResource extends XdsResourceType<RdsUpdate> {
       case CLUSTER:
         return StructOrError.fromStruct(RouteAction.forCluster(
             proto.getCluster(), hashPolicies, timeoutNano, retryPolicy,
-            GrpcUtil.getFlag(GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE, false)
-            && args.getServerInfo().isTrustedXdsServer() && proto.getAutoHostRewrite().getValue()));
+            args.getServerInfo().isTrustedXdsServer() && proto.getAutoHostRewrite().getValue()));
       case CLUSTER_HEADER:
         return null;
       case WEIGHTED_CLUSTERS:
@@ -510,8 +509,7 @@ class XdsRouteConfigureResource extends XdsResourceType<RdsUpdate> {
         }
         return StructOrError.fromStruct(VirtualHost.Route.RouteAction.forWeightedClusters(
             weightedClusters, hashPolicies, timeoutNano, retryPolicy,
-            GrpcUtil.getFlag(GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE, false)
-            && args.getServerInfo().isTrustedXdsServer() && proto.getAutoHostRewrite().getValue()));
+            args.getServerInfo().isTrustedXdsServer() && proto.getAutoHostRewrite().getValue()));
       case CLUSTER_SPECIFIER_PLUGIN:
         if (enableRouteLookup) {
           String pluginName = proto.getClusterSpecifierPlugin();
@@ -527,8 +525,7 @@ class XdsRouteConfigureResource extends XdsResourceType<RdsUpdate> {
           NamedPluginConfig namedPluginConfig = NamedPluginConfig.create(pluginName, pluginConfig);
           return StructOrError.fromStruct(VirtualHost.Route.RouteAction.forClusterSpecifierPlugin(
               namedPluginConfig, hashPolicies, timeoutNano, retryPolicy,
-              GrpcUtil.getFlag(GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE, false)
-              && args.getServerInfo().isTrustedXdsServer()
+              args.getServerInfo().isTrustedXdsServer()
                   && proto.getAutoHostRewrite().getValue()));
         } else {
           return null;

--- a/xds/src/main/java/io/grpc/xds/internal/security/SecurityProtocolNegotiators.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/SecurityProtocolNegotiators.java
@@ -215,21 +215,16 @@ public final class SecurityProtocolNegotiators {
       this.sslContextProviderSupplier = sslContextProviderSupplier;
       EnvoyServerProtoData.BaseTlsContext tlsContext = sslContextProviderSupplier.getTlsContext();
       UpstreamTlsContext upstreamTlsContext = ((UpstreamTlsContext) tlsContext);
-      if (CertificateUtils.isXdsSniEnabled) {
-        String sniToUse = upstreamTlsContext.getAutoHostSni()
-            && !Strings.isNullOrEmpty(endpointHostname)
-            ? endpointHostname : upstreamTlsContext.getSni();
-        if (sniToUse.isEmpty() && CertificateUtils.useChannelAuthorityIfNoSniApplicable) {
-          sniToUse = grpcHandler.getAuthority();
-          autoSniSanValidationDoesNotApply = true;
-        } else {
-          autoSniSanValidationDoesNotApply = false;
-        }
-        sni = sniToUse;
+      String sniToUse = upstreamTlsContext.getAutoHostSni()
+          && !Strings.isNullOrEmpty(endpointHostname)
+          ? endpointHostname : upstreamTlsContext.getSni();
+      if (sniToUse.isEmpty() && CertificateUtils.useChannelAuthorityIfNoSniApplicable) {
+        sniToUse = grpcHandler.getAuthority();
+        autoSniSanValidationDoesNotApply = true;
       } else {
-        sni = grpcHandler.getAuthority();
         autoSniSanValidationDoesNotApply = false;
       }
+      sni = sniToUse;
     }
 
     @VisibleForTesting

--- a/xds/src/main/java/io/grpc/xds/internal/security/trust/XdsX509TrustManager.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/trust/XdsX509TrustManager.java
@@ -308,7 +308,7 @@ final class XdsX509TrustManager extends X509ExtendedTrustManager implements X509
 
   private List<StringMatcher> getAutoSniSanMatchers(SSLParameters sslParams) {
     List<StringMatcher> sniNamesToMatch = new ArrayList<>();
-    if (CertificateUtils.isXdsSniEnabled && autoSniSanValidation) {
+    if (autoSniSanValidation) {
       List<SNIServerName> serverNames = sslParams.getServerNames();
       if (serverNames != null) {
         for (SNIServerName serverName : serverNames) {

--- a/xds/src/test/java/io/grpc/xds/GcpAuthenticationFilterTest.java
+++ b/xds/src/test/java/io/grpc/xds/GcpAuthenticationFilterTest.java
@@ -88,11 +88,6 @@ public class GcpAuthenticationFilterTest {
   private static final RdsUpdate rdsUpdate = getRdsUpdate();
   private static final CdsUpdate cdsUpdate = getCdsUpdate();
 
-  @Before
-  public void setUp() {
-    System.setProperty("GRPC_EXPERIMENTAL_XDS_GCP_AUTHENTICATION_FILTER", "true");
-  }
-
   @Test
   public void testNewFilterInstancesPerFilterName() {
     assertThat(new GcpAuthenticationFilter("FILTER_INSTANCE_NAME1", 10))

--- a/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplDataTest.java
@@ -172,26 +172,21 @@ public class GrpcXdsClientImplDataTest {
 
   private static final ServerInfo LRS_SERVER_INFO =
       ServerInfo.create("lrs.googleapis.com", InsecureChannelCredentials.create());
-  private static final String GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE =
-      "GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE";
 
   private final FilterRegistry filterRegistry = FilterRegistry.getDefaultRegistry();
   private boolean originalEnableRouteLookup;
   private boolean originalEnableLeastRequest;
-  private boolean originalEnableUseSystemRootCerts;
 
   @Before
   public void setUp() {
     originalEnableRouteLookup = XdsRouteConfigureResource.enableRouteLookup;
     originalEnableLeastRequest = XdsClusterResource.enableLeastRequest;
-    originalEnableUseSystemRootCerts = XdsClusterResource.enableSystemRootCerts;
   }
 
   @After
   public void tearDown() {
     XdsRouteConfigureResource.enableRouteLookup = originalEnableRouteLookup;
     XdsClusterResource.enableLeastRequest = originalEnableLeastRequest;
-    XdsClusterResource.enableSystemRootCerts = originalEnableUseSystemRootCerts;
   }
 
   @Test
@@ -536,23 +531,18 @@ public class GrpcXdsClientImplDataTest {
 
   @Test
   public void parseRouteAction_withCluster_autoHostRewriteEnabled() {
-    System.setProperty(GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE, "true");
-    try {
-      io.envoyproxy.envoy.config.route.v3.RouteAction proto =
-          io.envoyproxy.envoy.config.route.v3.RouteAction.newBuilder()
-              .setCluster("cluster-foo")
-              .setAutoHostRewrite(BoolValue.of(true))
-              .build();
-      StructOrError<RouteAction> struct =
-          XdsRouteConfigureResource.parseRouteAction(proto, filterRegistry,
-              ImmutableMap.of(), ImmutableSet.of(), getXdsResourceTypeArgs(true));
-      assertThat(struct.getErrorDetail()).isNull();
-      assertThat(struct.getStruct().cluster()).isEqualTo("cluster-foo");
-      assertThat(struct.getStruct().weightedClusters()).isNull();
-      assertThat(struct.getStruct().autoHostRewrite()).isTrue();
-    } finally {
-      System.clearProperty(GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE);
-    }
+    io.envoyproxy.envoy.config.route.v3.RouteAction proto =
+        io.envoyproxy.envoy.config.route.v3.RouteAction.newBuilder()
+            .setCluster("cluster-foo")
+            .setAutoHostRewrite(BoolValue.of(true))
+            .build();
+    StructOrError<RouteAction> struct =
+        XdsRouteConfigureResource.parseRouteAction(proto, filterRegistry,
+            ImmutableMap.of(), ImmutableSet.of(), getXdsResourceTypeArgs(true));
+    assertThat(struct.getErrorDetail()).isNull();
+    assertThat(struct.getStruct().cluster()).isEqualTo("cluster-foo");
+    assertThat(struct.getStruct().weightedClusters()).isNull();
+    assertThat(struct.getStruct().autoHostRewrite()).isTrue();
   }
 
   @Test
@@ -600,35 +590,30 @@ public class GrpcXdsClientImplDataTest {
 
   @Test
   public void parseRouteAction_withWeightedCluster_autoHostRewriteEnabled() {
-    System.setProperty(GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE, "true");
-    try {
-      io.envoyproxy.envoy.config.route.v3.RouteAction proto =
-          io.envoyproxy.envoy.config.route.v3.RouteAction.newBuilder()
-              .setWeightedClusters(
-                  WeightedCluster.newBuilder()
-                      .addClusters(
-                          WeightedCluster.ClusterWeight
-                              .newBuilder()
-                              .setName("cluster-foo")
-                              .setWeight(UInt32Value.newBuilder().setValue(30)))
-                      .addClusters(WeightedCluster.ClusterWeight
-                          .newBuilder()
-                          .setName("cluster-bar")
-                          .setWeight(UInt32Value.newBuilder().setValue(70))))
-              .setAutoHostRewrite(BoolValue.of(true))
-              .build();
-      StructOrError<RouteAction> struct =
-          XdsRouteConfigureResource.parseRouteAction(proto, filterRegistry,
-              ImmutableMap.of(), ImmutableSet.of(), getXdsResourceTypeArgs(true));
-      assertThat(struct.getErrorDetail()).isNull();
-      assertThat(struct.getStruct().cluster()).isNull();
-      assertThat(struct.getStruct().weightedClusters()).containsExactly(
-          ClusterWeight.create("cluster-foo", 30, ImmutableMap.<String, FilterConfig>of()),
-          ClusterWeight.create("cluster-bar", 70, ImmutableMap.<String, FilterConfig>of()));
-      assertThat(struct.getStruct().autoHostRewrite()).isTrue();
-    } finally {
-      System.clearProperty(GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE);
-    }
+    io.envoyproxy.envoy.config.route.v3.RouteAction proto =
+        io.envoyproxy.envoy.config.route.v3.RouteAction.newBuilder()
+            .setWeightedClusters(
+                WeightedCluster.newBuilder()
+                    .addClusters(
+                        WeightedCluster.ClusterWeight
+                            .newBuilder()
+                            .setName("cluster-foo")
+                            .setWeight(UInt32Value.newBuilder().setValue(30)))
+                    .addClusters(WeightedCluster.ClusterWeight
+                        .newBuilder()
+                        .setName("cluster-bar")
+                        .setWeight(UInt32Value.newBuilder().setValue(70))))
+            .setAutoHostRewrite(BoolValue.of(true))
+            .build();
+    StructOrError<RouteAction> struct =
+        XdsRouteConfigureResource.parseRouteAction(proto, filterRegistry,
+            ImmutableMap.of(), ImmutableSet.of(), getXdsResourceTypeArgs(true));
+    assertThat(struct.getErrorDetail()).isNull();
+    assertThat(struct.getStruct().cluster()).isNull();
+    assertThat(struct.getStruct().weightedClusters()).containsExactly(
+        ClusterWeight.create("cluster-foo", 30, ImmutableMap.<String, FilterConfig>of()),
+        ClusterWeight.create("cluster-bar", 70, ImmutableMap.<String, FilterConfig>of()));
+    assertThat(struct.getStruct().autoHostRewrite()).isTrue();
   }
 
   @Test
@@ -1004,28 +989,6 @@ public class GrpcXdsClientImplDataTest {
 
   @Test
   public void parseRouteAction_clusterSpecifier_autoHostRewriteEnabled() {
-    System.setProperty(GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE, "true");
-    try {
-      XdsRouteConfigureResource.enableRouteLookup = true;
-      io.envoyproxy.envoy.config.route.v3.RouteAction proto =
-          io.envoyproxy.envoy.config.route.v3.RouteAction.newBuilder()
-              .setClusterSpecifierPlugin(CLUSTER_SPECIFIER_PLUGIN.name())
-              .setAutoHostRewrite(BoolValue.of(true))
-              .build();
-      StructOrError<RouteAction> struct =
-          XdsRouteConfigureResource.parseRouteAction(proto, filterRegistry,
-              ImmutableMap.of(CLUSTER_SPECIFIER_PLUGIN.name(), RlsPluginConfig.create(
-                  ImmutableMap.of("lookupService", "rls-cbt.googleapis.com"))), ImmutableSet.of(),
-              getXdsResourceTypeArgs(true));
-      assertThat(struct.getStruct()).isNotNull();
-      assertThat(struct.getStruct().autoHostRewrite()).isTrue();
-    } finally {
-      System.clearProperty(GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE);
-    }
-  }
-
-  @Test
-  public void parseRouteAction_clusterSpecifier_flagDisabled_autoHostRewriteDisabled() {
     XdsRouteConfigureResource.enableRouteLookup = true;
     io.envoyproxy.envoy.config.route.v3.RouteAction proto =
         io.envoyproxy.envoy.config.route.v3.RouteAction.newBuilder()
@@ -1038,7 +1001,7 @@ public class GrpcXdsClientImplDataTest {
                 ImmutableMap.of("lookupService", "rls-cbt.googleapis.com"))), ImmutableSet.of(),
             getXdsResourceTypeArgs(true));
     assertThat(struct.getStruct()).isNotNull();
-    assertThat(struct.getStruct().autoHostRewrite()).isFalse();
+    assertThat(struct.getStruct().autoHostRewrite()).isTrue();
   }
 
   @Test
@@ -2447,7 +2410,6 @@ public class GrpcXdsClientImplDataTest {
 
   @Test
   public void processCluster_parsesAudienceMetadata() throws Exception {
-    FilterRegistry.isEnabledGcpAuthnFilter = true;
     MetadataRegistry.getInstance();
 
     Audience audience = Audience.newBuilder()
@@ -2491,14 +2453,10 @@ public class GrpcXdsClientImplDataTest {
         "FILTER_METADATA", ImmutableMap.of(
             "key1", "value1",
             "key2", 42.0));
-    try {
-      assertThat(update.parsedMetadata().get("FILTER_METADATA"))
-          .isEqualTo(expectedParsedMetadata.get("FILTER_METADATA"));
-      assertThat(update.parsedMetadata().get("AUDIENCE_METADATA"))
-          .isInstanceOf(AudienceWrapper.class);
-    } finally {
-      FilterRegistry.isEnabledGcpAuthnFilter = false;
-    }
+    assertThat(update.parsedMetadata().get("FILTER_METADATA"))
+        .isEqualTo(expectedParsedMetadata.get("FILTER_METADATA"));
+    assertThat(update.parsedMetadata().get("AUDIENCE_METADATA"))
+        .isInstanceOf(AudienceWrapper.class);
   }
 
   @Test
@@ -3178,35 +3136,8 @@ public class GrpcXdsClientImplDataTest {
   }
 
   @Test
-  public void
-      validateCommonTlsContext_combinedValidationContextSystemRootCerts_envVarNotSet_throws() {
-    XdsClusterResource.enableSystemRootCerts = false;
-    CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
-        .setCombinedValidationContext(
-            CommonTlsContext.CombinedCertificateValidationContext.newBuilder()
-                .setDefaultValidationContext(
-                    CertificateValidationContext.newBuilder()
-                        .setSystemRootCerts(
-                            CertificateValidationContext.SystemRootCerts.newBuilder().build())
-                        .build()
-                )
-                .build())
-        .build();
-    try {
-      XdsClusterResource
-          .validateCommonTlsContext(commonTlsContext, ImmutableSet.of(), false);
-      fail("Expected exception");
-    } catch (ResourceInvalidException ex) {
-      assertThat(ex.getMessage()).isEqualTo(
-          "ca_certificate_provider_instance or system_root_certs is required in"
-              + " upstream-tls-context");
-    }
-  }
-
-  @Test
   public void validateCommonTlsContext_combinedValidationContextSystemRootCerts()
       throws ResourceInvalidException {
-    XdsClusterResource.enableSystemRootCerts = true;
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
         .setCombinedValidationContext(
             CommonTlsContext.CombinedCertificateValidationContext.newBuilder()
@@ -3223,30 +3154,8 @@ public class GrpcXdsClientImplDataTest {
   }
 
   @Test
-  public void validateCommonTlsContext_validationContextSystemRootCerts_envVarNotSet_throws() {
-    XdsClusterResource.enableSystemRootCerts = false;
-    CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
-        .setValidationContext(
-            CertificateValidationContext.newBuilder()
-                .setSystemRootCerts(
-                    CertificateValidationContext.SystemRootCerts.newBuilder().build())
-                .build())
-        .build();
-    try {
-      XdsClusterResource
-          .validateCommonTlsContext(commonTlsContext, ImmutableSet.of(), false);
-      fail("Expected exception");
-    } catch (ResourceInvalidException ex) {
-      assertThat(ex.getMessage()).isEqualTo(
-          "ca_certificate_provider_instance or system_root_certs is required in "
-              + "upstream-tls-context");
-    }
-  }
-
-  @Test
   public void validateCommonTlsContext_validationContextSystemRootCerts()
       throws ResourceInvalidException {
-    XdsClusterResource.enableSystemRootCerts = true;
     CommonTlsContext commonTlsContext = CommonTlsContext.newBuilder()
         .setValidationContext(
             CertificateValidationContext.newBuilder()

--- a/xds/src/test/java/io/grpc/xds/XdsSecurityClientServerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsSecurityClientServerTest.java
@@ -317,7 +317,6 @@ public class XdsSecurityClientServerTest {
   @Test
   public void tlsClientServer_autoSniValidation_sniInUtc()
       throws Exception {
-    CertificateUtils.isXdsSniEnabled = true;
     Path trustStoreFilePath = getCacertFilePathForTestCa();
     try {
       setTrustStoreSystemProperties(trustStoreFilePath.toAbsolutePath().toString());
@@ -341,14 +340,12 @@ public class XdsSecurityClientServerTest {
     } finally {
       Files.deleteIfExists(trustStoreFilePath);
       clearTrustStoreSystemProperties();
-      CertificateUtils.isXdsSniEnabled = false;
     }
   }
 
   @Test
   public void tlsClientServer_autoSniValidation_sniFromHostname()
       throws Exception {
-    CertificateUtils.isXdsSniEnabled = true;
     Path trustStoreFilePath = getCacertFilePathForTestCa();
     try {
       setTrustStoreSystemProperties(trustStoreFilePath.toAbsolutePath().toString());
@@ -375,14 +372,12 @@ public class XdsSecurityClientServerTest {
     } finally {
       Files.deleteIfExists(trustStoreFilePath);
       clearTrustStoreSystemProperties();
-      CertificateUtils.isXdsSniEnabled = false;
     }
   }
 
   @Test
   public void tlsClientServer_autoSniValidation_noSniApplicable_usesMatcherFromCmnVdnCtx()
       throws Exception {
-    CertificateUtils.isXdsSniEnabled = true;
     Path trustStoreFilePath = getCacertFilePathForTestCa();
     try {
       setTrustStoreSystemProperties(trustStoreFilePath.toAbsolutePath().toString());
@@ -406,7 +401,6 @@ public class XdsSecurityClientServerTest {
     } finally {
       Files.deleteIfExists(trustStoreFilePath);
       clearTrustStoreSystemProperties();
-      CertificateUtils.isXdsSniEnabled = false;
     }
   }
 

--- a/xds/src/test/java/io/grpc/xds/internal/security/SecurityProtocolNegotiatorsTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/SecurityProtocolNegotiatorsTest.java
@@ -151,32 +151,27 @@ public class SecurityProtocolNegotiatorsTest {
 
   @Test
   public void clientSecurityProtocolNegotiator_autoHostSni_hostnamePassedToClientSecurityHandlr() {
-    CertificateUtils.isXdsSniEnabled = true;
-    try {
-      UpstreamTlsContext upstreamTlsContext =
-          CommonTlsContextTestsUtil.buildUpstreamTlsContext(
-              CommonTlsContext.newBuilder().build(), "", true, false);
-      ClientSecurityProtocolNegotiator pn =
-          new ClientSecurityProtocolNegotiator(InternalProtocolNegotiators.plaintext());
-      GrpcHttp2ConnectionHandler mockHandler = mock(GrpcHttp2ConnectionHandler.class);
-      ChannelLogger logger = mock(ChannelLogger.class);
-      doNothing().when(logger).log(any(ChannelLogLevel.class), anyString());
-      when(mockHandler.getNegotiationLogger()).thenReturn(logger);
-      TlsContextManager mockTlsContextManager = mock(TlsContextManager.class);
-      when(mockHandler.getEagAttributes())
-          .thenReturn(
-              Attributes.newBuilder()
-                  .set(SecurityProtocolNegotiators.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER,
-                      new SslContextProviderSupplier(upstreamTlsContext, mockTlsContextManager))
-                  .set(XdsInternalAttributes.ATTR_ADDRESS_NAME, FAKE_AUTHORITY)
-                  .build());
-      ChannelHandler newHandler = pn.newHandler(mockHandler);
-      assertThat(newHandler).isNotNull();
-      assertThat(newHandler).isInstanceOf(ClientSecurityHandler.class);
-      assertThat(((ClientSecurityHandler) newHandler).getSni()).isEqualTo(FAKE_AUTHORITY);
-    } finally {
-      CertificateUtils.isXdsSniEnabled = false;
-    }
+    UpstreamTlsContext upstreamTlsContext =
+        CommonTlsContextTestsUtil.buildUpstreamTlsContext(
+            CommonTlsContext.newBuilder().build(), "", true, false);
+    ClientSecurityProtocolNegotiator pn =
+        new ClientSecurityProtocolNegotiator(InternalProtocolNegotiators.plaintext());
+    GrpcHttp2ConnectionHandler mockHandler = mock(GrpcHttp2ConnectionHandler.class);
+    ChannelLogger logger = mock(ChannelLogger.class);
+    doNothing().when(logger).log(any(ChannelLogLevel.class), anyString());
+    when(mockHandler.getNegotiationLogger()).thenReturn(logger);
+    TlsContextManager mockTlsContextManager = mock(TlsContextManager.class);
+    when(mockHandler.getEagAttributes())
+        .thenReturn(
+            Attributes.newBuilder()
+                .set(SecurityProtocolNegotiators.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER,
+                    new SslContextProviderSupplier(upstreamTlsContext, mockTlsContextManager))
+                .set(XdsInternalAttributes.ATTR_ADDRESS_NAME, FAKE_AUTHORITY)
+                .build());
+    ChannelHandler newHandler = pn.newHandler(mockHandler);
+    assertThat(newHandler).isNotNull();
+    assertThat(newHandler).isInstanceOf(ClientSecurityHandler.class);
+    assertThat(((ClientSecurityHandler) newHandler).getSni()).isEqualTo(FAKE_AUTHORITY);
   }
 
   @Test
@@ -235,110 +230,71 @@ public class SecurityProtocolNegotiatorsTest {
 
   @Test
   public void sniInClientSecurityHandler_autoHostSniIsTrue_usesEndpointHostname() {
-    CertificateUtils.isXdsSniEnabled = true;
-    try {
-      Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
-          .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
-              CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
-      UpstreamTlsContext upstreamTlsContext =
-          CommonTlsContextTestsUtil
-              .buildUpstreamTlsContext("google_cloud_private_spiffe-client", true, "", true);
-      SslContextProviderSupplier sslContextProviderSupplier =
-          new SslContextProviderSupplier(upstreamTlsContext,
-              new TlsContextManagerImpl(bootstrapInfoForClient));
+    Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
+        .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
+            CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
+    UpstreamTlsContext upstreamTlsContext =
+        CommonTlsContextTestsUtil
+            .buildUpstreamTlsContext("google_cloud_private_spiffe-client", true, "", true);
+    SslContextProviderSupplier sslContextProviderSupplier =
+        new SslContextProviderSupplier(upstreamTlsContext,
+            new TlsContextManagerImpl(bootstrapInfoForClient));
 
-      ClientSecurityHandler clientSecurityHandler =
-          new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, HOSTNAME);
+    ClientSecurityHandler clientSecurityHandler =
+        new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, HOSTNAME);
 
-      assertThat(clientSecurityHandler.getSni()).isEqualTo(HOSTNAME);
-    } finally {
-      CertificateUtils.isXdsSniEnabled = false;
-    }
+    assertThat(clientSecurityHandler.getSni()).isEqualTo(HOSTNAME);
   }
 
   @Test
   public void sniInClientSecurityHandler_autoHostSni_endpointHostnameIsEmpty_usesSniFromUtc() {
-    CertificateUtils.isXdsSniEnabled = true;
-    try {
-      Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
-          .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
-              CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
-      UpstreamTlsContext upstreamTlsContext = CommonTlsContextTestsUtil.buildUpstreamTlsContext(
-          "google_cloud_private_spiffe-client", true, SNI_IN_UTC, true);
-      SslContextProviderSupplier sslContextProviderSupplier =
-          new SslContextProviderSupplier(upstreamTlsContext,
-              new TlsContextManagerImpl(bootstrapInfoForClient));
+    Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
+        .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
+            CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
+    UpstreamTlsContext upstreamTlsContext = CommonTlsContextTestsUtil.buildUpstreamTlsContext(
+        "google_cloud_private_spiffe-client", true, SNI_IN_UTC, true);
+    SslContextProviderSupplier sslContextProviderSupplier =
+        new SslContextProviderSupplier(upstreamTlsContext,
+            new TlsContextManagerImpl(bootstrapInfoForClient));
 
-      ClientSecurityHandler clientSecurityHandler =
-          new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, "");
+    ClientSecurityHandler clientSecurityHandler =
+        new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, "");
 
-      assertThat(clientSecurityHandler.getSni()).isEqualTo(SNI_IN_UTC);
-    } finally {
-      CertificateUtils.isXdsSniEnabled = false;
-    }
+    assertThat(clientSecurityHandler.getSni()).isEqualTo(SNI_IN_UTC);
   }
 
   @Test
   public void sniInClientSecurityHandler_autoHostSni_endpointHostnameIsNull_usesSniFromUtc() {
-    CertificateUtils.isXdsSniEnabled = true;
-    try {
-      Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
-          .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
-              CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
-      UpstreamTlsContext upstreamTlsContext = CommonTlsContextTestsUtil.buildUpstreamTlsContext(
-          "google_cloud_private_spiffe-client", true, SNI_IN_UTC, true);
-      SslContextProviderSupplier sslContextProviderSupplier =
-          new SslContextProviderSupplier(upstreamTlsContext,
-              new TlsContextManagerImpl(bootstrapInfoForClient));
+    Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
+        .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
+            CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
+    UpstreamTlsContext upstreamTlsContext = CommonTlsContextTestsUtil.buildUpstreamTlsContext(
+        "google_cloud_private_spiffe-client", true, SNI_IN_UTC, true);
+    SslContextProviderSupplier sslContextProviderSupplier =
+        new SslContextProviderSupplier(upstreamTlsContext,
+            new TlsContextManagerImpl(bootstrapInfoForClient));
 
-      ClientSecurityHandler clientSecurityHandler =
-          new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, null);
+    ClientSecurityHandler clientSecurityHandler =
+        new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, null);
 
-      assertThat(clientSecurityHandler.getSni()).isEqualTo(SNI_IN_UTC);
-    } finally {
-      CertificateUtils.isXdsSniEnabled = false;
-    }
+    assertThat(clientSecurityHandler.getSni()).isEqualTo(SNI_IN_UTC);
   }
 
   @Test
   public void sniInClientSecurityHandler_autoHostSniIsFalse_usesSniFromUpstreamTlsContext() {
-    CertificateUtils.isXdsSniEnabled = true;
-    try {
-      Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
-          .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
-              CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
-      UpstreamTlsContext upstreamTlsContext = CommonTlsContextTestsUtil.buildUpstreamTlsContext(
-          "google_cloud_private_spiffe-client", true, SNI_IN_UTC, false);
-      SslContextProviderSupplier sslContextProviderSupplier =
-          new SslContextProviderSupplier(upstreamTlsContext,
-              new TlsContextManagerImpl(bootstrapInfoForClient));
-
-      ClientSecurityHandler clientSecurityHandler =
-          new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, HOSTNAME);
-
-      assertThat(clientSecurityHandler.getSni()).isEqualTo(SNI_IN_UTC);
-    } finally {
-      CertificateUtils.isXdsSniEnabled = false;
-    }
-  }
-
-  @Test
-  public void sniFeatureNotEnabled_usesChannelAuthorityForSni() {
-    CertificateUtils.isXdsSniEnabled = false;
     Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
-            .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
-                    CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
-    UpstreamTlsContext upstreamTlsContext =
-            CommonTlsContextTestsUtil
-                .buildUpstreamTlsContext("google_cloud_private_spiffe-client", true);
+        .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
+            CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
+    UpstreamTlsContext upstreamTlsContext = CommonTlsContextTestsUtil.buildUpstreamTlsContext(
+        "google_cloud_private_spiffe-client", true, SNI_IN_UTC, false);
     SslContextProviderSupplier sslContextProviderSupplier =
-            new SslContextProviderSupplier(upstreamTlsContext,
-                    new TlsContextManagerImpl(bootstrapInfoForClient));
+        new SslContextProviderSupplier(upstreamTlsContext,
+            new TlsContextManagerImpl(bootstrapInfoForClient));
 
     ClientSecurityHandler clientSecurityHandler =
-            new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, HOSTNAME);
+        new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, HOSTNAME);
 
-    assertThat(clientSecurityHandler.getSni()).isEqualTo(FAKE_AUTHORITY);
+    assertThat(clientSecurityHandler.getSni()).isEqualTo(SNI_IN_UTC);
   }
 
   @Test
@@ -504,59 +460,54 @@ public class SecurityProtocolNegotiatorsTest {
   @Test
   public void clientSecurityProtocolNegotiatorNewHandler_fireProtocolNegotiationEvent()
           throws InterruptedException, TimeoutException, ExecutionException {
-    CertificateUtils.isXdsSniEnabled = true;
-    try {
-      FakeClock executor = new FakeClock();
-      CommonCertProviderTestUtils.register(executor);
-      Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
-          .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
-              CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
-      UpstreamTlsContext upstreamTlsContext =
-          CommonTlsContextTestsUtil
-              .buildUpstreamTlsContext("google_cloud_private_spiffe-client", true);
+    FakeClock executor = new FakeClock();
+    CommonCertProviderTestUtils.register(executor);
+    Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
+        .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
+            CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
+    UpstreamTlsContext upstreamTlsContext =
+        CommonTlsContextTestsUtil
+            .buildUpstreamTlsContext("google_cloud_private_spiffe-client", true);
 
-      SslContextProviderSupplier sslContextProviderSupplier =
-          new SslContextProviderSupplier(upstreamTlsContext,
-              new TlsContextManagerImpl(bootstrapInfoForClient));
-      ClientSecurityHandler clientSecurityHandler =
-          new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, HOSTNAME);
+    SslContextProviderSupplier sslContextProviderSupplier =
+        new SslContextProviderSupplier(upstreamTlsContext,
+            new TlsContextManagerImpl(bootstrapInfoForClient));
+    ClientSecurityHandler clientSecurityHandler =
+        new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, HOSTNAME);
 
-      pipeline.addLast(clientSecurityHandler);
-      channelHandlerCtx = pipeline.context(clientSecurityHandler);
-      assertNotNull(channelHandlerCtx); // non-null since we just added it
+    pipeline.addLast(clientSecurityHandler);
+    channelHandlerCtx = pipeline.context(clientSecurityHandler);
+    assertNotNull(channelHandlerCtx); // non-null since we just added it
 
-      // kick off protocol negotiation.
-      pipeline.fireUserEventTriggered(InternalProtocolNegotiationEvent.getDefault());
-      final SettableFuture<Object> future = SettableFuture.create();
-      sslContextProviderSupplier
-          .updateSslContext(new SslContextProvider.Callback(MoreExecutors.directExecutor()) {
-            @Override
-            public void updateSslContextAndExtendedX509TrustManager(
-                AbstractMap.SimpleImmutableEntry<SslContext, X509TrustManager> sslContextAndTm) {
-              future.set(sslContextAndTm);
-            }
+    // kick off protocol negotiation.
+    pipeline.fireUserEventTriggered(InternalProtocolNegotiationEvent.getDefault());
+    final SettableFuture<Object> future = SettableFuture.create();
+    sslContextProviderSupplier
+        .updateSslContext(new SslContextProvider.Callback(MoreExecutors.directExecutor()) {
+          @Override
+          public void updateSslContextAndExtendedX509TrustManager(
+              AbstractMap.SimpleImmutableEntry<SslContext, X509TrustManager> sslContextAndTm) {
+            future.set(sslContextAndTm);
+          }
 
-            @Override
-            protected void onException(Throwable throwable) {
-              future.set(throwable);
-            }
-          }, false);
-      executor.runDueTasks();
-      channel.runPendingTasks(); // need this for tasks to execute on eventLoop
-      Object fromFuture = future.get(5, TimeUnit.SECONDS);
-      assertThat(fromFuture).isInstanceOf(AbstractMap.SimpleImmutableEntry.class);
-      channel.runPendingTasks();
-      channelHandlerCtx = pipeline.context(clientSecurityHandler);
-      assertThat(channelHandlerCtx).isNull();
-      Object sslEvent = SslHandshakeCompletionEvent.SUCCESS;
+          @Override
+          protected void onException(Throwable throwable) {
+            future.set(throwable);
+          }
+        }, false);
+    executor.runDueTasks();
+    channel.runPendingTasks(); // need this for tasks to execute on eventLoop
+    Object fromFuture = future.get(5, TimeUnit.SECONDS);
+    assertThat(fromFuture).isInstanceOf(AbstractMap.SimpleImmutableEntry.class);
+    channel.runPendingTasks();
+    channelHandlerCtx = pipeline.context(clientSecurityHandler);
+    assertThat(channelHandlerCtx).isNull();
+    Object sslEvent = SslHandshakeCompletionEvent.SUCCESS;
 
-      pipeline.fireUserEventTriggered(sslEvent);
-      channel.runPendingTasks(); // need this for tasks to execute on eventLoop
-      assertTrue(channel.isOpen());
-      CommonCertProviderTestUtils.register0();
-    } finally {
-      CertificateUtils.isXdsSniEnabled = false;
-    }
+    pipeline.fireUserEventTriggered(sslEvent);
+    channel.runPendingTasks(); // need this for tasks to execute on eventLoop
+    assertTrue(channel.isOpen());
+    CommonCertProviderTestUtils.register0();
   }
 
   @Test


### PR DESCRIPTION
Removes the following env var usages.
  GRPC_EXPERIMENTAL_XDS_SNI
  GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE
  GRPC_EXPERIMENTAL_XDS_SYSTEM_ROOT_CERTS
  GRPC_EXPERIMENTAL_XDS_GCP_AUTHENTICATION_FILTER