### PR TITLE
Reduce volatile reads in Metadata.LazyValue#toBytes

### DIFF
--- a/api/src/main/java/io/grpc/Metadata.java
+++ b/api/src/main/java/io/grpc/Metadata.java
@@ -936,10 +936,12 @@ public final class Metadata {
     }
 
     byte[] toBytes() {
+      byte[] serialized = this.serialized;
       if (serialized == null) {
         synchronized (this) {
+          serialized = this.serialized;
           if (serialized == null) {
-            serialized = streamToBytes(toStream());
+            this.serialized = serialized = streamToBytes(toStream());
           }
         }
       }


### PR DESCRIPTION
Fix double-checked locking idiom and reduce volatile reads in Metadata.LazyValue#toBytes.