### PR TITLE
servlet: Ignore timeoutOnSleepingServer for Tomcat (1.77.x backport)

### DIFF
--- a/servlet/src/tomcatTest/java/io/grpc/servlet/TomcatInteropTest.java
+++ b/servlet/src/tomcatTest/java/io/grpc/servlet/TomcatInteropTest.java
@@ -113,27 +113,28 @@ public class TomcatInteropTest extends AbstractInteropTest {
   @Test
   public void gracefulShutdown() {}
 
-  // FIXME
   @Override
   @Ignore("Tomcat is not able to send trailer only")
   @Test
   public void specialStatusMessage() {}
 
-  // FIXME
   @Override
   @Ignore("Tomcat is not able to send trailer only")
   @Test
   public void unimplementedMethod() {}
 
-  // FIXME
   @Override
   @Ignore("Tomcat is not able to send trailer only")
   @Test
   public void statusCodeAndMessage() {}
 
-  // FIXME
   @Override
   @Ignore("Tomcat is not able to send trailer only")
   @Test
   public void emptyStream() {}
+
+  @Override
+  @Ignore("Tomcat is not able to send trailer only")
+  @Test
+  public void timeoutOnSleepingServer() {}
 }


### PR DESCRIPTION
tomcat10Test is frequently failing on Windows because Tomcat doesn't support trailers-only. I removed the FIXMEs because we won't workaround Tomcat in grpc-servlet because:

1. An interceptor that converts trailers-only into headers+trailers would handle most cases, as it could run directly next to the application.  That is semantically very safe. But an interceptor doesn't help deadline handling and other transport-caused closures, as those trailers-only are produced by the transport
2. Having the transport convert trailers-only would work for deadline handling, but is not semantically safe
3. The other languages didn't find Tomcat to be important enough to support HEADERS+empty DATA(END_STREAM) as trailers-only on the client-side

```
Unexpected status: Status{code=INTERNAL, description=Received unexpected EOS on empty DATA frame from server, cause=null}
value of: getCode()
expected: DEADLINE_EXCEEDED
but was : INTERNAL
	at app//io.grpc.testing.integration.AbstractInteropTest.assertCodeEquals(AbstractInteropTest.java:2028)
	at app//io.grpc.testing.integration.AbstractInteropTest.timeoutOnSleepingServer(AbstractInteropTest.java:1644)
```

Backport of #12510