### PR TITLE
compiler: Replace usages of deprecated protobuf method `protobuf::compiler::java::ClassName` with `protobuf::compiler::java::QualifiedClassName`

### DIFF
--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -213,7 +213,7 @@ static inline std::string MethodIdFieldName(const MethodDescriptor* method) {
 }
 
 static inline std::string MessageFullJavaName(const Descriptor* desc) {
-  return protobuf::compiler::java::ClassName(desc);
+  return proto2::compiler::java::QualifiedClassName(desc);
 }
 
 // TODO(nmittler): Remove once protobuf includes javadoc methods in distribution.
@@ -1050,7 +1050,7 @@ static void PrintGetServiceDescriptorMethod(const ServiceDescriptor* service,
     (*vars)["proto_base_descriptor_supplier"] = service_name + "BaseDescriptorSupplier";
     (*vars)["proto_file_descriptor_supplier"] = service_name + "FileDescriptorSupplier";
     (*vars)["proto_method_descriptor_supplier"] = service_name + "MethodDescriptorSupplier";
-    (*vars)["proto_class_name"] = protobuf::compiler::java::ClassName(service->file());
+    (*vars)["proto_class_name"] = proto2::compiler::java::QualifiedClassName(service->file());
     p->Print(
         *vars,
         "private static abstract class $proto_base_descriptor_supplier$\n"
@@ -1384,7 +1384,7 @@ void GenerateService(const ServiceDescriptor* service,
 }
 
 std::string ServiceJavaPackage(const FileDescriptor* file) {
-  std::string result = protobuf::compiler::java::ClassName(file);
+  std::string result = proto2::compiler::java::QualifiedClassName(file);
   size_t last_dot_pos = result.find_last_of('.');
   if (last_dot_pos != std::string::npos) {
     result.resize(last_dot_pos);

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -213,7 +213,7 @@ static inline std::string MethodIdFieldName(const MethodDescriptor* method) {
 }
 
 static inline std::string MessageFullJavaName(const Descriptor* desc) {
-  return proto2::compiler::java::QualifiedClassName(desc);
+  return protobuf::compiler::java::QualifiedClassName(desc);
 }
 
 // TODO(nmittler): Remove once protobuf includes javadoc methods in distribution.
@@ -1050,7 +1050,7 @@ static void PrintGetServiceDescriptorMethod(const ServiceDescriptor* service,
     (*vars)["proto_base_descriptor_supplier"] = service_name + "BaseDescriptorSupplier";
     (*vars)["proto_file_descriptor_supplier"] = service_name + "FileDescriptorSupplier";
     (*vars)["proto_method_descriptor_supplier"] = service_name + "MethodDescriptorSupplier";
-    (*vars)["proto_class_name"] = proto2::compiler::java::QualifiedClassName(service->file());
+    (*vars)["proto_class_name"] = protobuf::compiler::java::QualifiedClassName(service->file());
     p->Print(
         *vars,
         "private static abstract class $proto_base_descriptor_supplier$\n"
@@ -1384,7 +1384,7 @@ void GenerateService(const ServiceDescriptor* service,
 }
 
 std::string ServiceJavaPackage(const FileDescriptor* file) {
-  std::string result = proto2::compiler::java::QualifiedClassName(file);
+  std::string result = protobuf::compiler::java::QualifiedClassName(file);
   size_t last_dot_pos = result.find_last_of('.');
   if (last_dot_pos != std::string::npos) {
     result.resize(last_dot_pos);


### PR DESCRIPTION
Fixes #12464.