### PR TITLE
interop-testing: Increase timeout for StressTestClientTest

### DIFF
--- a/interop-testing/src/test/java/io/grpc/testing/integration/StressTestClientTest.java
+++ b/interop-testing/src/test/java/io/grpc/testing/integration/StressTestClientTest.java
@@ -44,7 +44,7 @@ import org.junit.runners.JUnit4;
 public class StressTestClientTest {
 
   @Rule
-  public final Timeout globalTimeout = Timeout.seconds(10);
+  public final Timeout globalTimeout = Timeout.seconds(15);
 
   @Test
   public void ipv6AddressesShouldBeSupported() {


### PR DESCRIPTION
gaugesShouldBeExported with TSAN doesn't finish in less than 6 seconds and sometimes takes 12 seconds.