### PR TITLE
Enable flags for CSM Cloud run gRPC Java (1.77.x backport)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/FilterRegistry.java
+++ b/xds/src/main/java/io/grpc/xds/FilterRegistry.java
@@ -17,7 +17,6 @@
 package io.grpc.xds;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.grpc.internal.GrpcUtil;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -33,18 +32,13 @@ final class FilterRegistry {
 
   private FilterRegistry() {}
 
-  static boolean isEnabledGcpAuthnFilter =
-      GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_GCP_AUTHENTICATION_FILTER", false);
-
   static synchronized FilterRegistry getDefaultRegistry() {
     if (instance == null) {
       instance = newRegistry().register(
               new FaultFilter.Provider(),
               new RouterFilter.Provider(),
-              new RbacFilter.Provider());
-      if (isEnabledGcpAuthnFilter) {
-        instance.register(new GcpAuthenticationFilter.Provider());
-      }
+              new RbacFilter.Provider(),
+              new GcpAuthenticationFilter.Provider());
     }
     return instance;
   }

--- a/xds/src/main/java/io/grpc/xds/GcpAuthenticationFilter.java
+++ b/xds/src/main/java/io/grpc/xds/GcpAuthenticationFilter.java
@@ -17,7 +17,6 @@
 package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.grpc.xds.FilterRegistry.isEnabledGcpAuthnFilter;
 import static io.grpc.xds.XdsNameResolver.CLUSTER_SELECTION_KEY;
 import static io.grpc.xds.XdsNameResolver.XDS_CONFIG_CALL_OPTION_KEY;
 
@@ -313,10 +312,6 @@ final class GcpAuthenticationFilter implements Filter {
     public AudienceWrapper parse(Any any) throws ResourceInvalidException {
       Audience audience;
       try {
-        if (!isEnabledGcpAuthnFilter) {
-          throw new InvalidProtocolBufferException("Environment variable for GCP Authentication "
-              + "Filter is Not Set");
-        }
         audience = any.unpack(Audience.class);
       } catch (InvalidProtocolBufferException ex) {
         throw new ResourceInvalidException("Invalid Resource in address proto", ex);

--- a/xds/src/main/java/io/grpc/xds/XdsClusterResource.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClusterResource.java
@@ -66,7 +66,7 @@ class XdsClusterResource extends XdsResourceType<CdsUpdate> {
               System.getProperty("io.grpc.xds.experimentalEnableLeastRequest", "true"));
   @VisibleForTesting
   public static boolean enableSystemRootCerts =
-      GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_SYSTEM_ROOT_CERTS", false);
+      GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_SYSTEM_ROOT_CERTS", true);
   static boolean isEnabledXdsHttpConnect =
       GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_HTTP_CONNECT", false);
 

--- a/xds/src/main/java/io/grpc/xds/XdsRouteConfigureResource.java
+++ b/xds/src/main/java/io/grpc/xds/XdsRouteConfigureResource.java
@@ -69,8 +69,8 @@ import javax.annotation.Nullable;
 
 class XdsRouteConfigureResource extends XdsResourceType<RdsUpdate> {
 
-  private static final String GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE =
-      "GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE";
+  private static final boolean isXdsAuthorityRewriteEnabled = GrpcUtil.getFlag(
+      "GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE", true);
   @VisibleForTesting
   static boolean enableRouteLookup = GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_RLS_LB", true);
 
@@ -475,8 +475,8 @@ class XdsRouteConfigureResource extends XdsResourceType<RdsUpdate> {
       case CLUSTER:
         return StructOrError.fromStruct(RouteAction.forCluster(
             proto.getCluster(), hashPolicies, timeoutNano, retryPolicy,
-            GrpcUtil.getFlag(GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE, false)
-            && args.getServerInfo().isTrustedXdsServer() && proto.getAutoHostRewrite().getValue()));
+            isXdsAuthorityRewriteEnabled && args.getServerInfo().isTrustedXdsServer()
+                && proto.getAutoHostRewrite().getValue()));
       case CLUSTER_HEADER:
         return null;
       case WEIGHTED_CLUSTERS:
@@ -510,8 +510,8 @@ class XdsRouteConfigureResource extends XdsResourceType<RdsUpdate> {
         }
         return StructOrError.fromStruct(VirtualHost.Route.RouteAction.forWeightedClusters(
             weightedClusters, hashPolicies, timeoutNano, retryPolicy,
-            GrpcUtil.getFlag(GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE, false)
-            && args.getServerInfo().isTrustedXdsServer() && proto.getAutoHostRewrite().getValue()));
+            isXdsAuthorityRewriteEnabled && args.getServerInfo().isTrustedXdsServer()
+                && proto.getAutoHostRewrite().getValue()));
       case CLUSTER_SPECIFIER_PLUGIN:
         if (enableRouteLookup) {
           String pluginName = proto.getClusterSpecifierPlugin();
@@ -527,8 +527,7 @@ class XdsRouteConfigureResource extends XdsResourceType<RdsUpdate> {
           NamedPluginConfig namedPluginConfig = NamedPluginConfig.create(pluginName, pluginConfig);
           return StructOrError.fromStruct(VirtualHost.Route.RouteAction.forClusterSpecifierPlugin(
               namedPluginConfig, hashPolicies, timeoutNano, retryPolicy,
-              GrpcUtil.getFlag(GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE, false)
-              && args.getServerInfo().isTrustedXdsServer()
+              isXdsAuthorityRewriteEnabled && args.getServerInfo().isTrustedXdsServer()
                   && proto.getAutoHostRewrite().getValue()));
         } else {
           return null;

--- a/xds/src/main/java/io/grpc/xds/internal/security/trust/CertificateUtils.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/trust/CertificateUtils.java
@@ -30,7 +30,7 @@ import java.security.cert.X509Certificate;
  * Contains certificate utility method(s).
  */
 public final class CertificateUtils {
-  public static boolean isXdsSniEnabled = GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_SNI", false);
+  public static boolean isXdsSniEnabled = GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_SNI", true);
   public static boolean useChannelAuthorityIfNoSniApplicable
       = GrpcUtil.getFlag("GRPC_USE_CHANNEL_AUTHORITY_IF_NO_SNI_APPLICABLE", false);
 

--- a/xds/src/test/java/io/grpc/xds/GcpAuthenticationFilterTest.java
+++ b/xds/src/test/java/io/grpc/xds/GcpAuthenticationFilterTest.java
@@ -468,7 +468,8 @@ public class GcpAuthenticationFilterTest {
   private static RdsUpdate getRdsUpdate() {
     RouteConfiguration routeConfiguration =
         buildRouteConfiguration("my-server", RDS_NAME, CLUSTER_NAME);
-    XdsResourceType.Args args = new XdsResourceType.Args(null, "0", "0", null, null, null);
+    XdsResourceType.Args args = new XdsResourceType.Args(
+        XdsTestUtils.EMPTY_BOOTSTRAPPER_SERVER_INFO, "0", "0", null, null, null);
     try {
       return XdsRouteConfigureResource.getInstance().doParse(args, routeConfiguration);
     } catch (ResourceInvalidException ex) {

--- a/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplDataTest.java
@@ -568,7 +568,7 @@ public class GrpcXdsClientImplDataTest {
     assertThat(struct.getErrorDetail()).isNull();
     assertThat(struct.getStruct().cluster()).isEqualTo("cluster-foo");
     assertThat(struct.getStruct().weightedClusters()).isNull();
-    assertThat(struct.getStruct().autoHostRewrite()).isFalse();
+    assertThat(struct.getStruct().autoHostRewrite()).isTrue();
   }
 
   @Test
@@ -656,7 +656,7 @@ public class GrpcXdsClientImplDataTest {
     assertThat(struct.getStruct().weightedClusters()).containsExactly(
         ClusterWeight.create("cluster-foo", 30, ImmutableMap.<String, FilterConfig>of()),
         ClusterWeight.create("cluster-bar", 70, ImmutableMap.<String, FilterConfig>of()));
-    assertThat(struct.getStruct().autoHostRewrite()).isFalse();
+    assertThat(struct.getStruct().autoHostRewrite()).isTrue();
   }
 
   @Test
@@ -1038,7 +1038,7 @@ public class GrpcXdsClientImplDataTest {
                 ImmutableMap.of("lookupService", "rls-cbt.googleapis.com"))), ImmutableSet.of(),
             getXdsResourceTypeArgs(true));
     assertThat(struct.getStruct()).isNotNull();
-    assertThat(struct.getStruct().autoHostRewrite()).isFalse();
+    assertThat(struct.getStruct().autoHostRewrite()).isTrue();
   }
 
   @Test
@@ -2447,7 +2447,6 @@ public class GrpcXdsClientImplDataTest {
 
   @Test
   public void processCluster_parsesAudienceMetadata() throws Exception {
-    FilterRegistry.isEnabledGcpAuthnFilter = true;
     MetadataRegistry.getInstance();
 
     Audience audience = Audience.newBuilder()
@@ -2491,14 +2490,11 @@ public class GrpcXdsClientImplDataTest {
         "FILTER_METADATA", ImmutableMap.of(
             "key1", "value1",
             "key2", 42.0));
-    try {
-      assertThat(update.parsedMetadata().get("FILTER_METADATA"))
-          .isEqualTo(expectedParsedMetadata.get("FILTER_METADATA"));
-      assertThat(update.parsedMetadata().get("AUDIENCE_METADATA"))
-          .isInstanceOf(AudienceWrapper.class);
-    } finally {
-      FilterRegistry.isEnabledGcpAuthnFilter = false;
-    }
+
+    assertThat(update.parsedMetadata().get("FILTER_METADATA"))
+        .isEqualTo(expectedParsedMetadata.get("FILTER_METADATA"));
+    assertThat(update.parsedMetadata().get("AUDIENCE_METADATA"))
+        .isInstanceOf(AudienceWrapper.class);
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/XdsTestUtils.java
+++ b/xds/src/test/java/io/grpc/xds/XdsTestUtils.java
@@ -47,6 +47,7 @@ import io.envoyproxy.envoy.service.load_stats.v3.LoadStatsResponse;
 import io.grpc.BindableService;
 import io.grpc.Context;
 import io.grpc.Context.CancellationListener;
+import io.grpc.InsecureChannelCredentials;
 import io.grpc.StatusOr;
 import io.grpc.internal.ExponentialBackoffPolicy;
 import io.grpc.internal.FakeClock;
@@ -84,6 +85,9 @@ public class XdsTestUtils {
   static final String HTTP_CONNECTION_MANAGER_TYPE_URL =
       "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3"
           + ".HttpConnectionManager";
+  static final Bootstrapper.ServerInfo EMPTY_BOOTSTRAPPER_SERVER_INFO =
+      Bootstrapper.ServerInfo.create(
+      "td.googleapis.com", InsecureChannelCredentials.create(), false, true, false);
   public static final String ENDPOINT_HOSTNAME = "data-host";
   public static final int ENDPOINT_PORT = 1234;
 
@@ -247,8 +251,8 @@ public class XdsTestUtils {
 
     RouteConfiguration routeConfiguration =
         buildRouteConfiguration(serverHostName, RDS_NAME, CLUSTER_NAME);
-    Bootstrapper.ServerInfo serverInfo = null;
-    XdsResourceType.Args args = new XdsResourceType.Args(serverInfo, "0", "0", null, null, null);
+    XdsResourceType.Args args = new XdsResourceType.Args(
+        EMPTY_BOOTSTRAPPER_SERVER_INFO, "0", "0", null, null, null);
     XdsRouteConfigureResource.RdsUpdate rdsUpdate =
         XdsRouteConfigureResource.getInstance().doParse(args, routeConfiguration);
 
@@ -268,7 +272,7 @@ public class XdsTestUtils {
     XdsEndpointResource.EdsUpdate edsUpdate = new XdsEndpointResource.EdsUpdate(
         EDS_NAME, lbEndpointsMap, Collections.emptyList());
     XdsClusterResource.CdsUpdate cdsUpdate = XdsClusterResource.CdsUpdate.forEds(
-        CLUSTER_NAME, EDS_NAME, serverInfo, null, null, null, false, null)
+        CLUSTER_NAME, EDS_NAME, null, null, null, null, false, null)
         .lbPolicyConfig(getWrrLbConfigAsMap()).build();
     XdsConfig.XdsClusterConfig clusterConfig = new XdsConfig.XdsClusterConfig(
         CLUSTER_NAME, cdsUpdate, new EndpointConfig(StatusOr.fromValue(edsUpdate)));


### PR DESCRIPTION
Make default to true for the env vars
GRPC_EXPERIMENTAL_XDS_SNI
GRPC_EXPERIMENTAL_XDS_AUTHORITY_REWRITE
GRPC_EXPERIMENTAL_XDS_SYSTEM_ROOT_CERTS

and remove usage of the env var GRPC_EXPERIMENTAL_XDS_GCP_AUTHENTICATION_FILTER and make it enabled.

Backport of #12499