### PR TITLE
bazel: always load java_proto_library from the protobuf repo

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_java//java:defs.bzl", "java_library", "java_plugin", "java_proto_library")
+load("@com_google_protobuf//bazel:java_proto_library.bzl", "java_proto_library")
+load("@rules_java//java:defs.bzl", "java_library", "java_plugin")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 load(":java_grpc_library.bzl", "java_grpc_library")
 

--- a/alts/BUILD.bazel
+++ b/alts/BUILD.bazel
@@ -1,5 +1,6 @@
+load("@com_google_protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
-load("@rules_java//java:defs.bzl", "java_library", "java_proto_library")
+load("@rules_java//java:defs.bzl", "java_library")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 load("//:java_grpc_library.bzl", "java_grpc_library")
 

--- a/testing-proto/BUILD.bazel
+++ b/testing-proto/BUILD.bazel
@@ -1,5 +1,5 @@
+load("@com_google_protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
-load("@rules_java//java:defs.bzl", "java_proto_library")
 load("//:java_grpc_library.bzl", "java_grpc_library")
 
 proto_library(

--- a/xds/BUILD.bazel
+++ b/xds/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@bazel_jar_jar//:jar_jar.bzl", "jar_jar")
+load("@com_google_protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
-load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_proto_library", "java_test")
+load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_test")
 load("@rules_jvm_external//:defs.bzl", "artifact")
 load("//:java_grpc_library.bzl", "INTERNAL_java_grpc_library_for_xds", "java_grpc_library", "java_rpc_toolchain")
 


### PR DESCRIPTION
The java_proto_library rule in rules_java is deprecated.