### PR TITLE
bazel: Fix Bazel 8 WORKSPACE support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,49 +1,33 @@
 workspace(name = "io_grpc_grpc_java")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//:repositories.bzl", "IO_GRPC_GRPC_JAVA_ARTIFACTS", "IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS", "grpc_java_repositories")
+
+grpc_java_repositories()
 
 http_archive(
-    name = "bazel_features",
-    sha256 = "a660027f5a87f13224ab54b8dc6e191693c554f2692fcca46e8e29ee7dabc43b",
-    strip_prefix = "bazel_features-1.30.0",
-    url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.30.0/bazel_features-v1.30.0.tar.gz",
+    name = "rules_java",
+    sha256 = "47632cc506c858011853073449801d648e10483d4b50e080ec2549a4b2398960",
+    urls = [
+        "https://github.com/bazelbuild/rules_java/releases/download/8.15.2/rules_java-8.15.2.tar.gz",
+    ],
 )
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "PROTOBUF_MAVEN_ARTIFACTS", "protobuf_deps")
+
+protobuf_deps()
+
+load("@rules_java//java:rules_java_deps.bzl", "rules_java_dependencies")
+
+rules_java_dependencies()
 
 load("@bazel_features//:deps.bzl", "bazel_features_deps")
 
 bazel_features_deps()
 
-http_archive(
-    name = "rules_java",
-    sha256 = "4e1a28a25c2efa53500c928d22ceffbc505dd95b335a2d025836a293b592212f",
-    urls = [
-        "https://github.com/bazelbuild/rules_java/releases/download/9.1.0/rules_java-9.1.0.tar.gz",
-    ],
-)
-
-load("@rules_java//java:rules_java_deps.bzl", "compatibility_proxy_repo")
-
-compatibility_proxy_repo()
-
-http_archive(
-    name = "rules_jvm_external",
-    sha256 = "d31e369b854322ca5098ea12c69d7175ded971435e55c18dd9dd5f29cc5249ac",
-    strip_prefix = "rules_jvm_external-5.3",
-    url = "https://github.com/bazelbuild/rules_jvm_external/releases/download/5.3/rules_jvm_external-5.3.tar.gz",
-)
-
-load("@rules_jvm_external//:defs.bzl", "maven_install")
-load("//:repositories.bzl", "IO_GRPC_GRPC_JAVA_ARTIFACTS", "IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS", "grpc_java_repositories")
-
-grpc_java_repositories()
-
 load("@bazel_jar_jar//:jar_jar.bzl", "jar_jar_repositories")
 
 jar_jar_repositories()
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "PROTOBUF_MAVEN_ARTIFACTS", "protobuf_deps")
-
-protobuf_deps()
 
 load("@rules_python//python:repositories.bzl", "py_repositories")
 
@@ -54,6 +38,15 @@ load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_languag
 switched_rules_by_language(
     name = "com_google_googleapis_imports",
 )
+
+http_archive(
+    name = "rules_jvm_external",
+    sha256 = "d31e369b854322ca5098ea12c69d7175ded971435e55c18dd9dd5f29cc5249ac",
+    strip_prefix = "rules_jvm_external-5.3",
+    url = "https://github.com/bazelbuild/rules_jvm_external/releases/download/5.3/rules_jvm_external-5.3.tar.gz",
+)
+
+load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 maven_install(
     artifacts = IO_GRPC_GRPC_JAVA_ARTIFACTS + PROTOBUF_MAVEN_ARTIFACTS,

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -14,21 +14,17 @@ local_repository(
     path = "..",
 )
 
-http_archive(
-    name = "rules_jvm_external",
-    sha256 = "d31e369b854322ca5098ea12c69d7175ded971435e55c18dd9dd5f29cc5249ac",
-    strip_prefix = "rules_jvm_external-5.3",
-    url = "https://github.com/bazelbuild/rules_jvm_external/releases/download/5.3/rules_jvm_external-5.3.tar.gz",
-)
-
 load("@io_grpc_grpc_java//:repositories.bzl", "IO_GRPC_GRPC_JAVA_ARTIFACTS", "IO_GRPC_GRPC_JAVA_OVERRIDE_TARGETS", "grpc_java_repositories")
-load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 grpc_java_repositories()
 
-load("@bazel_jar_jar//:jar_jar.bzl", "jar_jar_repositories")
-
-jar_jar_repositories()
+http_archive(
+    name = "rules_java",
+    sha256 = "47632cc506c858011853073449801d648e10483d4b50e080ec2549a4b2398960",
+    urls = [
+        "https://github.com/bazelbuild/rules_java/releases/download/8.15.2/rules_java-8.15.2.tar.gz",
+    ],
+)
 
 # Protobuf now requires C++14 or higher, which requires Bazel configuration
 # outside the WORKSPACE. See .bazelrc in this directory.
@@ -36,19 +32,38 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "PROTOBUF_MAVEN_ARTIFACTS", "pr
 
 protobuf_deps()
 
+load("@rules_java//java:rules_java_deps.bzl", "compatibility_proxy_repo", "rules_java_dependencies")
+
+rules_java_dependencies()
+
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
+compatibility_proxy_repo()
+
+load("@bazel_jar_jar//:jar_jar.bzl", "jar_jar_repositories")
+
+jar_jar_repositories()
+
 load("@rules_python//python:repositories.bzl", "py_repositories")
 
 py_repositories()
-
-load("@rules_java//java:rules_java_deps.bzl", "compatibility_proxy_repo")
-
-compatibility_proxy_repo()
 
 load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
 
 switched_rules_by_language(
     name = "com_google_googleapis_imports",
 )
+
+http_archive(
+    name = "rules_jvm_external",
+    sha256 = "d31e369b854322ca5098ea12c69d7175ded971435e55c18dd9dd5f29cc5249ac",
+    strip_prefix = "rules_jvm_external-5.3",
+    url = "https://github.com/bazelbuild/rules_jvm_external/releases/download/5.3/rules_jvm_external-5.3.tar.gz",
+)
+
+load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 maven_install(
     artifacts = [


### PR DESCRIPTION
There's some rearranging happening here, like moving jar_jar later. But the main thing is downgrading rules_java to 8.15.2. rules_java 8.16 and later somehow break protobuf:

```
	File ".../external/com_google_protobuf/bazel/private/proto_library_rule.bzl", line 43, column 17, in _get_import_prefix
		if not paths.is_normalized(import_prefix):
Error: 'struct' value has no field or method 'is_normalized'
Available attributes: basename, dirname, is_absolute, join, normalize, relativize, replace_extension, split_extension
```

https://github.com/protocolbuffers/protobuf/issues/17687 claims that this is due to not using bazel_skylib 1.7.0, but protobuf_deps is defining bazel_skylib to be 1.7.0 and nothing earlier seems to be defining bazel_skylib. So we'll leave this as a bit of a mystery for later. rules_java 8.15.2 is still newer than protobuf_deps's 8.6.1.

CC @benjaminp