### PR TITLE
Fix AbstractClientStream Javadoc

### DIFF
--- a/core/src/main/java/io/grpc/internal/AbstractClientStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractClientStream.java
@@ -44,8 +44,8 @@ import javax.annotation.Nullable;
 
 /**
  * The abstract base class for {@link ClientStream} implementations.
- * <p>
- * Must only be called from the sending application thread.
+ *
+ * <p>Must only be called from the sending application thread.
  */
 public abstract class AbstractClientStream extends AbstractStream
     implements ClientStream, MessageFramer.Sink {


### PR DESCRIPTION
Subclasses also need to implement `setAuthority(String)` and `getAttributes()` which come in from the `ClientStream` interface.

An alternative fix is to implement defaults for these two methods in `AbstractClientStream`. `getAttributes()` could return an empty `Attributes`, and `setAuthority()` would no-op. Let me know if you'd prefer that.