### PR TITLE
pick_first weighted shuffle (1.79.x backport)

### DIFF
--- a/xds/src/main/java/io/grpc/xds/Endpoints.java
+++ b/xds/src/main/java/io/grpc/xds/Endpoints.java
@@ -59,7 +59,7 @@ final class Endpoints {
     // The endpoint address to be connected to.
     abstract EquivalentAddressGroup eag();
 
-    // Endpoint's weight for load balancing. If unspecified, value of 0 is returned.
+    // Endpoint's weight for load balancing. Guaranteed not to be 0.
     abstract int loadBalancingWeight();
 
     // Whether the endpoint is healthy.
@@ -71,6 +71,9 @@ final class Endpoints {
 
     static LbEndpoint create(EquivalentAddressGroup eag, int loadBalancingWeight,
         boolean isHealthy, String hostname, ImmutableMap<String, Object> endpointMetadata) {
+      if (loadBalancingWeight == 0) {
+        loadBalancingWeight = 1;
+      }
       return new AutoValue_Endpoints_LbEndpoint(
           eag, loadBalancingWeight, isHealthy, hostname, endpointMetadata);
     }


### PR DESCRIPTION
There's two commits here with descriptions in each; take a look at each individually and I'll keep them separate when merging.

~There will be a gRFC for this, but apparently it hasn't been created yet~ (gRFC A113 https://github.com/grpc/proposal/pull/535) and I didn't want to wait longer for it to be created before starting review, because the plan is to delay the 1.79.0 release for this in Java and Go. We will want to merge this ASAP (and backport at our convenience), but we must wait until the gRFC is merged before publishing the 1.79.0 release. I suggest we leave `TODO:release blocker` label here until the gRFC is merged. (Kannan, I shared a doc and an email thread with you to give you some context; mostly for what problem is being solved, and not the specific solution here. The specific solution here is split across a lot of comments, so you're best off waiting for the gRFC to see something documenting it.)

While doing this I've noticed lots of things to fix with how weights are handled. I've basically ignored them at the moment, only trying to make sure that I don't make things worse. I'll be doing a follow-up to fix more weight handling, but I will not be trying to backport it.

Backport of #12623