### PR TITLE
Add missing @Nullable annotation

### DIFF
--- a/api/src/main/java/io/grpc/StatusException.java
+++ b/api/src/main/java/io/grpc/StatusException.java
@@ -65,6 +65,7 @@ public class StatusException extends Exception {
    *
    * @since 1.0.0
    */
+  @Nullable
   public final Metadata getTrailers() {
     return trailers;
   }


### PR DESCRIPTION
This simple commit adds a missing but necessary @Nullable annotation to `StatusException.getTrailers()`.