### PR TITLE
Upgrade errorprone annotations to 2.44.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,7 +15,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "com.google.auto.value:auto-value:1.11.0",
     "com.google.code.findbugs:jsr305:3.0.2",
     "com.google.code.gson:gson:2.12.1",
-    "com.google.errorprone:error_prone_annotations:2.36.0",
+    "com.google.errorprone:error_prone_annotations:2.44.0",
     "com.google.guava:failureaccess:1.0.1",
     "com.google.guava:guava:33.4.8-android",
     "com.google.re2j:re2j:1.8",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ commons-math3 = "org.apache.commons:commons-math3:3.6.1"
 conscrypt = "org.conscrypt:conscrypt-openjdk-uber:2.5.2"
 cronet-api = "org.chromium.net:cronet-api:119.6045.31"
 cronet-embedded = "org.chromium.net:cronet-embedded:119.6045.31"
-errorprone-annotations = "com.google.errorprone:error_prone_annotations:2.36.0"
+errorprone-annotations = "com.google.errorprone:error_prone_annotations:2.44.0"
 # error-prone 2.32.0+ require Java 17+
 errorprone-core = "com.google.errorprone:error_prone_core:2.31.0"
 google-api-protos = "com.google.api.grpc:proto-google-common-protos:2.59.2"

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -19,7 +19,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
     "com.google.auto.value:auto-value:1.11.0",
     "com.google.code.findbugs:jsr305:3.0.2",
     "com.google.code.gson:gson:2.12.1",
-    "com.google.errorprone:error_prone_annotations:2.36.0",
+    "com.google.errorprone:error_prone_annotations:2.44.0",
     "com.google.guava:failureaccess:1.0.1",
     "com.google.guava:guava:33.4.8-android",
     "com.google.re2j:re2j:1.8",


### PR DESCRIPTION
In v2.37.0 the annotations that were previously in type_annotations artifact have been merged into annotations. Annotations added there:
* com.google.errorprone.annotations.ImmutableTypeParameter,
* com.google.errorprone.annotations.ThreadSafeTypeParameter.

In next releases only Javadoc was changed.

This update will enable updates of gson and guava libraries.