### PR TITLE
util: Add RunWith to RandomSubsettingLoadBalancerTest

### DIFF
--- a/util/src/test/java/io/grpc/util/RandomSubsettingLoadBalancerTest.java
+++ b/util/src/test/java/io/grpc/util/RandomSubsettingLoadBalancerTest.java
@@ -47,6 +47,8 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -55,6 +57,7 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.stubbing.Answer;
 
+@RunWith(JUnit4.class)
 public class RandomSubsettingLoadBalancerTest {
   @Rule
   public final MockitoRule mockitoRule = MockitoJUnit.rule();


### PR DESCRIPTION
In some environments the test won't run without the annotation.

CC @Zgoda91