### PR TITLE
Fix build with Bazel 9 by upgrading bazel_jar_jar and grpc-proto versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -46,10 +46,10 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
 ]
 # GRPC_DEPS_END
 
-bazel_dep(name = "bazel_jar_jar", version = "0.1.7")
+bazel_dep(name = "bazel_jar_jar", version = "0.1.11.bcr.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "googleapis", version = "0.0.0-20240326-1c8d509c5", repo_name = "com_google_googleapis")
-bazel_dep(name = "grpc-proto", version = "0.0.0-20240627-ec30f58", repo_name = "io_grpc_grpc_proto")
+bazel_dep(name = "grpc-proto", version = "0.0.0-20240627-ec30f58.bcr.1", repo_name = "io_grpc_grpc_proto")
 bazel_dep(name = "protobuf", version = "33.1", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "rules_java", version = "9.1.0")


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel-central-registry/pull/6856