### PR TITLE
xds: Remove isXdsSniEnabled and align SNI logic with gRFC A101

### DIFF
--- a/xds/src/main/java/io/grpc/xds/internal/security/SecurityProtocolNegotiators.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/SecurityProtocolNegotiators.java
@@ -215,23 +215,21 @@ public final class SecurityProtocolNegotiators {
       this.sslContextProviderSupplier = sslContextProviderSupplier;
       EnvoyServerProtoData.BaseTlsContext tlsContext = sslContextProviderSupplier.getTlsContext();
       UpstreamTlsContext upstreamTlsContext = ((UpstreamTlsContext) tlsContext);
-      if (CertificateUtils.isXdsSniEnabled) {
-        String sniToUse = upstreamTlsContext.getAutoHostSni()
-            && !Strings.isNullOrEmpty(endpointHostname)
-            ? endpointHostname : upstreamTlsContext.getSni();
-        if (sniToUse.isEmpty()) {
-          if (CertificateUtils.useChannelAuthorityIfNoSniApplicable) {
-            sniToUse = grpcHandler.getAuthority();
-          }
-          autoSniSanValidationDoesNotApply = true;
+
+      String sniToUse = upstreamTlsContext.getAutoHostSni()
+          && !Strings.isNullOrEmpty(endpointHostname)
+          ? endpointHostname : upstreamTlsContext.getSni();
+      if (sniToUse.isEmpty()) {
+        if (CertificateUtils.useChannelAuthorityIfNoSniApplicable) {
+          sniToUse = grpcHandler.getAuthority();
         } else {
-          autoSniSanValidationDoesNotApply = false;
+          sniToUse = "";
         }
-        sni = sniToUse;
+        autoSniSanValidationDoesNotApply = true;
       } else {
-        sni = grpcHandler.getAuthority();
         autoSniSanValidationDoesNotApply = false;
       }
+      sni = sniToUse;
     }
 
     @VisibleForTesting

--- a/xds/src/main/java/io/grpc/xds/internal/security/SecurityProtocolNegotiators.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/SecurityProtocolNegotiators.java
@@ -222,8 +222,6 @@ public final class SecurityProtocolNegotiators {
       if (sniToUse.isEmpty()) {
         if (CertificateUtils.useChannelAuthorityIfNoSniApplicable) {
           sniToUse = grpcHandler.getAuthority();
-        } else {
-          sniToUse = "";
         }
         autoSniSanValidationDoesNotApply = true;
       } else {

--- a/xds/src/main/java/io/grpc/xds/internal/security/trust/CertificateUtils.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/trust/CertificateUtils.java
@@ -30,7 +30,6 @@ import java.security.cert.X509Certificate;
  * Contains certificate utility method(s).
  */
 public final class CertificateUtils {
-  public static boolean isXdsSniEnabled = GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_SNI", true);
   public static boolean useChannelAuthorityIfNoSniApplicable
       = GrpcUtil.getFlag("GRPC_USE_CHANNEL_AUTHORITY_IF_NO_SNI_APPLICABLE", false);
 

--- a/xds/src/main/java/io/grpc/xds/internal/security/trust/XdsX509TrustManager.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/trust/XdsX509TrustManager.java
@@ -308,7 +308,7 @@ final class XdsX509TrustManager extends X509ExtendedTrustManager implements X509
 
   private List<StringMatcher> getAutoSniSanMatchers(SSLParameters sslParams) {
     List<StringMatcher> sniNamesToMatch = new ArrayList<>();
-    if (CertificateUtils.isXdsSniEnabled && autoSniSanValidation) {
+    if (autoSniSanValidation) {
       List<SNIServerName> serverNames = sslParams.getServerNames();
       if (serverNames != null) {
         for (SNIServerName serverName : serverNames) {

--- a/xds/src/test/java/io/grpc/xds/XdsSecurityClientServerTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsSecurityClientServerTest.java
@@ -77,7 +77,6 @@ import io.grpc.xds.internal.security.SecurityProtocolNegotiators;
 import io.grpc.xds.internal.security.SslContextProviderSupplier;
 import io.grpc.xds.internal.security.TlsContextManagerImpl;
 import io.grpc.xds.internal.security.certprovider.FileWatcherCertificateProviderProvider;
-import io.grpc.xds.internal.security.trust.CertificateUtils;
 import io.netty.handler.ssl.NotSslRecordException;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -317,7 +316,6 @@ public class XdsSecurityClientServerTest {
   @Test
   public void tlsClientServer_autoSniValidation_sniInUtc()
       throws Exception {
-    CertificateUtils.isXdsSniEnabled = true;
     Path trustStoreFilePath = getCacertFilePathForTestCa();
     try {
       setTrustStoreSystemProperties(trustStoreFilePath.toAbsolutePath().toString());
@@ -341,14 +339,12 @@ public class XdsSecurityClientServerTest {
     } finally {
       Files.deleteIfExists(trustStoreFilePath);
       clearTrustStoreSystemProperties();
-      CertificateUtils.isXdsSniEnabled = false;
     }
   }
 
   @Test
   public void tlsClientServer_autoSniValidation_sniFromHostname()
       throws Exception {
-    CertificateUtils.isXdsSniEnabled = true;
     Path trustStoreFilePath = getCacertFilePathForTestCa();
     try {
       setTrustStoreSystemProperties(trustStoreFilePath.toAbsolutePath().toString());
@@ -375,14 +371,12 @@ public class XdsSecurityClientServerTest {
     } finally {
       Files.deleteIfExists(trustStoreFilePath);
       clearTrustStoreSystemProperties();
-      CertificateUtils.isXdsSniEnabled = false;
     }
   }
 
   @Test
   public void tlsClientServer_autoSniValidation_noSniApplicable_usesMatcherFromCmnVdnCtx()
       throws Exception {
-    CertificateUtils.isXdsSniEnabled = true;
     Path trustStoreFilePath = getCacertFilePathForTestCa();
     try {
       setTrustStoreSystemProperties(trustStoreFilePath.toAbsolutePath().toString());
@@ -406,7 +400,6 @@ public class XdsSecurityClientServerTest {
     } finally {
       Files.deleteIfExists(trustStoreFilePath);
       clearTrustStoreSystemProperties();
-      CertificateUtils.isXdsSniEnabled = false;
     }
   }
 

--- a/xds/src/test/java/io/grpc/xds/internal/security/SecurityProtocolNegotiatorsTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/SecurityProtocolNegotiatorsTest.java
@@ -297,23 +297,6 @@ public class SecurityProtocolNegotiatorsTest {
   }
 
   @Test
-  public void sniInClientSecurityHandler_noSniConditionsMet_omitsSni() {
-    Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
-        .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
-            CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
-    UpstreamTlsContext upstreamTlsContext = CommonTlsContextTestsUtil.buildUpstreamTlsContext(
-        "google_cloud_private_spiffe-client", true, "", false);
-    SslContextProviderSupplier sslContextProviderSupplier =
-        new SslContextProviderSupplier(upstreamTlsContext,
-            new TlsContextManagerImpl(bootstrapInfoForClient));
-
-    ClientSecurityHandler clientSecurityHandler =
-        new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, HOSTNAME);
-
-    assertThat(clientSecurityHandler.getSni()).isEqualTo("");
-  }
-
-  @Test
   public void serverSecurityHandler_addLast()
       throws InterruptedException, TimeoutException, ExecutionException {
     FakeClock executor = new FakeClock();

--- a/xds/src/test/java/io/grpc/xds/internal/security/SecurityProtocolNegotiatorsTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/SecurityProtocolNegotiatorsTest.java
@@ -54,7 +54,6 @@ import io.grpc.xds.internal.XdsInternalAttributes;
 import io.grpc.xds.internal.security.SecurityProtocolNegotiators.ClientSecurityHandler;
 import io.grpc.xds.internal.security.SecurityProtocolNegotiators.ClientSecurityProtocolNegotiator;
 import io.grpc.xds.internal.security.certprovider.CommonCertProviderTestUtils;
-import io.grpc.xds.internal.security.trust.CertificateUtils;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
@@ -151,32 +150,27 @@ public class SecurityProtocolNegotiatorsTest {
 
   @Test
   public void clientSecurityProtocolNegotiator_autoHostSni_hostnamePassedToClientSecurityHandlr() {
-    CertificateUtils.isXdsSniEnabled = true;
-    try {
-      UpstreamTlsContext upstreamTlsContext =
-          CommonTlsContextTestsUtil.buildUpstreamTlsContext(
-              CommonTlsContext.newBuilder().build(), "", true, false);
-      ClientSecurityProtocolNegotiator pn =
-          new ClientSecurityProtocolNegotiator(InternalProtocolNegotiators.plaintext());
-      GrpcHttp2ConnectionHandler mockHandler = mock(GrpcHttp2ConnectionHandler.class);
-      ChannelLogger logger = mock(ChannelLogger.class);
-      doNothing().when(logger).log(any(ChannelLogLevel.class), anyString());
-      when(mockHandler.getNegotiationLogger()).thenReturn(logger);
-      TlsContextManager mockTlsContextManager = mock(TlsContextManager.class);
-      when(mockHandler.getEagAttributes())
-          .thenReturn(
-              Attributes.newBuilder()
-                  .set(SecurityProtocolNegotiators.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER,
-                      new SslContextProviderSupplier(upstreamTlsContext, mockTlsContextManager))
-                  .set(XdsInternalAttributes.ATTR_ADDRESS_NAME, FAKE_AUTHORITY)
-                  .build());
-      ChannelHandler newHandler = pn.newHandler(mockHandler);
-      assertThat(newHandler).isNotNull();
-      assertThat(newHandler).isInstanceOf(ClientSecurityHandler.class);
-      assertThat(((ClientSecurityHandler) newHandler).getSni()).isEqualTo(FAKE_AUTHORITY);
-    } finally {
-      CertificateUtils.isXdsSniEnabled = false;
-    }
+    UpstreamTlsContext upstreamTlsContext =
+        CommonTlsContextTestsUtil.buildUpstreamTlsContext(
+            CommonTlsContext.newBuilder().build(), "", true, false);
+    ClientSecurityProtocolNegotiator pn =
+        new ClientSecurityProtocolNegotiator(InternalProtocolNegotiators.plaintext());
+    GrpcHttp2ConnectionHandler mockHandler = mock(GrpcHttp2ConnectionHandler.class);
+    ChannelLogger logger = mock(ChannelLogger.class);
+    doNothing().when(logger).log(any(ChannelLogLevel.class), anyString());
+    when(mockHandler.getNegotiationLogger()).thenReturn(logger);
+    TlsContextManager mockTlsContextManager = mock(TlsContextManager.class);
+    when(mockHandler.getEagAttributes())
+        .thenReturn(
+            Attributes.newBuilder()
+                .set(SecurityProtocolNegotiators.ATTR_SSL_CONTEXT_PROVIDER_SUPPLIER,
+                    new SslContextProviderSupplier(upstreamTlsContext, mockTlsContextManager))
+                .set(XdsInternalAttributes.ATTR_ADDRESS_NAME, FAKE_AUTHORITY)
+                .build());
+    ChannelHandler newHandler = pn.newHandler(mockHandler);
+    assertThat(newHandler).isNotNull();
+    assertThat(newHandler).isInstanceOf(ClientSecurityHandler.class);
+    assertThat(((ClientSecurityHandler) newHandler).getSni()).isEqualTo(FAKE_AUTHORITY);
   }
 
   @Test
@@ -235,110 +229,88 @@ public class SecurityProtocolNegotiatorsTest {
 
   @Test
   public void sniInClientSecurityHandler_autoHostSniIsTrue_usesEndpointHostname() {
-    CertificateUtils.isXdsSniEnabled = true;
-    try {
-      Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
-          .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
-              CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
-      UpstreamTlsContext upstreamTlsContext =
-          CommonTlsContextTestsUtil
-              .buildUpstreamTlsContext("google_cloud_private_spiffe-client", true, "", true);
-      SslContextProviderSupplier sslContextProviderSupplier =
-          new SslContextProviderSupplier(upstreamTlsContext,
-              new TlsContextManagerImpl(bootstrapInfoForClient));
+    Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
+        .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
+            CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
+    UpstreamTlsContext upstreamTlsContext =
+        CommonTlsContextTestsUtil
+            .buildUpstreamTlsContext("google_cloud_private_spiffe-client", true, "", true);
+    SslContextProviderSupplier sslContextProviderSupplier =
+        new SslContextProviderSupplier(upstreamTlsContext,
+            new TlsContextManagerImpl(bootstrapInfoForClient));
 
-      ClientSecurityHandler clientSecurityHandler =
-          new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, HOSTNAME);
+    ClientSecurityHandler clientSecurityHandler =
+        new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, HOSTNAME);
 
-      assertThat(clientSecurityHandler.getSni()).isEqualTo(HOSTNAME);
-    } finally {
-      CertificateUtils.isXdsSniEnabled = false;
-    }
+    assertThat(clientSecurityHandler.getSni()).isEqualTo(HOSTNAME);
   }
 
   @Test
   public void sniInClientSecurityHandler_autoHostSni_endpointHostnameIsEmpty_usesSniFromUtc() {
-    CertificateUtils.isXdsSniEnabled = true;
-    try {
-      Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
-          .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
-              CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
-      UpstreamTlsContext upstreamTlsContext = CommonTlsContextTestsUtil.buildUpstreamTlsContext(
-          "google_cloud_private_spiffe-client", true, SNI_IN_UTC, true);
-      SslContextProviderSupplier sslContextProviderSupplier =
-          new SslContextProviderSupplier(upstreamTlsContext,
-              new TlsContextManagerImpl(bootstrapInfoForClient));
+    Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
+        .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
+            CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
+    UpstreamTlsContext upstreamTlsContext = CommonTlsContextTestsUtil.buildUpstreamTlsContext(
+        "google_cloud_private_spiffe-client", true, SNI_IN_UTC, true);
+    SslContextProviderSupplier sslContextProviderSupplier =
+        new SslContextProviderSupplier(upstreamTlsContext,
+            new TlsContextManagerImpl(bootstrapInfoForClient));
 
-      ClientSecurityHandler clientSecurityHandler =
-          new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, "");
+    ClientSecurityHandler clientSecurityHandler =
+        new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, "");
 
-      assertThat(clientSecurityHandler.getSni()).isEqualTo(SNI_IN_UTC);
-    } finally {
-      CertificateUtils.isXdsSniEnabled = false;
-    }
+    assertThat(clientSecurityHandler.getSni()).isEqualTo(SNI_IN_UTC);
   }
 
   @Test
   public void sniInClientSecurityHandler_autoHostSni_endpointHostnameIsNull_usesSniFromUtc() {
-    CertificateUtils.isXdsSniEnabled = true;
-    try {
-      Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
-          .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
-              CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
-      UpstreamTlsContext upstreamTlsContext = CommonTlsContextTestsUtil.buildUpstreamTlsContext(
-          "google_cloud_private_spiffe-client", true, SNI_IN_UTC, true);
-      SslContextProviderSupplier sslContextProviderSupplier =
-          new SslContextProviderSupplier(upstreamTlsContext,
-              new TlsContextManagerImpl(bootstrapInfoForClient));
+    Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
+        .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
+            CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
+    UpstreamTlsContext upstreamTlsContext = CommonTlsContextTestsUtil.buildUpstreamTlsContext(
+        "google_cloud_private_spiffe-client", true, SNI_IN_UTC, true);
+    SslContextProviderSupplier sslContextProviderSupplier =
+        new SslContextProviderSupplier(upstreamTlsContext,
+            new TlsContextManagerImpl(bootstrapInfoForClient));
 
-      ClientSecurityHandler clientSecurityHandler =
-          new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, null);
+    ClientSecurityHandler clientSecurityHandler =
+        new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, null);
 
-      assertThat(clientSecurityHandler.getSni()).isEqualTo(SNI_IN_UTC);
-    } finally {
-      CertificateUtils.isXdsSniEnabled = false;
-    }
+    assertThat(clientSecurityHandler.getSni()).isEqualTo(SNI_IN_UTC);
   }
 
   @Test
   public void sniInClientSecurityHandler_autoHostSniIsFalse_usesSniFromUpstreamTlsContext() {
-    CertificateUtils.isXdsSniEnabled = true;
-    try {
-      Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
-          .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
-              CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
-      UpstreamTlsContext upstreamTlsContext = CommonTlsContextTestsUtil.buildUpstreamTlsContext(
-          "google_cloud_private_spiffe-client", true, SNI_IN_UTC, false);
-      SslContextProviderSupplier sslContextProviderSupplier =
-          new SslContextProviderSupplier(upstreamTlsContext,
-              new TlsContextManagerImpl(bootstrapInfoForClient));
+    Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
+        .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
+            CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
+    UpstreamTlsContext upstreamTlsContext = CommonTlsContextTestsUtil.buildUpstreamTlsContext(
+        "google_cloud_private_spiffe-client", true, SNI_IN_UTC, false);
+    SslContextProviderSupplier sslContextProviderSupplier =
+        new SslContextProviderSupplier(upstreamTlsContext,
+            new TlsContextManagerImpl(bootstrapInfoForClient));
 
-      ClientSecurityHandler clientSecurityHandler =
-          new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, HOSTNAME);
+    ClientSecurityHandler clientSecurityHandler =
+        new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, HOSTNAME);
 
-      assertThat(clientSecurityHandler.getSni()).isEqualTo(SNI_IN_UTC);
-    } finally {
-      CertificateUtils.isXdsSniEnabled = false;
-    }
+    assertThat(clientSecurityHandler.getSni()).isEqualTo(SNI_IN_UTC);
   }
 
   @Test
-  public void sniFeatureNotEnabled_usesChannelAuthorityForSni() {
-    CertificateUtils.isXdsSniEnabled = false;
+  public void sniInClientSecurityHandler_noSniConditionsMet_omitsSni() {
     Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
-            .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
-                    CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
-    UpstreamTlsContext upstreamTlsContext =
-            CommonTlsContextTestsUtil
-                .buildUpstreamTlsContext("google_cloud_private_spiffe-client", true);
+        .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
+            CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
+    UpstreamTlsContext upstreamTlsContext = CommonTlsContextTestsUtil.buildUpstreamTlsContext(
+        "google_cloud_private_spiffe-client", true, "", false);
     SslContextProviderSupplier sslContextProviderSupplier =
-            new SslContextProviderSupplier(upstreamTlsContext,
-                    new TlsContextManagerImpl(bootstrapInfoForClient));
+        new SslContextProviderSupplier(upstreamTlsContext,
+            new TlsContextManagerImpl(bootstrapInfoForClient));
 
     ClientSecurityHandler clientSecurityHandler =
-            new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, HOSTNAME);
+        new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, HOSTNAME);
 
-    assertThat(clientSecurityHandler.getSni()).isEqualTo(FAKE_AUTHORITY);
+    assertThat(clientSecurityHandler.getSni()).isEqualTo("");
   }
 
   @Test
@@ -503,60 +475,55 @@ public class SecurityProtocolNegotiatorsTest {
 
   @Test
   public void clientSecurityProtocolNegotiatorNewHandler_fireProtocolNegotiationEvent()
-          throws InterruptedException, TimeoutException, ExecutionException {
-    CertificateUtils.isXdsSniEnabled = true;
-    try {
-      FakeClock executor = new FakeClock();
-      CommonCertProviderTestUtils.register(executor);
-      Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
-          .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
-              CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
-      UpstreamTlsContext upstreamTlsContext =
-          CommonTlsContextTestsUtil
-              .buildUpstreamTlsContext("google_cloud_private_spiffe-client", true);
+      throws InterruptedException, TimeoutException, ExecutionException {
+    FakeClock executor = new FakeClock();
+    CommonCertProviderTestUtils.register(executor);
+    Bootstrapper.BootstrapInfo bootstrapInfoForClient = CommonBootstrapperTestUtils
+        .buildBootstrapInfo("google_cloud_private_spiffe-client", CLIENT_KEY_FILE,
+            CLIENT_PEM_FILE, CA_PEM_FILE, null, null, null, null, null);
+    UpstreamTlsContext upstreamTlsContext =
+        CommonTlsContextTestsUtil
+            .buildUpstreamTlsContext("google_cloud_private_spiffe-client", true);
 
-      SslContextProviderSupplier sslContextProviderSupplier =
-          new SslContextProviderSupplier(upstreamTlsContext,
-              new TlsContextManagerImpl(bootstrapInfoForClient));
-      ClientSecurityHandler clientSecurityHandler =
-          new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, HOSTNAME);
+    SslContextProviderSupplier sslContextProviderSupplier =
+        new SslContextProviderSupplier(upstreamTlsContext,
+            new TlsContextManagerImpl(bootstrapInfoForClient));
+    ClientSecurityHandler clientSecurityHandler =
+        new ClientSecurityHandler(grpcHandler, sslContextProviderSupplier, HOSTNAME);
 
-      pipeline.addLast(clientSecurityHandler);
-      channelHandlerCtx = pipeline.context(clientSecurityHandler);
-      assertNotNull(channelHandlerCtx); // non-null since we just added it
+    pipeline.addLast(clientSecurityHandler);
+    channelHandlerCtx = pipeline.context(clientSecurityHandler);
+    assertNotNull(channelHandlerCtx); // non-null since we just added it
 
-      // kick off protocol negotiation.
-      pipeline.fireUserEventTriggered(InternalProtocolNegotiationEvent.getDefault());
-      final SettableFuture<Object> future = SettableFuture.create();
-      sslContextProviderSupplier
-          .updateSslContext(new SslContextProvider.Callback(MoreExecutors.directExecutor()) {
-            @Override
-            public void updateSslContextAndExtendedX509TrustManager(
-                AbstractMap.SimpleImmutableEntry<SslContext, X509TrustManager> sslContextAndTm) {
-              future.set(sslContextAndTm);
-            }
+    // kick off protocol negotiation.
+    pipeline.fireUserEventTriggered(InternalProtocolNegotiationEvent.getDefault());
+    final SettableFuture<Object> future = SettableFuture.create();
+    sslContextProviderSupplier
+        .updateSslContext(new SslContextProvider.Callback(MoreExecutors.directExecutor()) {
+          @Override
+          public void updateSslContextAndExtendedX509TrustManager(
+              AbstractMap.SimpleImmutableEntry<SslContext, X509TrustManager> sslContextAndTm) {
+            future.set(sslContextAndTm);
+          }
 
-            @Override
-            protected void onException(Throwable throwable) {
-              future.set(throwable);
-            }
-          }, false);
-      executor.runDueTasks();
-      channel.runPendingTasks(); // need this for tasks to execute on eventLoop
-      Object fromFuture = future.get(5, TimeUnit.SECONDS);
-      assertThat(fromFuture).isInstanceOf(AbstractMap.SimpleImmutableEntry.class);
-      channel.runPendingTasks();
-      channelHandlerCtx = pipeline.context(clientSecurityHandler);
-      assertThat(channelHandlerCtx).isNull();
-      Object sslEvent = SslHandshakeCompletionEvent.SUCCESS;
+          @Override
+          protected void onException(Throwable throwable) {
+            future.set(throwable);
+          }
+        }, false);
+    executor.runDueTasks();
+    channel.runPendingTasks(); // need this for tasks to execute on eventLoop
+    Object fromFuture = future.get(5, TimeUnit.SECONDS);
+    assertThat(fromFuture).isInstanceOf(AbstractMap.SimpleImmutableEntry.class);
+    channel.runPendingTasks();
+    channelHandlerCtx = pipeline.context(clientSecurityHandler);
+    assertThat(channelHandlerCtx).isNull();
+    Object sslEvent = SslHandshakeCompletionEvent.SUCCESS;
 
-      pipeline.fireUserEventTriggered(sslEvent);
-      channel.runPendingTasks(); // need this for tasks to execute on eventLoop
-      assertTrue(channel.isOpen());
-      CommonCertProviderTestUtils.register0();
-    } finally {
-      CertificateUtils.isXdsSniEnabled = false;
-    }
+    pipeline.fireUserEventTriggered(sslEvent);
+    channel.runPendingTasks(); // need this for tasks to execute on eventLoop
+    assertTrue(channel.isOpen());
+    CommonCertProviderTestUtils.register0();
   }
 
   @Test


### PR DESCRIPTION
## Description
Remove the `isXdsSniEnabled` (GRPC_EXPERIMENTAL_XDS_SNI) guard so that SNI determination via xDS is always enabled. This aligns the behavior with
**gRFC A101**, where SNI is determined by xDS configurations such as `auto_host_sni` or `UpstreamTlsContext.sni`, without relying on an
experimental toggle.

This change does **not** remove the  `GRPC_USE_CHANNEL_AUTHORITY_IF_NO_SNI_APPLICABLE` fallback logic, which remains unchanged.

## Changes
- Remove the `isXdsSniEnabled` flag and the related conditional logic.
- Remove test cases that specifically covered behavior when the 
experimental flag was disabled, since the flag is no longer supported.

## Note for Reviewers
Some test files show large diffs because of re-indentation after removing
`try-finally` blocks (since the `isXdsSniEnabled` flag is no longer needed).
I recommend reviewing these files with the **'Hide whitespace changes'**
option enabled.

Ref #11784
