### PR TITLE
okhttp: Fix bidirectional keep-alive causing spurious GO_AWAY (1.77.x backport)

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpServerTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpServerTransport.java
@@ -951,13 +951,13 @@ final class OkHttpServerTransport implements ServerTransport,
 
     @Override
     public void ping(boolean ack, int payload1, int payload2) {
-      if (!keepAliveEnforcer.pingAcceptable()) {
-        abruptShutdown(ErrorCode.ENHANCE_YOUR_CALM, "too_many_pings",
-            Status.RESOURCE_EXHAUSTED.withDescription("Too many pings from client"), false);
-        return;
-      }
       long payload = (((long) payload1) << 32) | (payload2 & 0xffffffffL);
       if (!ack) {
+        if (!keepAliveEnforcer.pingAcceptable()) {
+          abruptShutdown(ErrorCode.ENHANCE_YOUR_CALM, "too_many_pings",
+              Status.RESOURCE_EXHAUSTED.withDescription("Too many pings from client"), false);
+          return;
+        }
         frameLogger.logPing(OkHttpFrameLogger.Direction.INBOUND, payload);
         synchronized (lock) {
           frameWriter.ping(true, payload1, payload2);


### PR DESCRIPTION
## Problem

When bidirectional keep-alive is enabled (both client and server sending keep-alive pings), the server incorrectly terminates connections with a `GO_AWAY` frame even when the client is compliant with the server's keep-alive policies. This occurs because the `KeepAliveEnforcer` validates all incoming ping frames—both client-initiated ping requests and ping acknowledgments (ACKs) sent in response to server-initiated pings.

In a bidirectional keep-alive scenario, the client sends ACKs back to the server for each server-initiated ping. These ACKs are legitimate protocol responses, not abusive client behavior. However, the enforcer treats them as strike-worthy events, causing the strike counter to increment until `MAX_PING_STRIKES` is exceeded, triggering a connection shutdown with `ENHANCE_YOUR_CALM`.

This breaks bidirectional keep-alive entirely—a legitimate use case for detecting network failures from both endpoints.

## Solution

The keep-alive enforcement logic now only validates client-initiated ping requests (`ack=false`), not ping acknowledgments (`ack=true`). This allows servers and clients to exchange keep-alive pings independently without either side's pings counting against the other's enforcement limits.

The fix moves the `keepAliveEnforcer.pingAcceptable()` check inside the `!ack` conditional block in `okhttp/src/main/java/io/grpc/okhttp/OkHttpServerTransport.java:954`, ensuring ping ACKs bypass validation entirely.

## Impact

This fix enables bidirectional keep-alive to work correctly. Clients can now respond to server pings without triggering spurious connection shutdowns. Server-side keep-alive enforcement continues to protect against abusive client behavior for actual ping requests.

No breaking changes. This corrects existing behavior to match the expected semantics of the HTTP/2 ping mechanism.

Fixes #12417

Backport of #12502

CC @kssumin