### PR TITLE
xds: Use separate key for ATTR_ADDRESS_NAME on a subchannel

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -87,6 +87,9 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
 
   private static final Attributes.Key<AtomicReference<ClusterLocality>> ATTR_CLUSTER_LOCALITY =
       Attributes.Key.create("io.grpc.xds.ClusterImplLoadBalancer.clusterLocality");
+  @VisibleForTesting
+  static final Attributes.Key<String> ATTR_SUBCHANNEL_ADDRESS_NAME =
+      Attributes.Key.create("io.grpc.xds.ClusterImplLoadBalancer.addressName");
 
   private final XdsLogger logger;
   private final Helper helper;
@@ -243,7 +246,7 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
         String hostname = args.getAddresses().get(0).getAttributes()
             .get(XdsInternalAttributes.ATTR_ADDRESS_NAME);
         if (hostname != null) {
-          attrsBuilder.set(XdsInternalAttributes.ATTR_ADDRESS_NAME, hostname);
+          attrsBuilder.set(ATTR_SUBCHANNEL_ADDRESS_NAME, hostname);
         }
       }
       args = args.toBuilder().setAddresses(addresses).setAttributes(attrsBuilder.build()).build();
@@ -442,8 +445,7 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
               && args.getCallOptions().getOption(XdsNameResolver.AUTO_HOST_REWRITE_KEY)) {
             result = PickResult.withSubchannel(result.getSubchannel(),
                 result.getStreamTracerFactory(),
-                result.getSubchannel().getAttributes().get(
-                    XdsInternalAttributes.ATTR_ADDRESS_NAME));
+                result.getSubchannel().getAttributes().get(ATTR_SUBCHANNEL_ADDRESS_NAME));
           }
         }
         return result;

--- a/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
@@ -19,6 +19,7 @@ package io.grpc.xds;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static io.grpc.xds.ClusterImplLoadBalancer.ATTR_SUBCHANNEL_ADDRESS_NAME;
 import static io.grpc.xds.XdsNameResolver.AUTO_HOST_REWRITE_KEY;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
@@ -909,7 +910,7 @@ public class ClusterImplLoadBalancerTest {
               new FixedResultPicker(PickResult.withSubchannel(subchannel)));
         }
       });
-      assertThat(subchannel.getAttributes().get(XdsInternalAttributes.ATTR_ADDRESS_NAME)).isEqualTo(
+      assertThat(subchannel.getAttributes().get(ATTR_SUBCHANNEL_ADDRESS_NAME)).isEqualTo(
           "authority-host-name");
       for (EquivalentAddressGroup eag : subchannel.getAllAddresses()) {
         assertThat(eag.getAttributes().get(XdsInternalAttributes.ATTR_ADDRESS_NAME))
@@ -961,7 +962,7 @@ public class ClusterImplLoadBalancerTest {
       }
     });
     // Sub Channel wrapper args won't have the address name although addresses will.
-    assertThat(subchannel.getAttributes().get(XdsInternalAttributes.ATTR_ADDRESS_NAME)).isNull();
+    assertThat(subchannel.getAttributes().get(ATTR_SUBCHANNEL_ADDRESS_NAME)).isNull();
     for (EquivalentAddressGroup eag : subchannel.getAllAddresses()) {
       assertThat(eag.getAttributes().get(XdsInternalAttributes.ATTR_ADDRESS_NAME))
           .isEqualTo("authority-host-name");


### PR DESCRIPTION
XdsInternalAttributes.ATTR_ADDRESS_NAME is annotated with `@EquivalentAddressGroup.Attr`, so it should only be used in the EAG.