### PR TITLE
core: Improve DEADLINE_EXCEEDED message for CallCreds delays

### DIFF
--- a/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/DelayedClientTransport.java
@@ -363,6 +363,7 @@ final class DelayedClientTransport implements ManagedClientTransport {
     private volatile Status lastPickStatus;
 
     private PendingStream(PickSubchannelArgs args, ClientStreamTracer[] tracers) {
+      super("connecting_and_lb");
       this.args = args;
       this.tracers = tracers;
     }

--- a/core/src/main/java/io/grpc/internal/MetadataApplierImpl.java
+++ b/core/src/main/java/io/grpc/internal/MetadataApplierImpl.java
@@ -120,7 +120,7 @@ final class MetadataApplierImpl extends MetadataApplier {
     synchronized (lock) {
       if (returnedStream == null) {
         // apply() has not been called, needs to buffer the requests.
-        delayedStream = new DelayedStream();
+        delayedStream = new DelayedStream("call_credentials");
         return returnedStream = delayedStream;
       } else {
         return returnedStream;

--- a/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedClientTransportTest.java
@@ -742,7 +742,7 @@ public class DelayedClientTransportTest {
     InsightBuilder insight = new InsightBuilder();
     stream.appendTimeoutInsight(insight);
     assertThat(insight.toString())
-        .matches("\\[wait_for_ready, buffered_nanos=[0-9]+\\, waiting_for_connection]");
+        .matches("\\[wait_for_ready, connecting_and_lb_delay=[0-9]+ns\\, was_still_waiting]");
   }
 
   @Test
@@ -759,7 +759,7 @@ public class DelayedClientTransportTest {
     assertThat(insight.toString())
         .matches("\\[wait_for_ready, "
             + "Last Pick Failure=Status\\{code=PERMISSION_DENIED, description=null, cause=null\\},"
-            + " buffered_nanos=[0-9]+, waiting_for_connection]");
+            + " connecting_and_lb_delay=[0-9]+ns, was_still_waiting]");
   }
 
   private static TransportProvider newTransportProvider(final ClientTransport transport) {

--- a/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/DelayedStreamTest.java
@@ -71,7 +71,7 @@ public class DelayedStreamTest {
   @Mock private ClientStreamListener listener;
   @Mock private ClientStream realStream;
   @Captor private ArgumentCaptor<ClientStreamListener> listenerCaptor;
-  private DelayedStream stream = new DelayedStream();
+  private DelayedStream stream = new DelayedStream("test_op");
 
   @Test
   public void setStream_setAuthority() {
@@ -450,7 +450,7 @@ public class DelayedStreamTest {
     InsightBuilder insight = new InsightBuilder();
     stream.start(listener);
     stream.appendTimeoutInsight(insight);
-    assertThat(insight.toString()).matches("\\[buffered_nanos=[0-9]+\\, waiting_for_connection]");
+    assertThat(insight.toString()).matches("\\[test_op_delay=[0-9]+ns\\, was_still_waiting]");
   }
 
   @Test
@@ -469,7 +469,7 @@ public class DelayedStreamTest {
     InsightBuilder insight = new InsightBuilder();
     stream.appendTimeoutInsight(insight);
     assertThat(insight.toString())
-        .matches("\\[buffered_nanos=[0-9]+, remote_addr=127\\.0\\.0\\.1:443\\]");
+        .matches("\\[test_op_delay=[0-9]+ns, remote_addr=127\\.0\\.0\\.1:443\\]");
   }
 
   private void callMeMaybe(Runnable r) {


### PR DESCRIPTION
DelayedStream is used both by DelayedClientTransport and CallCredentialsApplyingTransport, but it wasn't clear from the error which of the two was the cause of the delay. Now the two will have different messages.

b/462499883