### PR TITLE
feat:Add RISC-V 64-bit architecture support to compiler build configuration

### DIFF
--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -76,6 +76,7 @@ model {
         aarch_64 { architecture "aarch_64" }
         s390_64 { architecture "s390_64" }
         loongarch_64 { architecture "loongarch_64" }
+        riscv_64 { architecture "riscv_64" }
     }
 
     components {
@@ -84,6 +85,7 @@ model {
                 'x86_32',
                 'x86_64',
                 'ppcle_64',
+                'riscv_64',
                 'aarch_64',
                 's390_64',
                 'loongarch_64'


### PR DESCRIPTION
Add riscv_64 platform definition and include it in the supported architectures list for the protoc plugin compiler. This enables the gRPC Java compiler to generate native code for RISC-V 64-bit architecture.

The changes allow the compiler module to recognize and build for RISC-V architecture, enabling native code generation for RISC-V platforms. This has been tested and verified on RISC-V SG2044 servers.