### PR TITLE
Update maximum supported edition to EDITION_2024

### DIFF
--- a/compiler/src/java_plugin/cpp/java_plugin.cpp
+++ b/compiler/src/java_plugin/cpp/java_plugin.cpp
@@ -58,7 +58,11 @@ class JavaGrpcGenerator : public protobuf::compiler::CodeGenerator {
     return protobuf::Edition::EDITION_PROTO2;
   }
   protobuf::Edition GetMaximumEdition() const override {
+#if GOOGLE_PROTOBUF_VERSION >= 6032000
     return protobuf::Edition::EDITION_2024;
+#else
+    return protobuf::Edition::EDITION_2023;
+#endif
   }
   std::vector<const protobuf::FieldDescriptor*> GetFeatureExtensions()
       const override {


### PR DESCRIPTION
gRPC doesn't do anything sensitive to the new 2024 features