### PR TITLE
alts: Metadata Server Address Override with Environment Variable (1.77.x backport)

### DIFF
--- a/alts/src/test/java/io/grpc/alts/HandshakerServiceChannelTest.java
+++ b/alts/src/test/java/io/grpc/alts/HandshakerServiceChannelTest.java
@@ -68,6 +68,24 @@ public final class HandshakerServiceChannelTest {
   }
 
   @Test
+  public void getHandshakerTarget_nullEnvVar() {
+    assertThat(HandshakerServiceChannel.getHandshakerTarget(null))
+        .isEqualTo("metadata.google.internal.:8080");
+  }
+
+  @Test
+  public void getHandshakerTarget_envVarWithPort() {
+    assertThat(HandshakerServiceChannel.getHandshakerTarget("169.254.169.254:80"))
+        .isEqualTo("169.254.169.254:8080");
+  }
+
+  @Test
+  public void getHandshakerTarget_envVarWithHostOnly() {
+    assertThat(HandshakerServiceChannel.getHandshakerTarget("169.254.169.254"))
+        .isEqualTo("169.254.169.254:8080");
+  }
+  
+  @Test
   public void resource_works() {
     Channel channel = resource.create();
     try {


### PR DESCRIPTION
Adding an option to override "metadata.google.internal.:8080" by setting a value for GCE_METADATA_HOST environment variable.

b/451639946

cc: @apolcyn , @anicr7 

-----

Fixing the utilization of the GCE Metadata host server address environment variable to account for the case where the user does not specify a port (defaults to port 8080)

b/451639946

Backport of #12447 and #12468