### PR TITLE
core: Delete ReadableBuffer.readBytes(ByteBuffer)

### DIFF
--- a/core/src/main/java/io/grpc/internal/CompositeReadableBuffer.java
+++ b/core/src/main/java/io/grpc/internal/CompositeReadableBuffer.java
@@ -18,7 +18,6 @@ package io.grpc.internal;
 
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.InvalidMarkException;
 import java.util.ArrayDeque;
@@ -120,20 +119,6 @@ public class CompositeReadableBuffer extends AbstractReadableBuffer {
         }
       };
 
-  private static final NoThrowReadOperation<ByteBuffer> BYTE_BUF_OP =
-      new NoThrowReadOperation<ByteBuffer>() {
-        @Override
-        public int read(ReadableBuffer buffer, int length, ByteBuffer dest, int unused) {
-          // Change the limit so that only lengthToCopy bytes are available.
-          int prevLimit = dest.limit();
-          ((Buffer) dest).limit(dest.position() + length);
-          // Write the bytes and restore the original limit.
-          buffer.readBytes(dest);
-          ((Buffer) dest).limit(prevLimit);
-          return 0;
-        }
-      };
-
   private static final ReadOperation<OutputStream> STREAM_OP =
       new ReadOperation<OutputStream>() {
         @Override
@@ -147,11 +132,6 @@ public class CompositeReadableBuffer extends AbstractReadableBuffer {
   @Override
   public void readBytes(byte[] dest, int destOffset, int length) {
     executeNoThrow(BYTE_ARRAY_OP, length, dest, destOffset);
-  }
-
-  @Override
-  public void readBytes(ByteBuffer dest) {
-    executeNoThrow(BYTE_BUF_OP, dest.remaining(), dest, 0);
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ForwardingReadableBuffer.java
+++ b/core/src/main/java/io/grpc/internal/ForwardingReadableBuffer.java
@@ -68,11 +68,6 @@ public abstract class ForwardingReadableBuffer implements ReadableBuffer {
   }
 
   @Override
-  public void readBytes(ByteBuffer dest) {
-    buf.readBytes(dest);
-  }
-
-  @Override
   public void readBytes(OutputStream dest, int length) throws IOException {
     buf.readBytes(dest, length);
   }

--- a/core/src/main/java/io/grpc/internal/ReadableBuffer.java
+++ b/core/src/main/java/io/grpc/internal/ReadableBuffer.java
@@ -72,15 +72,6 @@ public interface ReadableBuffer extends Closeable {
   void readBytes(byte[] dest, int destOffset, int length);
 
   /**
-   * Reads from this buffer until the destination's position reaches its limit, and increases the
-   * read position by the number of the transferred bytes.
-   *
-   * @param dest the destination buffer to receive the bytes.
-   * @throws IndexOutOfBoundsException if required bytes are not readable
-   */
-  void readBytes(ByteBuffer dest);
-
-  /**
    * Reads {@code length} bytes from this buffer and writes them to the destination stream.
    * Increments the read position by {@code length}. If the required bytes are not readable, throws
    * {@link IndexOutOfBoundsException}.

--- a/core/src/main/java/io/grpc/internal/ReadableBuffers.java
+++ b/core/src/main/java/io/grpc/internal/ReadableBuffers.java
@@ -172,15 +172,6 @@ public final class ReadableBuffers {
     }
 
     @Override
-    public void readBytes(ByteBuffer dest) {
-      Preconditions.checkNotNull(dest, "dest");
-      int length = dest.remaining();
-      checkReadable(length);
-      dest.put(bytes, offset, length);
-      offset += length;
-    }
-
-    @Override
     public void readBytes(OutputStream dest, int length) throws IOException {
       checkReadable(length);
       dest.write(bytes, offset, length);
@@ -260,21 +251,6 @@ public final class ReadableBuffers {
     public void readBytes(byte[] dest, int destOffset, int length) {
       checkReadable(length);
       bytes.get(dest, destOffset, length);
-    }
-
-    @Override
-    public void readBytes(ByteBuffer dest) {
-      Preconditions.checkNotNull(dest, "dest");
-      int length = dest.remaining();
-      checkReadable(length);
-
-      // Change the limit so that only length bytes are available.
-      int prevLimit = bytes.limit();
-      ((Buffer) bytes).limit(bytes.position() + length);
-
-      // Write the bytes and restore the original limit.
-      dest.put(bytes);
-      bytes.limit(prevLimit);
     }
 
     @Override

--- a/core/src/test/java/io/grpc/internal/CompositeReadableBufferTest.java
+++ b/core/src/test/java/io/grpc/internal/CompositeReadableBufferTest.java
@@ -28,8 +28,6 @@ import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.Buffer;
-import java.nio.ByteBuffer;
 import java.nio.InvalidMarkException;
 import org.junit.After;
 import org.junit.Before;
@@ -122,27 +120,6 @@ public class CompositeReadableBufferTest {
   }
 
   @Test
-  public void readByteBufferShouldSucceed() {
-    ByteBuffer byteBuffer = ByteBuffer.allocate(EXPECTED_VALUE.length());
-    int remaining = EXPECTED_VALUE.length();
-
-    ((Buffer) byteBuffer).limit(1);
-    composite.readBytes(byteBuffer);
-    remaining--;
-    assertEquals(remaining, composite.readableBytes());
-
-    ((Buffer) byteBuffer).limit(byteBuffer.limit() + 5);
-    composite.readBytes(byteBuffer);
-    remaining -= 5;
-    assertEquals(remaining, composite.readableBytes());
-
-    ((Buffer) byteBuffer).limit(byteBuffer.limit() + remaining);
-    composite.readBytes(byteBuffer);
-    assertEquals(0, composite.readableBytes());
-    assertEquals(EXPECTED_VALUE, new String(byteBuffer.array(), UTF_8));
-  }
-
-  @Test
   public void readStreamShouldSucceed() throws IOException {
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
     int remaining = EXPECTED_VALUE.length();
@@ -213,18 +190,6 @@ public class CompositeReadableBufferTest {
     assertEquals(EXPECTED_VALUE.length(), composite.readableBytes());
     byte[] second = new byte[EXPECTED_VALUE.length()];
     composite.readBytes(second, 0, EXPECTED_VALUE.length());
-    assertArrayEquals(first, second);
-  }
-
-  @Test
-  public void markAndResetWithReadByteBufferShouldSucceed() {
-    byte[] first = new byte[EXPECTED_VALUE.length()];
-    composite.mark();
-    composite.readBytes(ByteBuffer.wrap(first));
-    composite.reset();
-    byte[] second = new byte[EXPECTED_VALUE.length()];
-    assertEquals(EXPECTED_VALUE.length(), composite.readableBytes());
-    composite.readBytes(ByteBuffer.wrap(second));
     assertArrayEquals(first, second);
   }
 

--- a/core/src/test/java/io/grpc/internal/ForwardingReadableBufferTest.java
+++ b/core/src/test/java/io/grpc/internal/ForwardingReadableBufferTest.java
@@ -25,7 +25,6 @@ import io.grpc.ForwardingTestUtil;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Method;
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import org.junit.Before;
 import org.junit.Rule;
@@ -89,14 +88,6 @@ public class ForwardingReadableBufferTest {
     buffer.readBytes(dest, 1, 2);
 
     verify(delegate).readBytes(dest, 1, 2);
-  }
-
-  @Test
-  public void readBytes_overload1() {
-    ByteBuffer dest = ByteBuffer.allocate(0);
-    buffer.readBytes(dest);
-
-    verify(delegate).readBytes(dest);
   }
 
   @Test

--- a/core/src/testFixtures/java/io/grpc/internal/ReadableBufferTestBase.java
+++ b/core/src/testFixtures/java/io/grpc/internal/ReadableBufferTestBase.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayOutputStream;
-import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import org.junit.Assume;
@@ -80,30 +79,6 @@ public abstract class ReadableBufferTestBase {
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
     buffer.readBytes(stream, 2);
     assertArrayEquals(new byte[]{'h', 'e'}, Arrays.copyOfRange(stream.toByteArray(), 0, 2));
-    assertEquals(msg.length() - 2, buffer.readableBytes());
-  }
-
-  @Test
-  public void readToByteBufferShouldSucceed() {
-    ReadableBuffer buffer = buffer();
-    ByteBuffer byteBuffer = ByteBuffer.allocate(msg.length());
-    buffer.readBytes(byteBuffer);
-    ((Buffer) byteBuffer).flip();
-    byte[] array = new byte[msg.length()];
-    byteBuffer.get(array);
-    assertArrayEquals(msg.getBytes(UTF_8), array);
-    assertEquals(0, buffer.readableBytes());
-  }
-
-  @Test
-  public void partialReadToByteBufferShouldSucceed() {
-    ReadableBuffer buffer = buffer();
-    ByteBuffer byteBuffer = ByteBuffer.allocate(2);
-    buffer.readBytes(byteBuffer);
-    ((Buffer) byteBuffer).flip();
-    byte[] array = new byte[2];
-    byteBuffer.get(array);
-    assertArrayEquals(new byte[]{'h', 'e'}, array);
     assertEquals(msg.length() - 2, buffer.readableBytes());
   }
 

--- a/netty/src/main/java/io/grpc/netty/NettyReadableBuffer.java
+++ b/netty/src/main/java/io/grpc/netty/NettyReadableBuffer.java
@@ -61,11 +61,6 @@ class NettyReadableBuffer extends AbstractReadableBuffer {
   }
 
   @Override
-  public void readBytes(ByteBuffer dest) {
-    buffer.readBytes(dest);
-  }
-
-  @Override
   public void readBytes(OutputStream dest, int length) {
     try {
       buffer.readBytes(dest, length);

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpReadableBuffer.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpReadableBuffer.java
@@ -21,7 +21,6 @@ import io.grpc.internal.ReadableBuffer;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.ByteBuffer;
 
 /**
  * A {@link ReadableBuffer} implementation that is backed by an {@link okio.Buffer}.
@@ -69,12 +68,6 @@ class OkHttpReadableBuffer extends AbstractReadableBuffer {
       length -= bytesRead;
       destOffset += bytesRead;
     }
-  }
-
-  @Override
-  public void readBytes(ByteBuffer dest) {
-    // We are not using it.
-    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpReadableBufferTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpReadableBufferTest.java
@@ -46,18 +46,6 @@ public class OkHttpReadableBufferTest extends ReadableBufferTestBase {
 
   @Override
   @Test
-  public void readToByteBufferShouldSucceed() {
-    // Not supported.
-  }
-
-  @Override
-  @Test
-  public void partialReadToByteBufferShouldSucceed() {
-    // Not supported.
-  }
-
-  @Override
-  @Test
   public void markAndResetWithReadShouldSucceed() {
     // Not supported.
   }


### PR DESCRIPTION
At the very least it isn't used now. The method is as old as ReadableBytes itself (05a2b252b), but it appears to have never actually been used.

CC @NguyenHoangSon96, @AgraVator, @panchenko 