### PR TITLE
core: Fix inFlightSubStreams counting on retry commit

### DIFF
--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -167,7 +167,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
       final boolean wasCancelled = (scheduledRetry != null) ? scheduledRetry.isCancelled() : false;
       final Future<?> retryFuture;
       final boolean retryWasScheduled = scheduledRetry != null;
-      if (scheduledRetry != null) {
+      if (retryWasScheduled) {
         retryFuture = scheduledRetry.markCancelled();
         scheduledRetry = null;
       } else {

--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -166,6 +166,7 @@ abstract class RetriableStream<ReqT> implements ClientStream {
 
       final boolean wasCancelled = (scheduledRetry != null) ? scheduledRetry.isCancelled() : false;
       final Future<?> retryFuture;
+      final boolean retryWasScheduled = scheduledRetry != null;
       if (scheduledRetry != null) {
         retryFuture = scheduledRetry.markCancelled();
         scheduledRetry = null;
@@ -190,8 +191,10 @@ abstract class RetriableStream<ReqT> implements ClientStream {
               substream.stream.cancel(CANCELLED_BECAUSE_COMMITTED);
             }
           }
-          if (retryFuture != null) {
-            retryFuture.cancel(false);
+          if (retryWasScheduled) {
+            if (retryFuture != null) {
+              retryFuture.cancel(false);
+            }
             if (!wasCancelled && inFlightSubStreams.decrementAndGet() == Integer.MIN_VALUE) {
               assert savedCloseMasterListenerReason != null;
               listenerSerializeExecutor.execute(


### PR DESCRIPTION
This PR fixes a race condition in RetriableStream where, under certain retry and deadline timings, the response future may never be completed.

When a deadline cancellation occurs concurrently with retry commit, inFlightSubStreams may not be decremented, causing `ClientCallImpl.ClientStreamListenerImpl.closed` to never be invoked. As a result, blockingUnaryCall can hang indefinitely.

After this change, the inFlightSubStreams counting is consistent whenever a scheduled retry is committed, ensuring the close signal is always delivered.

I verified this using the issue reproduction code from the issue reporter, which previously caused blockingUnaryCall to hang and eventually hit a TimeoutException because a while loop never progressed. After this change, running the same reproduction code no longer hangs and continues as expected without timing out.

Fixes #12620