### PR TITLE
Catch Errors when calling complex parsing code

### DIFF
--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplTest.java
@@ -3943,6 +3943,28 @@ public class ManagedChannelImplTest {
   }
 
   @Test
+  public void nameResolverHelper_badParser_failsGracefully() {
+    boolean retryEnabled = false;
+    int maxRetryAttemptsLimit = 2;
+    int maxHedgedAttemptsLimit = 3;
+
+    Throwable t = new Error("really poor config parser");
+    when(mockLoadBalancerProvider.parseLoadBalancingPolicyConfig(any())).thenThrow(t);
+    ScParser parser = new ScParser(
+        retryEnabled,
+        maxRetryAttemptsLimit,
+        maxHedgedAttemptsLimit,
+        mockLoadBalancerProvider);
+
+    ConfigOrError coe = parser.parseServiceConfig(ImmutableMap.of());
+
+    assertThat(coe.getError()).isNotNull();
+    assertThat(coe.getError().getCode()).isEqualTo(Code.INTERNAL);
+    assertThat(coe.getError().getDescription()).contains("Unexpected error parsing service config");
+    assertThat(coe.getError().getCause()).isSameInstanceAs(t);
+  }
+
+  @Test
   public void nameResolverHelper_noConfigChosen() {
     boolean retryEnabled = false;
     int maxRetryAttemptsLimit = 2;


### PR DESCRIPTION
When we have involved parsing/validation logic, it would be easy to have bugs. There's little reason we can't handle those bugs, as the logic shouldn't be modifying global state. While the current config is bad or trigger a bug, we want to keep working until we get good/working config again.

For XDS, we do have the problem of losing the exception's stack trace. We could consider increasing the log level, but we could also consider propagating the error to the listener. Let's skip figuring out that exact behavior for now, and just move a step in the right direction.