### PR TITLE
api: Remove obsolete TODO in EquivalentAddressGroup#toString

### DIFF
--- a/api/src/main/java/io/grpc/EquivalentAddressGroup.java
+++ b/api/src/main/java/io/grpc/EquivalentAddressGroup.java
@@ -114,8 +114,8 @@ public final class EquivalentAddressGroup {
   @Override
   public String toString() {
     // EquivalentAddressGroup is intended to contain a small number of addresses for the same endpoint
-    // (e.g., IPv4/IPv6). Aggregating many groups into a single EquivalentAddressGroup is no longer done,
-    // so this no longer needs summarization.
+    // (e.g., IPv4/IPv6). Aggregating many groups into a single EquivalentAddressGroup is no
+    // longer done, so this no longer needs summarization.
     return "[" + addrs + "/" + attrs + "]";
   }
 

--- a/api/src/main/java/io/grpc/EquivalentAddressGroup.java
+++ b/api/src/main/java/io/grpc/EquivalentAddressGroup.java
@@ -113,7 +113,9 @@ public final class EquivalentAddressGroup {
 
   @Override
   public String toString() {
-    // TODO(zpencer): Summarize return value if addr is very large
+    // EquivalentAddressGroup is intended to contain a small number of addresses for the same endpoint
+    // (e.g., IPv4/IPv6). Aggregating many groups into a single EquivalentAddressGroup is no longer done,
+    // so this no longer needs summarization.
     return "[" + addrs + "/" + attrs + "]";
   }
 

--- a/api/src/main/java/io/grpc/EquivalentAddressGroup.java
+++ b/api/src/main/java/io/grpc/EquivalentAddressGroup.java
@@ -113,9 +113,9 @@ public final class EquivalentAddressGroup {
 
   @Override
   public String toString() {
-    // EquivalentAddressGroup is intended to contain a small number of addresses for the same endpoint
-    // (e.g., IPv4/IPv6). Aggregating many groups into a single EquivalentAddressGroup is no
-    // longer done, so this no longer needs summarization.
+    // EquivalentAddressGroup is intended to contain a small number of addresses for the same
+    // endpoint(e.g., IPv4/IPv6). Aggregating many groups into a single EquivalentAddressGroup
+    // is no longer done, so this no longer needs summarization.
     return "[" + addrs + "/" + attrs + "]";
   }
 


### PR DESCRIPTION
### Background

EquivalentAddressGroup is intended to represent a small set of addresses for the same endpoint (e.g., IPv4/IPv6). A long-standing TODO in EquivalentAddressGroup#toString() suggested adding summarization for very large address lists.

During review, maintainers noted that large address lists within a single EquivalentAddressGroup are no longer expected in current designs, and the historical behavior that could create a very large group (e.g., by aggregating many groups into one) has been removed. As a result, the TODO is now obsolete.

### Changes

Remove the obsolete TODO comment in EquivalentAddressGroup#toString().

Add a brief explanatory comment capturing why summarization is no longer needed.

### Purpose

Avoid leaving stale TODOs that imply work is still required.

Align the codebase with the intended semantics and current behavior of EquivalentAddressGroup.

### Note

This change is comment-only and does not alter any runtime behavior or output format.

Fixes https://github.com/grpc/grpc-java/issues/12593