### PR TITLE
servlet: disable RECYCLE_FACADES to reduce flaky tests

### DIFF
--- a/servlet/src/tomcatTest/java/io/grpc/servlet/TomcatTransportTest.java
+++ b/servlet/src/tomcatTest/java/io/grpc/servlet/TomcatTransportTest.java
@@ -93,6 +93,9 @@ public class TomcatTransportTest extends AbstractTransportTest {
             .setAsyncSupported(true);
         ctx.addServletMappingDecoded("/*", "TomcatTransportTest");
         tomcatServer.getConnector().addUpgradeProtocol(new Http2Protocol());
+        // Workaround for https://github.com/grpc/grpc-java/issues/12540
+        // Prevent premature OutputBuffer recycling by disabling facade recycling.
+        // This should be revisited once the root cause is fixed.
         tomcatServer.getConnector().setDiscardFacades(false);
         try {
           tomcatServer.start();


### PR DESCRIPTION
### Background
In the gRPC servlet transport with Tomcat 10 Embedded, 
we observed occasional flaky tests in `grpc-servlet-jakarta:tomcat10Test`. 
The issue is related to a race condition where the OutputBuffer is prematurely recycled  during asynchronous writes.

### Changes
Reference: https://github.com/spring-projects/spring-boot/issues/36763#issuecomment-1667382305

This PR explicitly calls `.setDiscardFacades(false)` on the Tomcat 10 Embedded Connector. 
The intention is to prevent outputBuffer reuse, so that the above race condition does not occur during tests.

### Purpose
- Reduce the likelihood of flaky tests in `grpc-servlet-jakarta:tomcat10Test`
- Apply the method suggested in the referenced Spring Boot discussion

### Note
This change aligns Tomcat 10 Embedded behavior with Tomcat 9 (where `RECYCLE_FACADES` defaults to `false`), and is known to prevent premature  `OutputBuffer` recycling during async writes.
Based on the investigation and prior reports (e.g., Spring Boot discussion),
this is currently the correct and safe configuration for servlet-based asynchronous responses in Tomcat 10.

Fixes #12524