### PR TITLE
format Bazel files

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,8 +1,8 @@
 module(
     name = "grpc-java",
+    version = "1.79.0-SNAPSHOT",  # CURRENT_GRPC_VERSION
     compatibility_level = 0,
     repo_name = "io_grpc_grpc_java",
-    version = "1.79.0-SNAPSHOT",  # CURRENT_GRPC_VERSION
 )
 
 # GRPC_DEPS_START
@@ -63,119 +63,96 @@ maven.install(
     ],
     strict_visibility = True,
 )
-
 use_repo(maven, "maven")
 
 maven.override(
     coordinates = "com.google.protobuf:protobuf-java",
     target = "@com_google_protobuf//:protobuf_java",
 )
-
 maven.override(
     coordinates = "com.google.protobuf:protobuf-java-util",
     target = "@com_google_protobuf//:protobuf_java_util",
 )
-
 maven.override(
     coordinates = "com.google.protobuf:protobuf-javalite",
     target = "@com_google_protobuf//:protobuf_javalite",
 )
-
 maven.override(
     coordinates = "io.grpc:grpc-alts",
     target = "@io_grpc_grpc_java//alts",
 )
-
 maven.override(
     coordinates = "io.grpc:grpc-api",
     target = "@io_grpc_grpc_java//api",
 )
-
 maven.override(
     coordinates = "io.grpc:grpc-auth",
     target = "@io_grpc_grpc_java//auth",
 )
-
 maven.override(
     coordinates = "io.grpc:grpc-census",
     target = "@io_grpc_grpc_java//census",
 )
-
 maven.override(
     coordinates = "io.grpc:grpc-context",
     target = "@io_grpc_grpc_java//context",
 )
-
 maven.override(
     coordinates = "io.grpc:grpc-core",
     target = "@io_grpc_grpc_java//core:core_maven",
 )
-
 maven.override(
     coordinates = "io.grpc:grpc-googleapis",
     target = "@io_grpc_grpc_java//googleapis",
 )
-
 maven.override(
     coordinates = "io.grpc:grpc-grpclb",
     target = "@io_grpc_grpc_java//grpclb",
 )
-
 maven.override(
     coordinates = "io.grpc:grpc-inprocess",
     target = "@io_grpc_grpc_java//inprocess",
 )
-
 maven.override(
     coordinates = "io.grpc:grpc-netty",
     target = "@io_grpc_grpc_java//netty",
 )
-
 maven.override(
     coordinates = "io.grpc:grpc-netty-shaded",
     target = "@io_grpc_grpc_java//netty:shaded_maven",
 )
-
 maven.override(
     coordinates = "io.grpc:grpc-okhttp",
     target = "@io_grpc_grpc_java//okhttp",
 )
-
 maven.override(
     coordinates = "io.grpc:grpc-protobuf",
     target = "@io_grpc_grpc_java//protobuf",
 )
-
 maven.override(
     coordinates = "io.grpc:grpc-protobuf-lite",
     target = "@io_grpc_grpc_java//protobuf-lite",
 )
-
 maven.override(
     coordinates = "io.grpc:grpc-rls",
     target = "@io_grpc_grpc_java//rls",
 )
-
 maven.override(
     coordinates = "io.grpc:grpc-services",
     target = "@io_grpc_grpc_java//services:services_maven",
 )
-
 maven.override(
     coordinates = "io.grpc:grpc-stub",
     target = "@io_grpc_grpc_java//stub",
 )
-
 maven.override(
     coordinates = "io.grpc:grpc-testing",
     target = "@io_grpc_grpc_java//testing",
 )
-
 maven.override(
     coordinates = "io.grpc:grpc-xds",
     target = "@io_grpc_grpc_java//xds:xds_maven",
 )
-
 maven.override(
     coordinates = "io.grpc:grpc-util",
     target = "@io_grpc_grpc_java//util",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -10,14 +10,15 @@ http_archive(
 )
 
 load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
 bazel_features_deps()
 
 http_archive(
     name = "rules_java",
+    sha256 = "4e1a28a25c2efa53500c928d22ceffbc505dd95b335a2d025836a293b592212f",
     urls = [
         "https://github.com/bazelbuild/rules_java/releases/download/9.1.0/rules_java-9.1.0.tar.gz",
     ],
-    sha256 = "4e1a28a25c2efa53500c928d22ceffbc505dd95b335a2d025836a293b592212f",
 )
 
 load("@rules_java//java:rules_java_deps.bzl", "compatibility_proxy_repo")
@@ -32,9 +33,7 @@ http_archive(
 )
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
-load("//:repositories.bzl", "IO_GRPC_GRPC_JAVA_ARTIFACTS")
-load("//:repositories.bzl", "IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS")
-load("//:repositories.bzl", "grpc_java_repositories")
+load("//:repositories.bzl", "IO_GRPC_GRPC_JAVA_ARTIFACTS", "IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS", "grpc_java_repositories")
 
 grpc_java_repositories()
 

--- a/compiler/BUILD.bazel
+++ b/compiler/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@rules_java//java:defs.bzl", "java_library")
 load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@rules_java//java:defs.bzl", "java_library")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 load("//:java_grpc_library.bzl", "java_rpc_toolchain")
 

--- a/context/BUILD.bazel
+++ b/context/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_java//java:defs.bzl", "java_library")
+
 java_library(
     name = "context",
     visibility = ["//visibility:public"],

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@com_google_protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
+load("@rules_java//java:java_binary.bzl", "java_binary")
+load("@rules_java//java:java_library.bzl", "java_library")
 
 proto_library(
     name = "helloworld_proto",

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -1,6 +1,7 @@
-bazel_dep(name = "grpc-java", repo_name = "io_grpc_grpc_java", version = "1.79.0-SNAPSHOT")  # CURRENT_GRPC_VERSION
-bazel_dep(name = "grpc-proto", repo_name = "io_grpc_grpc_proto", version = "0.0.0-20240627-ec30f58")
-bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "33.1")
+bazel_dep(name = "grpc-java", version = "1.79.0-SNAPSHOT", repo_name = "io_grpc_grpc_java")  # CURRENT_GRPC_VERSION
+bazel_dep(name = "rules_java", version = "9.3.0")
+bazel_dep(name = "grpc-proto", version = "0.0.0-20240627-ec30f58", repo_name = "io_grpc_grpc_proto")
+bazel_dep(name = "protobuf", version = "33.1", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_jvm_external", version = "6.0")
 
 # Do not use this override in your own MODULE.bazel. It is unnecessary when
@@ -19,7 +20,6 @@ local_path_override(
 )
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
-
 use_repo(maven, "maven")
 
 maven.install(

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -21,10 +21,8 @@ http_archive(
     url = "https://github.com/bazelbuild/rules_jvm_external/releases/download/5.3/rules_jvm_external-5.3.tar.gz",
 )
 
+load("@io_grpc_grpc_java//:repositories.bzl", "IO_GRPC_GRPC_JAVA_ARTIFACTS", "IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS", "grpc_java_repositories")
 load("@rules_jvm_external//:defs.bzl", "maven_install")
-load("@io_grpc_grpc_java//:repositories.bzl", "IO_GRPC_GRPC_JAVA_ARTIFACTS")
-load("@io_grpc_grpc_java//:repositories.bzl", "IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS")
-load("@io_grpc_grpc_java//:repositories.bzl", "grpc_java_repositories")
 
 grpc_java_repositories()
 

--- a/examples/example-alts/BUILD.bazel
+++ b/examples/example-alts/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@com_google_protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
+load("@rules_java//java:java_binary.bzl", "java_binary")
+load("@rules_java//java:java_library.bzl", "java_library")
 
 proto_library(
     name = "helloworld_proto",

--- a/examples/example-gauth/BUILD.bazel
+++ b/examples/example-gauth/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
+load("@rules_java//java:java_binary.bzl", "java_binary")
+load("@rules_java//java:java_library.bzl", "java_library")
 
 java_library(
     name = "example-gauth",

--- a/examples/example-hostname/BUILD.bazel
+++ b/examples/example-hostname/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@com_google_protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
+load("@rules_java//java:java_binary.bzl", "java_binary")
+load("@rules_java//java:java_library.bzl", "java_library")
 
 proto_library(
     name = "helloworld_proto",

--- a/examples/example-tls/BUILD.bazel
+++ b/examples/example-tls/BUILD.bazel
@@ -1,6 +1,8 @@
 load("@com_google_protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_grpc_grpc_java//:java_grpc_library.bzl", "java_grpc_library")
+load("@rules_java//java:java_binary.bzl", "java_binary")
+load("@rules_java//java:java_library.bzl", "java_library")
 
 proto_library(
     name = "helloworld_proto",

--- a/s2a/BUILD.bazel
+++ b/s2a/BUILD.bazel
@@ -56,8 +56,8 @@ java_library(
         "src/main/java/io/grpc/s2a/internal/handshaker/SslContextFactory.java",
     ],
     deps = [
-        ":token_manager",
         ":s2a_identity",
+        ":token_manager",
         "//api",
         "//core:internal",
         "//netty",
@@ -87,7 +87,7 @@ java_library(
         "//netty",
         artifact("com.google.code.findbugs:jsr305"),
         artifact("com.google.errorprone:error_prone_annotations"),
-        artifact("com.google.guava:guava"), 
-        artifact("org.checkerframework:checker-qual"), 
+        artifact("com.google.guava:guava"),
+        artifact("org.checkerframework:checker-qual"),
     ],
 )


### PR DESCRIPTION
This prevents automated transformations of BUILD files from making extraneous diff noise.