### PR TITLE
Fix unit tests for name resolver provider returning null for the name resolver

### DIFF
--- a/api/src/test/java/io/grpc/NameResolverRegistryTest.java
+++ b/api/src/test/java/io/grpc/NameResolverRegistryTest.java
@@ -102,7 +102,9 @@ public class NameResolverRegistryTest {
     registry.register(
         new BaseProvider(true, 5, "noScheme") {
           @Override
-          public NameResolver newNameResolver(URI passedUri, NameResolver.Args passedArgs) {
+          public NameResolver newNameResolver(io.grpc.Uri passedUri, NameResolver.Args passedArgs) {
+            assertThat(passedUri).isSameInstanceAs(ioGrpcUri);
+            assertThat(passedArgs).isSameInstanceAs(args);
             return null;
           }
         });
@@ -116,7 +118,9 @@ public class NameResolverRegistryTest {
     registry.register(
         new BaseProvider(true, 5, "noScheme") {
           @Override
-          public NameResolver newNameResolver(URI passedUri, NameResolver.Args passedArgs) {
+          public NameResolver newNameResolver(io.grpc.Uri passedUri, NameResolver.Args passedArgs) {
+            assertThat(passedUri).isSameInstanceAs(javaNetUri);
+            assertThat(passedArgs).isSameInstanceAs(args);
             return null;
           }
         });

--- a/api/src/test/java/io/grpc/NameResolverRegistryTest.java
+++ b/api/src/test/java/io/grpc/NameResolverRegistryTest.java
@@ -103,8 +103,6 @@ public class NameResolverRegistryTest {
         new BaseProvider(true, 5, "noScheme") {
           @Override
           public NameResolver newNameResolver(URI passedUri, NameResolver.Args passedArgs) {
-            assertThat(passedUri).isSameInstanceAs(ioGrpcUri);
-            assertThat(passedArgs).isSameInstanceAs(args);
             return null;
           }
         });
@@ -119,8 +117,6 @@ public class NameResolverRegistryTest {
         new BaseProvider(true, 5, "noScheme") {
           @Override
           public NameResolver newNameResolver(URI passedUri, NameResolver.Args passedArgs) {
-            assertThat(passedUri).isSameInstanceAs(javaNetUri);
-            assertThat(passedArgs).isSameInstanceAs(args);
             return null;
           }
         });

--- a/api/src/test/java/io/grpc/NameResolverRegistryTest.java
+++ b/api/src/test/java/io/grpc/NameResolverRegistryTest.java
@@ -100,32 +100,32 @@ public class NameResolverRegistryTest {
   public void newNameResolver_providerReturnsNull_ioGrpcUri() {
     NameResolverRegistry registry = new NameResolverRegistry();
     registry.register(
-        new BaseProvider(true, 5, "noScheme") {
+        new BaseProvider(true, 5, ioGrpcUri.getScheme()) {
           @Override
-          public NameResolver newNameResolver(io.grpc.Uri passedUri, NameResolver.Args passedArgs) {
+          public NameResolver newNameResolver(Uri passedUri, NameResolver.Args passedArgs) {
             assertThat(passedUri).isSameInstanceAs(ioGrpcUri);
             assertThat(passedArgs).isSameInstanceAs(args);
             return null;
           }
         });
     assertThat(registry.asFactory().newNameResolver(ioGrpcUri, args)).isNull();
-    assertThat(registry.asFactory().getDefaultScheme()).isEqualTo("noScheme");
+    assertThat(registry.asFactory().getDefaultScheme()).isEqualTo(ioGrpcUri.getScheme());
   }
 
   @Test
   public void newNameResolver_providerReturnsNull_javaNetUri() {
     NameResolverRegistry registry = new NameResolverRegistry();
     registry.register(
-        new BaseProvider(true, 5, "noScheme") {
+        new BaseProvider(true, 5, javaNetUri.getScheme()) {
           @Override
-          public NameResolver newNameResolver(io.grpc.Uri passedUri, NameResolver.Args passedArgs) {
+          public NameResolver newNameResolver(URI passedUri, NameResolver.Args passedArgs) {
             assertThat(passedUri).isSameInstanceAs(javaNetUri);
             assertThat(passedArgs).isSameInstanceAs(args);
             return null;
           }
         });
     assertThat(registry.asFactory().newNameResolver(javaNetUri, args)).isNull();
-    assertThat(registry.asFactory().getDefaultScheme()).isEqualTo("noScheme");
+    assertThat(registry.asFactory().getDefaultScheme()).isEqualTo(javaNetUri.getScheme());
   }
 
   @Test


### PR DESCRIPTION
Fix unit tests that were meant to test the case of a registered provider for a scheme returning null for the name resolver. The tests were passing even with no provider registered for the passed Uri scheme.