### PR TITLE
opentelemetry: Add Android API checking

### DIFF
--- a/opentelemetry/build.gradle
+++ b/opentelemetry/build.gradle
@@ -29,6 +29,11 @@ dependencies {
             extension = "signature"
         }
     }
+    signature (libraries.signature.android) {
+        artifact {
+            extension = "signature"
+        }
+    }
 }
 
 tasks.named("jar").configure {


### PR DESCRIPTION
opentelemetry-android is a thing, so support it with our otel code. opentelemetry-android actually requires desugaring, so some APIs would be available that animalsniffer would believe are not. However, gRPC normally doesn't require desugaring and requiring it in just this case makes it more annoying to verify.

CC @becomeStar