### PR TITLE
Upgrade gson to 2.12.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "com.google.auto.value:auto-value-annotations:1.11.0",
     "com.google.auto.value:auto-value:1.11.0",
     "com.google.code.findbugs:jsr305:3.0.2",
-    "com.google.code.gson:gson:2.11.0",
+    "com.google.code.gson:gson:2.12.1",
     "com.google.errorprone:error_prone_annotations:2.36.0",
     "com.google.guava:failureaccess:1.0.1",
     "com.google.guava:guava:33.4.8-android",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,8 +41,8 @@ google-auth-credentials = "com.google.auth:google-auth-library-credentials:1.24.
 google-auth-oauth2Http = "com.google.auth:google-auth-library-oauth2-http:1.24.1"
 # Release notes: https://cloud.google.com/logging/docs/release-notes
 google-cloud-logging = "com.google.cloud:google-cloud-logging:3.23.1"
-# 2.12.1 requires error_prone_annotations:2.36.0 but we are stuck with 2.30.0
-gson = "com.google.code.gson:gson:2.11.0"
+# 2.13.0 requires error_prone_annotations:2.37.0, but we are stuck with 2.36.0
+gson = "com.google.code.gson:gson:2.12.1"
 # 33.4.8 requires com.google.errorprone:error_prone_annotations:2.36.0
 guava = "com.google.guava:guava:33.4.8-android"
 guava-betaChecker = "com.google.guava:guava-beta-checker:1.0"

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -18,7 +18,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "com.google.auto.value:auto-value-annotations:1.11.0",
     "com.google.auto.value:auto-value:1.11.0",
     "com.google.code.findbugs:jsr305:3.0.2",
-    "com.google.code.gson:gson:2.11.0",
+    "com.google.code.gson:gson:2.12.1",
     "com.google.errorprone:error_prone_annotations:2.36.0",
     "com.google.guava:failureaccess:1.0.1",
     "com.google.guava:guava:33.4.8-android",


### PR DESCRIPTION
Since error_prone_annotations are in version 2.37.0, there is not reason why gson couldn't be bumped to v2.12.1.
Since v2.12.0 gson do not support Java 7, but it has been dropped in https://github.com/grpc/grpc-java/pull/8828.