### PR TITLE
core: improve ReflectionLongAdderCounter performance

### DIFF
--- a/core/src/main/java/io/grpc/internal/ReflectionLongAdderCounter.java
+++ b/core/src/main/java/io/grpc/internal/ReflectionLongAdderCounter.java
@@ -46,6 +46,8 @@ public final class ReflectionLongAdderCounter implements LongCounter {
 
       addMethodLookup = klass.getMethod("add", Long.TYPE);
       sumMethodLookup = klass.getMethod("sum");
+      addMethodLookup.setAccessible(true);
+      sumMethodLookup.setAccessible(true);
 
       Constructor<?>[] constructors = klass.getConstructors();
       for (Constructor<?> ctor : constructors) {


### PR DESCRIPTION
Avoid reflective access check in ReflectionLongAdderCounter.

The `ReflectionLongAdderCounter` uses reflection to invoke the `add` and `sum` methods of `java.util.concurrent.atomic.LongAdder`.

Previously, `setAccessible(true)` was not called on the reflected `Method` objects. This resulted in a security access check being performed on every invocation, causing a performance penalty.

This change calls `setAccessible(true)` on the `Method` objects after they are retrieved, which bypasses the access check and improves performance.

Fixes #12541

cc: @qsLI