### PR TITLE
okhttp: Assert no pending streams before transport READY

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -802,7 +802,9 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
         }
         synchronized (lock) {
           maxConcurrentStreams = Integer.MAX_VALUE;
-          startPendingStreams();
+          checkState(pendingStreams.isEmpty(),
+              "Pending streams detected during transport start."
+                  + " RPCs should not be started before transport is ready.");
         }
         // ClientFrameHandler need to be started after connectionPreface / settings, otherwise it
         // may send goAway immediately.


### PR DESCRIPTION
### What this PR does

Based on guidance from maintainers and what I have observed in the OkHttpClientTransport lifecycle, it seems that no pending streams should exist when the transport transitions to READY.
This PR adds an assertion to help verify this invariant.

---

### Note on Testing

All existing tests pass with this assertion in place.

---

This PR corresponds to **Step 2** of the plan discussed in #11985, by adding an explicit assertion to help ensure the transport readiness invariant.

Fixes #11985