### PR TITLE
core: Fix shutdown failing accepted RPCs

### DIFF
--- a/core/src/test/java/io/grpc/internal/DelayedClientCallTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientCallTest.java
@@ -151,10 +151,12 @@ public class DelayedClientCallTest {
     delayedClientCall.request(1);
     Runnable r = delayedClientCall.setCall(mockRealCall);
     assertThat(r).isNotNull();
-    r.run();
     @SuppressWarnings("unchecked")
     ArgumentCaptor<Listener<Integer>> listenerCaptor = ArgumentCaptor.forClass(Listener.class);
+    // start() must be called before setCall() returns (not in runnable), to ensure the in-use
+    // counts keeping the channel alive after shutdown() don't momentarily decrease to zero.
     verify(mockRealCall).start(listenerCaptor.capture(), any(Metadata.class));
+    r.run();
     Listener<Integer> realCallListener = listenerCaptor.getValue();
     verify(mockRealCall).request(1);
     realCallListener.onMessage(1);

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -1343,7 +1343,7 @@ public class ManagedChannelImplTest {
         PickResult.withSubchannel(subchannel));
 
     updateBalancingStateSafely(helper, READY, mockPicker);
-    assertEquals(2, executor.runDueTasks());
+    assertEquals(3, executor.runDueTasks());
 
     verify(mockPicker).pickSubchannel(any(PickSubchannelArgs.class));
     verify(mockTransport).newStream(


### PR DESCRIPTION
This fixes a race where RPCs could fail with "UNAVAILABLE: Channel shutdown invoked" even though they were created before channel.shutdown().

This basically adopts the internalStart() logic from DelayedStream, although the stream is a bit different because it has APIs that can be called before start() and doesn't need to handle cancel() without start().

The ManagedChannelImpltest had the number of due tasks increase because start() running earlier creates a DelayedStream. Previously the stream wasn't created until runDueTasks() so the mockPicker had already been installed and it could use a real stream from the beginning. But that's specific to the test; in practice it'd be a delayed stream before and after this change.

See #12536