### PR TITLE
Release v1.76.3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "grpc-java",
     compatibility_level = 0,
     repo_name = "io_grpc_grpc_java",
-    version = "1.76.3-SNAPSHOT",  # CURRENT_GRPC_VERSION
+    version = "1.76.3",  # CURRENT_GRPC_VERSION
 )
 
 # GRPC_DEPS_START

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@ module(
     name = "grpc-java",
     compatibility_level = 0,
     repo_name = "io_grpc_grpc_java",
-    version = "1.76.3",  # CURRENT_GRPC_VERSION
+    version = "1.76.4-SNAPSHOT",  # CURRENT_GRPC_VERSION
 )
 
 # GRPC_DEPS_START

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ For a guided tour, take a look at the [quick start
 guide](https://grpc.io/docs/languages/java/quickstart) or the more explanatory [gRPC
 basics](https://grpc.io/docs/languages/java/basics).
 
-The [examples](https://github.com/grpc/grpc-java/tree/v1.76.2/examples) and the
-[Android example](https://github.com/grpc/grpc-java/tree/v1.76.2/examples/android)
+The [examples](https://github.com/grpc/grpc-java/tree/v1.76.3/examples) and the
+[Android example](https://github.com/grpc/grpc-java/tree/v1.76.3/examples/android)
 are standalone projects that showcase the usage of gRPC.
 
 Download
@@ -56,34 +56,34 @@ Download [the JARs][]. Or for Maven with non-Android, add to your `pom.xml`:
 <dependency>
   <groupId>io.grpc</groupId>
   <artifactId>grpc-netty-shaded</artifactId>
-  <version>1.76.2</version>
+  <version>1.76.3</version>
   <scope>runtime</scope>
 </dependency>
 <dependency>
   <groupId>io.grpc</groupId>
   <artifactId>grpc-protobuf</artifactId>
-  <version>1.76.2</version>
+  <version>1.76.3</version>
 </dependency>
 <dependency>
   <groupId>io.grpc</groupId>
   <artifactId>grpc-stub</artifactId>
-  <version>1.76.2</version>
+  <version>1.76.3</version>
 </dependency>
 ```
 
 Or for Gradle with non-Android, add to your dependencies:
 ```gradle
-runtimeOnly 'io.grpc:grpc-netty-shaded:1.76.2'
-implementation 'io.grpc:grpc-protobuf:1.76.2'
-implementation 'io.grpc:grpc-stub:1.76.2'
+runtimeOnly 'io.grpc:grpc-netty-shaded:1.76.3'
+implementation 'io.grpc:grpc-protobuf:1.76.3'
+implementation 'io.grpc:grpc-stub:1.76.3'
 ```
 
 For Android client, use `grpc-okhttp` instead of `grpc-netty-shaded` and
 `grpc-protobuf-lite` instead of `grpc-protobuf`:
 ```gradle
-implementation 'io.grpc:grpc-okhttp:1.76.2'
-implementation 'io.grpc:grpc-protobuf-lite:1.76.2'
-implementation 'io.grpc:grpc-stub:1.76.2'
+implementation 'io.grpc:grpc-okhttp:1.76.3'
+implementation 'io.grpc:grpc-protobuf-lite:1.76.3'
+implementation 'io.grpc:grpc-stub:1.76.3'
 ```
 
 For [Bazel](https://bazel.build), you can either
@@ -91,7 +91,7 @@ For [Bazel](https://bazel.build), you can either
 (with the GAVs from above), or use `@io_grpc_grpc_java//api` et al (see below).
 
 [the JARs]:
-https://search.maven.org/search?q=g:io.grpc%20AND%20v:1.76.2
+https://search.maven.org/search?q=g:io.grpc%20AND%20v:1.76.3
 
 Development snapshots are available in [Sonatypes's snapshot
 repository](https://central.sonatype.com/repository/maven-snapshots/).
@@ -123,7 +123,7 @@ For protobuf-based codegen integrated with the Maven build system, you can use
       <configuration>
         <protocArtifact>com.google.protobuf:protoc:3.25.8:exe:${os.detected.classifier}</protocArtifact>
         <pluginId>grpc-java</pluginId>
-        <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.76.2:exe:${os.detected.classifier}</pluginArtifact>
+        <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.76.3:exe:${os.detected.classifier}</pluginArtifact>
       </configuration>
       <executions>
         <execution>
@@ -153,7 +153,7 @@ protobuf {
   }
   plugins {
     grpc {
-      artifact = 'io.grpc:protoc-gen-grpc-java:1.76.2'
+      artifact = 'io.grpc:protoc-gen-grpc-java:1.76.3'
     }
   }
   generateProtoTasks {
@@ -186,7 +186,7 @@ protobuf {
   }
   plugins {
     grpc {
-      artifact = 'io.grpc:protoc-gen-grpc-java:1.76.2'
+      artifact = 'io.grpc:protoc-gen-grpc-java:1.76.3'
     }
   }
   generateProtoTasks {

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ subprojects {
     apply plugin: "net.ltgt.errorprone"
 
     group = "io.grpc"
-    version = "1.76.3" // CURRENT_GRPC_VERSION
+    version = "1.76.4-SNAPSHOT" // CURRENT_GRPC_VERSION
 
     repositories {
         maven { // The google mirror is less flaky than mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ subprojects {
     apply plugin: "net.ltgt.errorprone"
 
     group = "io.grpc"
-    version = "1.76.3-SNAPSHOT" // CURRENT_GRPC_VERSION
+    version = "1.76.3" // CURRENT_GRPC_VERSION
 
     repositories {
         maven { // The google mirror is less flaky than mavenCentral()

--- a/compiler/src/test/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/test/golden/TestDeprecatedService.java.txt
@@ -8,7 +8,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.76.3-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.76.3)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @io.grpc.stub.annotations.GrpcGenerated
 @java.lang.Deprecated

--- a/compiler/src/test/golden/TestDeprecatedService.java.txt
+++ b/compiler/src/test/golden/TestDeprecatedService.java.txt
@@ -8,7 +8,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.76.3)",
+    value = "by gRPC proto compiler (version 1.76.4-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @io.grpc.stub.annotations.GrpcGenerated
 @java.lang.Deprecated

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -8,7 +8,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.76.3)",
+    value = "by gRPC proto compiler (version 1.76.4-SNAPSHOT)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @io.grpc.stub.annotations.GrpcGenerated
 public final class TestServiceGrpc {

--- a/compiler/src/test/golden/TestService.java.txt
+++ b/compiler/src/test/golden/TestService.java.txt
@@ -8,7 +8,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.76.3-SNAPSHOT)",
+    value = "by gRPC proto compiler (version 1.76.3)",
     comments = "Source: grpc/testing/compiler/test.proto")
 @io.grpc.stub.annotations.GrpcGenerated
 public final class TestServiceGrpc {

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -219,7 +219,7 @@ public final class GrpcUtil {
 
   public static final Splitter ACCEPT_ENCODING_SPLITTER = Splitter.on(',').trimResults();
 
-  public static final String IMPLEMENTATION_VERSION = "1.76.3-SNAPSHOT"; // CURRENT_GRPC_VERSION
+  public static final String IMPLEMENTATION_VERSION = "1.76.3"; // CURRENT_GRPC_VERSION
 
   /**
    * The default timeout in nanos for a keepalive ping request.

--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -219,7 +219,7 @@ public final class GrpcUtil {
 
   public static final Splitter ACCEPT_ENCODING_SPLITTER = Splitter.on(',').trimResults();
 
-  public static final String IMPLEMENTATION_VERSION = "1.76.3"; // CURRENT_GRPC_VERSION
+  public static final String IMPLEMENTATION_VERSION = "1.76.4-SNAPSHOT"; // CURRENT_GRPC_VERSION
 
   /**
    * The default timeout in nanos for a keepalive ping request.

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -1,4 +1,4 @@
-bazel_dep(name = "grpc-java", repo_name = "io_grpc_grpc_java", version = "1.76.3")  # CURRENT_GRPC_VERSION
+bazel_dep(name = "grpc-java", repo_name = "io_grpc_grpc_java", version = "1.76.4-SNAPSHOT")  # CURRENT_GRPC_VERSION
 bazel_dep(name = "grpc-proto", repo_name = "io_grpc_grpc_proto", version = "0.0.0-20240627-ec30f58")
 bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "23.1")
 bazel_dep(name = "rules_jvm_external", version = "6.0")

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -1,4 +1,4 @@
-bazel_dep(name = "grpc-java", repo_name = "io_grpc_grpc_java", version = "1.76.3-SNAPSHOT")  # CURRENT_GRPC_VERSION
+bazel_dep(name = "grpc-java", repo_name = "io_grpc_grpc_java", version = "1.76.3")  # CURRENT_GRPC_VERSION
 bazel_dep(name = "grpc-proto", repo_name = "io_grpc_grpc_proto", version = "0.0.0-20240627-ec30f58")
 bazel_dep(name = "protobuf", repo_name = "com_google_protobuf", version = "23.1")
 bazel_dep(name = "rules_jvm_external", version = "6.0")

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -34,7 +34,7 @@ android {
 protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.25.1' }
     plugins {
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.76.3' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -54,11 +54,11 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.76.3' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.76.3' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.76.3' // CURRENT_GRPC_VERSION
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.google.truth:truth:1.1.5'
-    testImplementation 'io.grpc:grpc-testing:1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-testing:1.76.3' // CURRENT_GRPC_VERSION
 }

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -34,7 +34,7 @@ android {
 protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.25.1' }
     plugins {
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.76.3' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -54,11 +54,11 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.76.3' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.76.3' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.76.3' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.google.truth:truth:1.1.5'
-    testImplementation 'io.grpc:grpc-testing:1.76.3' // CURRENT_GRPC_VERSION
+    testImplementation 'io.grpc:grpc-testing:1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
 }

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -32,7 +32,7 @@ android {
 protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.25.1' }
     plugins {
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.76.3' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -52,7 +52,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.76.3' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.76.3' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.76.3' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
 }

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -32,7 +32,7 @@ android {
 protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.25.1' }
     plugins {
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.76.3' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -52,7 +52,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.76.3' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.76.3' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.76.3' // CURRENT_GRPC_VERSION
 }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -32,7 +32,7 @@ android {
 protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.25.1' }
     plugins {
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.76.3' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -52,7 +52,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.76.3' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.76.3' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.76.3' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
 }

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -32,7 +32,7 @@ android {
 protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.25.1' }
     plugins {
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.76.3' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -52,7 +52,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.76.3' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.76.3' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.76.3' // CURRENT_GRPC_VERSION
 }

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -33,7 +33,7 @@ android {
 protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.25.1' }
     plugins {
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.76.3' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -53,7 +53,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.76.3' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.76.3' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.76.3' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
 }

--- a/examples/android/strictmode/app/build.gradle
+++ b/examples/android/strictmode/app/build.gradle
@@ -33,7 +33,7 @@ android {
 protobuf {
     protoc { artifact = 'com.google.protobuf:protoc:3.25.1' }
     plugins {
-        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+        grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.76.3' // CURRENT_GRPC_VERSION
         }
     }
     generateProtoTasks {
@@ -53,7 +53,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.0.0'
 
     // You need to build grpc-java to obtain these libraries below.
-    implementation 'io.grpc:grpc-okhttp:1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-protobuf-lite:1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
-    implementation 'io.grpc:grpc-stub:1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-okhttp:1.76.3' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-protobuf-lite:1.76.3' // CURRENT_GRPC_VERSION
+    implementation 'io.grpc:grpc-stub:1.76.3' // CURRENT_GRPC_VERSION
 }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -21,7 +21,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.25.8'
 def protocVersion = protobufVersion
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -21,7 +21,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.25.8'
 def protocVersion = protobufVersion
 

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -21,7 +21,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.8'
 
 dependencies {

--- a/examples/example-alts/build.gradle
+++ b/examples/example-alts/build.gradle
@@ -21,7 +21,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.8'
 
 dependencies {

--- a/examples/example-debug/build.gradle
+++ b/examples/example-debug/build.gradle
@@ -23,7 +23,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.25.8'
 
 dependencies {

--- a/examples/example-debug/build.gradle
+++ b/examples/example-debug/build.gradle
@@ -23,7 +23,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.25.8'
 
 dependencies {

--- a/examples/example-debug/pom.xml
+++ b/examples/example-debug/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.76.3</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.76.4-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-debug</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.76.3</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.76.4-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protoc.version>3.25.8</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/examples/example-debug/pom.xml
+++ b/examples/example-debug/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.76.3-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.76.3</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-debug</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.76.3-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.76.3</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protoc.version>3.25.8</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/examples/example-dualstack/build.gradle
+++ b/examples/example-dualstack/build.gradle
@@ -23,7 +23,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.25.8'
 
 dependencies {

--- a/examples/example-dualstack/build.gradle
+++ b/examples/example-dualstack/build.gradle
@@ -23,7 +23,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.25.8'
 
 dependencies {

--- a/examples/example-dualstack/pom.xml
+++ b/examples/example-dualstack/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.76.3</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.76.4-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-dualstack</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.76.3</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.76.4-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protoc.version>3.25.8</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/examples/example-dualstack/pom.xml
+++ b/examples/example-dualstack/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.76.3-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.76.3</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-dualstack</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.76.3-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.76.3</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protoc.version>3.25.8</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -21,7 +21,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.25.8'
 def protocVersion = protobufVersion
 

--- a/examples/example-gauth/build.gradle
+++ b/examples/example-gauth/build.gradle
@@ -21,7 +21,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.25.8'
 def protocVersion = protobufVersion
 

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.76.3</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.76.4-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-gauth</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.76.3</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.76.4-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.25.8</protobuf.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/examples/example-gauth/pom.xml
+++ b/examples/example-gauth/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.76.3-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.76.3</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-gauth</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.76.3-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.76.3</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.25.8</protobuf.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/examples/example-gcp-csm-observability/build.gradle
+++ b/examples/example-gcp-csm-observability/build.gradle
@@ -22,7 +22,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.8'
 def openTelemetryVersion = '1.52.0'
 def openTelemetryPrometheusVersion = '1.52.0-alpha'

--- a/examples/example-gcp-csm-observability/build.gradle
+++ b/examples/example-gcp-csm-observability/build.gradle
@@ -22,7 +22,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.8'
 def openTelemetryVersion = '1.52.0'
 def openTelemetryPrometheusVersion = '1.52.0-alpha'

--- a/examples/example-gcp-observability/build.gradle
+++ b/examples/example-gcp-observability/build.gradle
@@ -22,7 +22,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.8'
 
 dependencies {

--- a/examples/example-gcp-observability/build.gradle
+++ b/examples/example-gcp-observability/build.gradle
@@ -22,7 +22,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.8'
 
 dependencies {

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -21,7 +21,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.25.8'
 
 dependencies {

--- a/examples/example-hostname/build.gradle
+++ b/examples/example-hostname/build.gradle
@@ -21,7 +21,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.25.8'
 
 dependencies {

--- a/examples/example-hostname/pom.xml
+++ b/examples/example-hostname/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.76.3-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.76.3</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-hostname</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.76.3-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.76.3</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protoc.version>3.25.8</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/examples/example-hostname/pom.xml
+++ b/examples/example-hostname/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.76.3</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.76.4-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-hostname</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.76.3</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.76.4-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protoc.version>3.25.8</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -21,7 +21,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.25.8'
 def protocVersion = protobufVersion
 

--- a/examples/example-jwt-auth/build.gradle
+++ b/examples/example-jwt-auth/build.gradle
@@ -21,7 +21,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.25.8'
 def protocVersion = protobufVersion
 

--- a/examples/example-jwt-auth/pom.xml
+++ b/examples/example-jwt-auth/pom.xml
@@ -7,13 +7,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.76.3</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.76.4-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-jwt-auth</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.76.3</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.76.4-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.25.8</protobuf.version>
     <protoc.version>3.25.8</protoc.version>
     <!-- required for jdk9 -->

--- a/examples/example-jwt-auth/pom.xml
+++ b/examples/example-jwt-auth/pom.xml
@@ -7,13 +7,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.76.3-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.76.3</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-jwt-auth</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.76.3-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.76.3</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.25.8</protobuf.version>
     <protoc.version>3.25.8</protoc.version>
     <!-- required for jdk9 -->

--- a/examples/example-oauth/build.gradle
+++ b/examples/example-oauth/build.gradle
@@ -21,7 +21,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.25.8'
 def protocVersion = protobufVersion
 

--- a/examples/example-oauth/build.gradle
+++ b/examples/example-oauth/build.gradle
@@ -21,7 +21,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.25.8'
 def protocVersion = protobufVersion
 

--- a/examples/example-oauth/pom.xml
+++ b/examples/example-oauth/pom.xml
@@ -7,13 +7,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.76.3</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.76.4-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-oauth</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.76.3</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.76.4-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.25.8</protobuf.version>
     <protoc.version>3.25.8</protoc.version>
     <!-- required for jdk9 -->

--- a/examples/example-oauth/pom.xml
+++ b/examples/example-oauth/pom.xml
@@ -7,13 +7,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.76.3-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.76.3</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-oauth</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.76.3-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.76.3</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.25.8</protobuf.version>
     <protoc.version>3.25.8</protoc.version>
     <!-- required for jdk9 -->

--- a/examples/example-opentelemetry/build.gradle
+++ b/examples/example-opentelemetry/build.gradle
@@ -21,7 +21,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.8'
 def openTelemetryVersion = '1.52.0'
 def openTelemetryPrometheusVersion = '1.52.0-alpha'

--- a/examples/example-opentelemetry/build.gradle
+++ b/examples/example-opentelemetry/build.gradle
@@ -21,7 +21,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.8'
 def openTelemetryVersion = '1.52.0'
 def openTelemetryPrometheusVersion = '1.52.0-alpha'

--- a/examples/example-orca/build.gradle
+++ b/examples/example-orca/build.gradle
@@ -16,7 +16,7 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.8'
 
 dependencies {

--- a/examples/example-orca/build.gradle
+++ b/examples/example-orca/build.gradle
@@ -16,7 +16,7 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-def grpcVersion = '1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.8'
 
 dependencies {

--- a/examples/example-reflection/build.gradle
+++ b/examples/example-reflection/build.gradle
@@ -16,7 +16,7 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.8'
 
 dependencies {

--- a/examples/example-reflection/build.gradle
+++ b/examples/example-reflection/build.gradle
@@ -16,7 +16,7 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-def grpcVersion = '1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.8'
 
 dependencies {

--- a/examples/example-servlet/build.gradle
+++ b/examples/example-servlet/build.gradle
@@ -15,7 +15,7 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-def grpcVersion = '1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.8'
 
 dependencies {

--- a/examples/example-servlet/build.gradle
+++ b/examples/example-servlet/build.gradle
@@ -15,7 +15,7 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.8'
 
 dependencies {

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -21,7 +21,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.8'
 
 dependencies {

--- a/examples/example-tls/build.gradle
+++ b/examples/example-tls/build.gradle
@@ -21,7 +21,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.8'
 
 dependencies {

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.76.3</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.76.4-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-tls</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.76.3</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.76.4-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protoc.version>3.25.8</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/examples/example-tls/pom.xml
+++ b/examples/example-tls/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.76.3-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.76.3</version><!-- CURRENT_GRPC_VERSION -->
   <name>example-tls</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.76.3-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.76.3</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protoc.version>3.25.8</protoc.version>
     <!-- required for jdk9 -->
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -21,7 +21,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3-SNAPSHOT' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.8'
 
 dependencies {

--- a/examples/example-xds/build.gradle
+++ b/examples/example-xds/build.gradle
@@ -21,7 +21,7 @@ java {
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.76.3' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.76.4-SNAPSHOT' // CURRENT_GRPC_VERSION
 def protocVersion = '3.25.8'
 
 dependencies {

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.76.3</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.76.4-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
   <name>examples</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.76.3</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.76.4-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.25.8</protobuf.version>
     <protoc.version>3.25.8</protoc.version>
     <!-- required for JDK 8 -->

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,13 +6,13 @@
   <packaging>jar</packaging>
   <!-- Feel free to delete the comment at the end of these lines. It is just
        for safely updating the version in our release process. -->
-  <version>1.76.3-SNAPSHOT</version><!-- CURRENT_GRPC_VERSION -->
+  <version>1.76.3</version><!-- CURRENT_GRPC_VERSION -->
   <name>examples</name>
   <url>https://github.com/grpc/grpc-java</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.76.3-SNAPSHOT</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.76.3</grpc.version><!-- CURRENT_GRPC_VERSION -->
     <protobuf.version>3.25.8</protobuf.version>
     <protoc.version>3.25.8</protoc.version>
     <!-- required for JDK 8 -->


### PR DESCRIPTION
This obviously doesn't have the various 1.76.x PRs as part of it. After those go in I'll rebase this. The point is to get a head-start on the approval process since doing things in lock-step adds a day of delay.