### PR TITLE
Maybe use io.grpc.Uri for target parsing in ManagedChannelRegistry

### DIFF
--- a/api/src/main/java/io/grpc/FeatureFlags.java
+++ b/api/src/main/java/io/grpc/FeatureFlags.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+import com.google.common.base.Strings;
+
+class FeatureFlags {
+  static boolean getFlag(String envVarName, boolean enableByDefault) {
+    String envVar = System.getenv(envVarName);
+    if (envVar == null) {
+      envVar = System.getProperty(envVarName);
+    }
+    if (envVar != null) {
+      envVar = envVar.trim();
+    }
+    if (enableByDefault) {
+      return Strings.isNullOrEmpty(envVar) || Boolean.parseBoolean(envVar);
+    } else {
+      return !Strings.isNullOrEmpty(envVar) && Boolean.parseBoolean(envVar);
+    }
+  }
+
+  private FeatureFlags() {}
+}

--- a/api/src/main/java/io/grpc/FeatureFlags.java
+++ b/api/src/main/java/io/grpc/FeatureFlags.java
@@ -16,9 +16,25 @@
 
 package io.grpc;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 
 class FeatureFlags {
+  private static boolean enableRfc3986Uris = getFlag("GRPC_ENABLE_RFC3986_URIS", false);
+
+  /** Whether to parse targets as RFC 3986 URIs (true), or use {@link java.net.URI} (false). */
+  @VisibleForTesting
+  static boolean setRfc3986UrisEnabled(boolean value) {
+    boolean prevValue = enableRfc3986Uris;
+    enableRfc3986Uris = value;
+    return prevValue;
+  }
+
+  /** Whether to parse targets as RFC 3986 URIs (true), or use {@link java.net.URI} (false). */
+  static boolean getRfc3986UrisEnabled() {
+    return enableRfc3986Uris;
+  }
+
   static boolean getFlag(String envVarName, boolean enableByDefault) {
     String envVar = System.getenv(envVarName);
     if (envVar == null) {

--- a/api/src/main/java/io/grpc/InternalFeatureFlags.java
+++ b/api/src/main/java/io/grpc/InternalFeatureFlags.java
@@ -16,8 +16,23 @@
 
 package io.grpc;
 
+import com.google.common.annotations.VisibleForTesting;
+
+/** Global variables that govern major changes to the behavior of more than one grpc module. */
 @Internal
 public class InternalFeatureFlags {
+
+  /** Whether to parse targets as RFC 3986 URIs (true), or use {@link java.net.URI} (false). */
+  @VisibleForTesting
+  public static boolean setRfc3986UrisEnabled(boolean value) {
+    return FeatureFlags.setRfc3986UrisEnabled(value);
+  }
+
+  /** Whether to parse targets as RFC 3986 URIs (true), or use {@link java.net.URI} (false). */
+  public static boolean getRfc3986UrisEnabled() {
+    return FeatureFlags.getRfc3986UrisEnabled();
+  }
+
   public static boolean getFlag(String envVarName, boolean enableByDefault) {
     return FeatureFlags.getFlag(envVarName, enableByDefault);
   }

--- a/api/src/main/java/io/grpc/InternalFeatureFlags.java
+++ b/api/src/main/java/io/grpc/InternalFeatureFlags.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc;
+
+@Internal
+public class InternalFeatureFlags {
+  public static boolean getFlag(String envVarName, boolean enableByDefault) {
+    return FeatureFlags.getFlag(envVarName, enableByDefault);
+  }
+
+  private InternalFeatureFlags() {}
+}

--- a/api/src/main/java/io/grpc/ManagedChannelRegistry.java
+++ b/api/src/main/java/io/grpc/ManagedChannelRegistry.java
@@ -160,8 +160,11 @@ public final class ManagedChannelRegistry {
       String target, ChannelCredentials creds) {
     NameResolverProvider nameResolverProvider = null;
     try {
-      URI uri = new URI(target);
-      nameResolverProvider = nameResolverRegistry.getProviderForScheme(uri.getScheme());
+      String scheme =
+          FeatureFlags.getRfc3986UrisEnabled()
+              ? Uri.parse(target).getScheme()
+              : new URI(target).getScheme();
+      nameResolverProvider = nameResolverRegistry.getProviderForScheme(scheme);
     } catch (URISyntaxException ignore) {
       // bad URI found, just ignore and continue
     }

--- a/api/src/test/java/io/grpc/ManagedChannelRegistryTest.java
+++ b/api/src/test/java/io/grpc/ManagedChannelRegistryTest.java
@@ -20,17 +20,23 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 
 import com.google.common.collect.ImmutableSet;
+import io.grpc.FlagResetRule;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 /** Unit tests for {@link ManagedChannelRegistry}. */
-@RunWith(JUnit4.class)
+@RunWith(Parameterized.class)
 public class ManagedChannelRegistryTest {
   private String target = "testing123";
   private ChannelCredentials creds = new ChannelCredentials() {
@@ -39,6 +45,20 @@ public class ManagedChannelRegistryTest {
       throw new UnsupportedOperationException();
     }
   };
+
+  @Rule public final FlagResetRule flagResetRule = new FlagResetRule();
+
+  @Parameters(name = "enableRfc3986UrisParam={0}")
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(new Object[][] {{true}, {false}});
+  }
+
+  @Parameter public boolean enableRfc3986UrisParam;
+
+  @Before
+  public void setUp() {
+    flagResetRule.setFlagForTest(FeatureFlags::setRfc3986UrisEnabled, enableRfc3986UrisParam);
+  }
 
   @Test
   public void register_unavailableProviderThrows() {

--- a/api/src/testFixtures/java/io/grpc/FlagResetRule.java
+++ b/api/src/testFixtures/java/io/grpc/FlagResetRule.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.grpc.internal;
+package io.grpc;
 
 import java.util.ArrayDeque;
 import java.util.Deque;

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -24,7 +24,6 @@ import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Stopwatch;
-import com.google.common.base.Strings;
 import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -32,6 +31,7 @@ import io.grpc.CallOptions;
 import io.grpc.ClientStreamTracer;
 import io.grpc.ClientStreamTracer.StreamInfo;
 import io.grpc.InternalChannelz.SocketStats;
+import io.grpc.InternalFeatureFlags;
 import io.grpc.InternalLogId;
 import io.grpc.InternalMetadata;
 import io.grpc.InternalMetadata.TrustedAsciiMarshaller;
@@ -958,18 +958,7 @@ public final class GrpcUtil {
   }
 
   public static boolean getFlag(String envVarName, boolean enableByDefault) {
-    String envVar = System.getenv(envVarName);
-    if (envVar == null) {
-      envVar = System.getProperty(envVarName);
-    }
-    if (envVar != null) {
-      envVar = envVar.trim();
-    }
-    if (enableByDefault) {
-      return Strings.isNullOrEmpty(envVar) || Boolean.parseBoolean(envVar);
-    } else {
-      return !Strings.isNullOrEmpty(envVar) && Boolean.parseBoolean(envVar);
-    }
+    return InternalFeatureFlags.getFlag(envVarName, enableByDefault);
   }
 
 

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -38,6 +38,7 @@ import io.grpc.DecompressorRegistry;
 import io.grpc.EquivalentAddressGroup;
 import io.grpc.InternalChannelz;
 import io.grpc.InternalConfiguratorRegistry;
+import io.grpc.InternalFeatureFlags;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.MethodDescriptor;
@@ -105,16 +106,6 @@ public final class ManagedChannelImplBuilder
    * An idle timeout smaller than this would be capped to it.
    */
   static final long IDLE_MODE_MIN_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(1);
-
-  private static boolean enableRfc3986Uris = GrpcUtil.getFlag("GRPC_ENABLE_RFC3986_URIS", false);
-
-  /** Whether to parse targets as RFC 3986 URIs (true), or use {@link java.net.URI} (false). */
-  @VisibleForTesting
-  static boolean setRfc3986UrisEnabled(boolean value) {
-    boolean prevValue = ManagedChannelImplBuilder.enableRfc3986Uris;
-    ManagedChannelImplBuilder.enableRfc3986Uris = value;
-    return prevValue;
-  }
 
   private static final ObjectPool<? extends Executor> DEFAULT_EXECUTOR_POOL =
       SharedResourcePool.forResource(GrpcUtil.SHARED_CHANNEL_EXECUTOR);
@@ -731,7 +722,7 @@ public final class ManagedChannelImplBuilder
     ClientTransportFactory clientTransportFactory =
         clientTransportFactoryBuilder.buildClientTransportFactory();
     ResolvedNameResolver resolvedResolver =
-        enableRfc3986Uris
+        InternalFeatureFlags.getRfc3986UrisEnabled()
             ? getNameResolverProviderRfc3986(target, nameResolverRegistry)
             : getNameResolverProvider(target, nameResolverRegistry);
     resolvedResolver.checkAddressTypes(clientTransportFactory.getSupportedSocketAddressTypes());

--- a/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
+++ b/core/src/test/java/io/grpc/internal/DnsNameResolverTest.java
@@ -44,6 +44,7 @@ import com.google.common.net.InetAddresses;
 import com.google.common.testing.FakeTicker;
 import io.grpc.ChannelLogger;
 import io.grpc.EquivalentAddressGroup;
+import io.grpc.FlagResetRule;
 import io.grpc.HttpConnectProxiedSocketAddress;
 import io.grpc.NameResolver;
 import io.grpc.NameResolver.ConfigOrError;

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
@@ -38,6 +38,7 @@ import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.CompressorRegistry;
 import io.grpc.DecompressorRegistry;
+import io.grpc.FlagResetRule;
 import io.grpc.InternalConfigurator;
 import io.grpc.InternalConfiguratorRegistry;
 import io.grpc.InternalManagedChannelBuilder.InternalInterceptorFactory;

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
@@ -41,6 +41,7 @@ import io.grpc.DecompressorRegistry;
 import io.grpc.FlagResetRule;
 import io.grpc.InternalConfigurator;
 import io.grpc.InternalConfiguratorRegistry;
+import io.grpc.InternalFeatureFlags;
 import io.grpc.InternalManagedChannelBuilder.InternalInterceptorFactory;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
@@ -129,7 +130,7 @@ public class ManagedChannelImplBuilderTest {
   @Before
   public void setUp() throws Exception {
     flagResetRule.setFlagForTest(
-        ManagedChannelImplBuilder::setRfc3986UrisEnabled, enableRfc3986UrisParam);
+        InternalFeatureFlags::setRfc3986UrisEnabled, enableRfc3986UrisParam);
 
     builder = new ManagedChannelImplBuilder(
         DUMMY_TARGET,


### PR DESCRIPTION
Will not squash.