### PR TITLE
api: Remove unused ServiceProviders.load()

### DIFF
--- a/api/src/main/java/io/grpc/InternalServiceProviders.java
+++ b/api/src/main/java/io/grpc/InternalServiceProviders.java
@@ -27,17 +27,6 @@ public final class InternalServiceProviders {
   /**
    * Accessor for method.
    */
-  public static <T> T load(
-      Class<T> klass,
-      Iterable<Class<?>> hardcoded,
-      ClassLoader classLoader,
-      PriorityAccessor<T> priorityAccessor) {
-    return ServiceProviders.load(klass, hardcoded, classLoader, priorityAccessor);
-  }
-
-  /**
-   * Accessor for method.
-   */
   public static <T> List<T> loadAll(
       Class<T> klass,
       Iterable<Class<?>> hardCodedClasses,

--- a/api/src/main/java/io/grpc/ServiceProviders.java
+++ b/api/src/main/java/io/grpc/ServiceProviders.java
@@ -30,23 +30,6 @@ final class ServiceProviders {
   }
 
   /**
-   * If this is not Android, returns the highest priority implementation of the class via
-   * {@link ServiceLoader}.
-   * If this is Android, returns an instance of the highest priority class in {@code hardcoded}.
-   */
-  public static <T> T load(
-      Class<T> klass,
-      Iterable<Class<?>> hardcoded,
-      ClassLoader cl,
-      PriorityAccessor<T> priorityAccessor) {
-    List<T> candidates = loadAll(klass, hardcoded, cl, priorityAccessor);
-    if (candidates.isEmpty()) {
-      return null;
-    }
-    return candidates.get(0);
-  }
-
-  /**
    * If this is not Android, returns all available implementations discovered via
    * {@link ServiceLoader}.
    * If this is Android, returns all available implementations in {@code hardcoded}.


### PR DESCRIPTION
load() unused since c8a94d105 in 2020.

(I extracted this out of #12414)