### PR TITLE
unwrap ForwardingSubchannel during Picks

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -667,7 +667,7 @@ public abstract class LoadBalancer {
      *
      * @since 1.80.0
      */
-    public PickResult withSubchannelReplacement(Subchannel subchannel) {
+    public PickResult copyWithSubchannel(Subchannel subchannel) {
       return new PickResult(checkNotNull(subchannel, "subchannel"), streamTracerFactory,
           status, drop, authorityOverride);
     }
@@ -678,7 +678,7 @@ public abstract class LoadBalancer {
      *
      * @since 1.80.0
      */
-    public PickResult withStreamTracerFactory(
+    public PickResult copyWithStreamTracerFactory(
         @Nullable ClientStreamTracer.Factory streamTracerFactory) {
       return new PickResult(subchannel, streamTracerFactory, status, drop, authorityOverride);
     }

--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -632,6 +632,9 @@ public abstract class LoadBalancer {
      *                            stream is created at all in some cases.
      * @since 1.3.0
      */
+    // TODO(shivaspeaks): We need to deprecate old APIs and create new ones.
+    // Ideally these static methods should start with "of.." instead of "with.."
+    // to have consistency with other classes.
     public static PickResult withSubchannel(
         Subchannel subchannel, @Nullable ClientStreamTracer.Factory streamTracerFactory) {
       return new PickResult(

--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -632,9 +632,8 @@ public abstract class LoadBalancer {
      *                            stream is created at all in some cases.
      * @since 1.3.0
      */
-    // TODO(shivaspeaks): We need to deprecate old APIs and create new ones.
-    // Ideally these static methods should start with "of.." instead of "with.."
-    // to have consistency with other classes.
+    // TODO(shivaspeaks): Need to deprecate old APIs and create new ones, 
+    // per https://github.com/grpc/grpc-java/issues/12662.
     public static PickResult withSubchannel(
         Subchannel subchannel, @Nullable ClientStreamTracer.Factory streamTracerFactory) {
       return new PickResult(

--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -662,6 +662,28 @@ public abstract class LoadBalancer {
     }
 
     /**
+     * Creates a new {@code PickResult} with the given {@code subchannel},
+     * but retains all other properties from this {@code PickResult}.
+     *
+     * @since 1.80.0
+     */
+    public PickResult withSubchannelReplacement(Subchannel subchannel) {
+      return new PickResult(checkNotNull(subchannel, "subchannel"), streamTracerFactory,
+          status, drop, authorityOverride);
+    }
+
+    /**
+     * Creates a new {@code PickResult} with the given {@code streamTracerFactory},
+     * but retains all other properties from this {@code PickResult}.
+     *
+     * @since 1.80.0
+     */
+    public PickResult withStreamTracerFactory(
+        @Nullable ClientStreamTracer.Factory streamTracerFactory) {
+      return new PickResult(subchannel, streamTracerFactory, status, drop, authorityOverride);
+    }
+
+    /**
      * A decision to report a connectivity error to the RPC.  If the RPC is {@link
      * CallOptions#withWaitForReady wait-for-ready}, it will stay buffered.  Otherwise, it will fail
      * with the given error.

--- a/api/src/test/java/io/grpc/LoadBalancerTest.java
+++ b/api/src/test/java/io/grpc/LoadBalancerTest.java
@@ -65,6 +65,26 @@ public class LoadBalancerTest {
   }
 
   @Test
+  public void pickResult_withSubchannelReplacement() {
+    PickResult result = PickResult.withSubchannel(subchannel, tracerFactory)
+        .withSubchannelReplacement(subchannel2);
+    assertThat(result.getSubchannel()).isSameInstanceAs(subchannel2);
+    assertThat(result.getStatus()).isSameInstanceAs(Status.OK);
+    assertThat(result.getStreamTracerFactory()).isSameInstanceAs(tracerFactory);
+    assertThat(result.isDrop()).isFalse();
+  }
+
+  @Test
+  public void pickResult_withStreamTracerFactory() {
+    PickResult result = PickResult.withSubchannel(subchannel)
+        .withStreamTracerFactory(tracerFactory);
+    assertThat(result.getSubchannel()).isSameInstanceAs(subchannel);
+    assertThat(result.getStatus()).isSameInstanceAs(Status.OK);
+    assertThat(result.getStreamTracerFactory()).isSameInstanceAs(tracerFactory);
+    assertThat(result.isDrop()).isFalse();
+  }
+
+  @Test
   public void pickResult_withNoResult() {
     PickResult result = PickResult.withNoResult();
     assertThat(result.getSubchannel()).isNull();

--- a/api/src/test/java/io/grpc/LoadBalancerTest.java
+++ b/api/src/test/java/io/grpc/LoadBalancerTest.java
@@ -67,7 +67,7 @@ public class LoadBalancerTest {
   @Test
   public void pickResult_withSubchannelReplacement() {
     PickResult result = PickResult.withSubchannel(subchannel, tracerFactory)
-        .withSubchannelReplacement(subchannel2);
+        .copyWithSubchannel(subchannel2);
     assertThat(result.getSubchannel()).isSameInstanceAs(subchannel2);
     assertThat(result.getStatus()).isSameInstanceAs(Status.OK);
     assertThat(result.getStreamTracerFactory()).isSameInstanceAs(tracerFactory);
@@ -77,7 +77,7 @@ public class LoadBalancerTest {
   @Test
   public void pickResult_withStreamTracerFactory() {
     PickResult result = PickResult.withSubchannel(subchannel)
-        .withStreamTracerFactory(tracerFactory);
+        .copyWithStreamTracerFactory(tracerFactory);
     assertThat(result.getSubchannel()).isSameInstanceAs(subchannel);
     assertThat(result.getStatus()).isSameInstanceAs(Status.OK);
     assertThat(result.getStreamTracerFactory()).isSameInstanceAs(tracerFactory);

--- a/services/src/main/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactory.java
+++ b/services/src/main/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactory.java
@@ -163,7 +163,7 @@ final class HealthCheckingLoadBalancerFactory extends LoadBalancer.Factory {
         LoadBalancer.PickResult result = delegate.pickSubchannel(args);
         LoadBalancer.Subchannel subchannel = result.getSubchannel();
         if (subchannel instanceof SubchannelImpl) {
-          return result.withSubchannelReplacement(((SubchannelImpl) subchannel).delegate());
+          return result.copyWithSubchannel(((SubchannelImpl) subchannel).delegate());
         }
         return result;
       }

--- a/services/src/main/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactory.java
+++ b/services/src/main/java/io/grpc/protobuf/services/HealthCheckingLoadBalancerFactory.java
@@ -144,6 +144,30 @@ final class HealthCheckingLoadBalancerFactory extends LoadBalancer.Factory {
     public String toString() {
       return MoreObjects.toStringHelper(this).add("delegate", delegate()).toString();
     }
+
+    @Override
+    public void updateBalancingState(
+        io.grpc.ConnectivityState newState, LoadBalancer.SubchannelPicker newPicker) {
+      delegate().updateBalancingState(newState, new HealthCheckPicker(newPicker));
+    }
+
+    private final class HealthCheckPicker extends LoadBalancer.SubchannelPicker {
+      private final LoadBalancer.SubchannelPicker delegate;
+
+      HealthCheckPicker(LoadBalancer.SubchannelPicker delegate) {
+        this.delegate = delegate;
+      }
+
+      @Override
+      public LoadBalancer.PickResult pickSubchannel(LoadBalancer.PickSubchannelArgs args) {
+        LoadBalancer.PickResult result = delegate.pickSubchannel(args);
+        LoadBalancer.Subchannel subchannel = result.getSubchannel();
+        if (subchannel instanceof SubchannelImpl) {
+          return result.withSubchannelReplacement(((SubchannelImpl) subchannel).delegate());
+        }
+        return result;
+      }
+    }
   }
 
   @VisibleForTesting

--- a/util/src/main/java/io/grpc/util/HealthProducerHelper.java
+++ b/util/src/main/java/io/grpc/util/HealthProducerHelper.java
@@ -22,6 +22,7 @@ import static io.grpc.LoadBalancer.HEALTH_CONSUMER_LISTENER_ARG_KEY;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.Attributes;
+import io.grpc.ConnectivityState;
 import io.grpc.ConnectivityStateInfo;
 import io.grpc.Internal;
 import io.grpc.LoadBalancer;
@@ -82,6 +83,31 @@ public final class HealthProducerHelper extends ForwardingLoadBalancerHelper {
   @Override
   protected LoadBalancer.Helper delegate() {
     return delegate;
+  }
+
+  @Override
+  public void updateBalancingState(
+      ConnectivityState newState, LoadBalancer.SubchannelPicker newPicker) {
+    delegate.updateBalancingState(newState, new HealthProducerPicker(newPicker));
+  }
+
+  private static final class HealthProducerPicker extends LoadBalancer.SubchannelPicker {
+    private final LoadBalancer.SubchannelPicker delegate;
+
+    HealthProducerPicker(LoadBalancer.SubchannelPicker delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public LoadBalancer.PickResult pickSubchannel(LoadBalancer.PickSubchannelArgs args) {
+      LoadBalancer.PickResult result = delegate.pickSubchannel(args);
+      LoadBalancer.Subchannel subchannel = result.getSubchannel();
+      if (subchannel instanceof HealthProducerSubchannel) {
+        return result.withSubchannelReplacement(
+            ((HealthProducerSubchannel) subchannel).delegate());
+      }
+      return result;
+    }
   }
 
   // The parent subchannel in the health check producer LB chain. It duplicates subchannel state to

--- a/util/src/main/java/io/grpc/util/HealthProducerHelper.java
+++ b/util/src/main/java/io/grpc/util/HealthProducerHelper.java
@@ -103,7 +103,7 @@ public final class HealthProducerHelper extends ForwardingLoadBalancerHelper {
       LoadBalancer.PickResult result = delegate.pickSubchannel(args);
       LoadBalancer.Subchannel subchannel = result.getSubchannel();
       if (subchannel instanceof HealthProducerSubchannel) {
-        return result.withSubchannelReplacement(
+        return result.copyWithSubchannel(
             ((HealthProducerSubchannel) subchannel).delegate());
       }
       return result;

--- a/util/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
@@ -442,9 +442,14 @@ public final class OutlierDetectionLoadBalancer extends LoadBalancer {
 
       Subchannel subchannel = pickResult.getSubchannel();
       if (subchannel != null) {
-        return PickResult.withSubchannel(subchannel, new ResultCountingClientStreamTracerFactory(
-            subchannel.getAttributes().get(ENDPOINT_TRACKER_KEY),
-            pickResult.getStreamTracerFactory()));
+        EndpointTracker tracker = subchannel.getAttributes().get(ENDPOINT_TRACKER_KEY);
+        if (subchannel instanceof OutlierDetectionSubchannel) {
+          subchannel = ((OutlierDetectionSubchannel) subchannel).delegate();
+        }
+        return pickResult.withSubchannelReplacement(subchannel)
+            .withStreamTracerFactory(new ResultCountingClientStreamTracerFactory(
+                tracker,
+                pickResult.getStreamTracerFactory()));
       }
 
       return pickResult;

--- a/util/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
+++ b/util/src/main/java/io/grpc/util/OutlierDetectionLoadBalancer.java
@@ -446,8 +446,8 @@ public final class OutlierDetectionLoadBalancer extends LoadBalancer {
         if (subchannel instanceof OutlierDetectionSubchannel) {
           subchannel = ((OutlierDetectionSubchannel) subchannel).delegate();
         }
-        return pickResult.withSubchannelReplacement(subchannel)
-            .withStreamTracerFactory(new ResultCountingClientStreamTracerFactory(
+        return pickResult.copyWithSubchannel(subchannel)
+            .copyWithStreamTracerFactory(new ResultCountingClientStreamTracerFactory(
                 tracker,
                 pickResult.getStreamTracerFactory()));
       }

--- a/util/src/test/java/io/grpc/util/OutlierDetectionLoadBalancerTest.java
+++ b/util/src/test/java/io/grpc/util/OutlierDetectionLoadBalancerTest.java
@@ -408,7 +408,7 @@ public class OutlierDetectionLoadBalancerTest {
     // Make sure that we can pick the single READY subchannel.
     SubchannelPicker picker = pickerCaptor.getAllValues().get(2);
     PickResult pickResult = picker.pickSubchannel(mock(PickSubchannelArgs.class));
-    Subchannel s = ((OutlierDetectionSubchannel) pickResult.getSubchannel()).delegate();
+    Subchannel s = pickResult.getSubchannel();
     if (s instanceof HealthProducerHelper.HealthProducerSubchannel) {
       s = ((HealthProducerHelper.HealthProducerSubchannel) s).delegate();
     }

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -428,7 +428,7 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
           Subchannel subchannel = result.getSubchannel();
           if (subchannel instanceof ClusterImplLbHelper.ClusterImplSubchannel) {
             subchannel = ((ClusterImplLbHelper.ClusterImplSubchannel) subchannel).delegate();
-            result = result.withSubchannelReplacement(subchannel);
+            result = result.copyWithSubchannel(subchannel);
           }
           if (enableCircuitBreaking) {
             if (inFlights.get() >= maxConcurrentRequests) {
@@ -455,7 +455,7 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
                   stats, inFlights, result.getStreamTracerFactory());
               ClientStreamTracer.Factory orcaTracerFactory = OrcaPerRequestUtil.getInstance()
                   .newOrcaClientStreamTracerFactory(tracerFactory, new OrcaPerRpcListener(stats));
-              result = result.withStreamTracerFactory(orcaTracerFactory);
+              result = result.copyWithStreamTracerFactory(orcaTracerFactory);
             }
           }
           if (args.getCallOptions().getOption(XdsNameResolver.AUTO_HOST_REWRITE_KEY) != null

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -424,14 +424,12 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
           }
         }
         PickResult result = delegate.pickSubchannel(args);
-        Subchannel subchannel = result.getSubchannel();
-        if (subchannel != null) {
+        if (result.getStatus().isOk() && result.getSubchannel() != null) {
+          Subchannel subchannel = result.getSubchannel();
           if (subchannel instanceof ClusterImplLbHelper.ClusterImplSubchannel) {
             subchannel = ((ClusterImplLbHelper.ClusterImplSubchannel) subchannel).delegate();
             result = result.withSubchannelReplacement(subchannel);
           }
-        }
-        if (result.getStatus().isOk() && result.getSubchannel() != null) {
           if (enableCircuitBreaking) {
             if (inFlights.get() >= maxConcurrentRequests) {
               if (dropStats != null) {

--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -252,42 +252,55 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
       args = args.toBuilder().setAddresses(addresses).setAttributes(attrsBuilder.build()).build();
       final Subchannel subchannel = delegate().createSubchannel(args);
 
-      return new ForwardingSubchannel() {
-        @Override
-        public void start(SubchannelStateListener listener) {
-          delegate().start(new SubchannelStateListener() {
-            @Override
-            public void onSubchannelState(ConnectivityStateInfo newState) {
-              // Do nothing if LB has been shutdown
-              if (xdsClient != null && newState.getState().equals(ConnectivityState.READY)) {
-                // Get locality based on the connected address attributes
-                ClusterLocality updatedClusterLocality = createClusterLocalityFromAttributes(
-                    subchannel.getConnectedAddressAttributes());
-                ClusterLocality oldClusterLocality = localityAtomicReference
-                    .getAndSet(updatedClusterLocality);
-                oldClusterLocality.release();
+      return new ClusterImplSubchannel(subchannel, localityAtomicReference);
+    }
+
+    private final class ClusterImplSubchannel extends ForwardingSubchannel {
+      private final Subchannel delegate;
+      private final AtomicReference<ClusterLocality> localityAtomicReference;
+
+      private ClusterImplSubchannel(
+          Subchannel delegate, AtomicReference<ClusterLocality> localityAtomicReference) {
+        this.delegate = delegate;
+        this.localityAtomicReference = localityAtomicReference;
+      }
+
+      @Override
+      public void start(SubchannelStateListener listener) {
+        delegate().start(
+            new SubchannelStateListener() {
+              @Override
+              public void onSubchannelState(ConnectivityStateInfo newState) {
+                // Do nothing if LB has been shutdown
+                if (xdsClient != null && newState.getState().equals(ConnectivityState.READY)) {
+                  // Get locality based on the connected address attributes
+                  ClusterLocality updatedClusterLocality =
+                      createClusterLocalityFromAttributes(
+                          delegate.getConnectedAddressAttributes());
+                  ClusterLocality oldClusterLocality =
+                      localityAtomicReference.getAndSet(updatedClusterLocality);
+                  oldClusterLocality.release();
+                }
+                listener.onSubchannelState(newState);
               }
-              listener.onSubchannelState(newState);
-            }
-          });
-        }
+            });
+      }
 
-        @Override
-        public void shutdown() {
-          localityAtomicReference.get().release();
-          delegate().shutdown();
-        }
+      @Override
+      public void shutdown() {
+        localityAtomicReference.get().release();
+        delegate().shutdown();
+      }
 
-        @Override
-        public void updateAddresses(List<EquivalentAddressGroup> addresses) {
-          delegate().updateAddresses(withAdditionalAttributes(addresses));
-        }
+      @Override
+      public void updateAddresses(List<EquivalentAddressGroup> addresses) {
+        delegate().updateAddresses(withAdditionalAttributes(addresses));
+      }
 
-        @Override
-        protected Subchannel delegate() {
-          return subchannel;
-        }
-      };
+      @Override
+      protected Subchannel delegate() {
+        return delegate;
+      }
     }
 
     private List<EquivalentAddressGroup> withAdditionalAttributes(
@@ -411,6 +424,13 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
           }
         }
         PickResult result = delegate.pickSubchannel(args);
+        Subchannel subchannel = result.getSubchannel();
+        if (subchannel != null) {
+          if (subchannel instanceof ClusterImplLbHelper.ClusterImplSubchannel) {
+            subchannel = ((ClusterImplLbHelper.ClusterImplSubchannel) subchannel).delegate();
+            result = result.withSubchannelReplacement(subchannel);
+          }
+        }
         if (result.getStatus().isOk() && result.getSubchannel() != null) {
           if (enableCircuitBreaking) {
             if (inFlights.get() >= maxConcurrentRequests) {
@@ -437,8 +457,7 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
                   stats, inFlights, result.getStreamTracerFactory());
               ClientStreamTracer.Factory orcaTracerFactory = OrcaPerRequestUtil.getInstance()
                   .newOrcaClientStreamTracerFactory(tracerFactory, new OrcaPerRpcListener(stats));
-              result = PickResult.withSubchannel(result.getSubchannel(),
-                  orcaTracerFactory);
+              result = result.withStreamTracerFactory(orcaTracerFactory);
             }
           }
           if (args.getCallOptions().getOption(XdsNameResolver.AUTO_HOST_REWRITE_KEY) != null

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -508,12 +508,15 @@ final class WeightedRoundRobinLoadBalancer extends MultiChildLoadBalancer {
       if (subchannel == null) {
         return pickResult;
       }
+      
+      subchannel = ((WrrSubchannel) subchannel).delegate();
       if (!enableOobLoadReport) {
-        return PickResult.withSubchannel(subchannel,
-            OrcaPerRequestUtil.getInstance().newOrcaClientStreamTracerFactory(
-                reportListeners.get(pick)));
+        return pickResult.withSubchannelReplacement(subchannel)
+            .withStreamTracerFactory(
+                OrcaPerRequestUtil.getInstance().newOrcaClientStreamTracerFactory(
+                    reportListeners.get(pick)));
       } else {
-        return PickResult.withSubchannel(subchannel);
+        return pickResult.withSubchannelReplacement(subchannel);
       }
     }
 

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -511,12 +511,12 @@ final class WeightedRoundRobinLoadBalancer extends MultiChildLoadBalancer {
       
       subchannel = ((WrrSubchannel) subchannel).delegate();
       if (!enableOobLoadReport) {
-        return pickResult.withSubchannelReplacement(subchannel)
-            .withStreamTracerFactory(
+        return pickResult.copyWithSubchannel(subchannel)
+            .copyWithStreamTracerFactory(
                 OrcaPerRequestUtil.getInstance().newOrcaClientStreamTracerFactory(
                     reportListeners.get(pick)));
       } else {
-        return pickResult.withSubchannelReplacement(subchannel);
+        return pickResult.copyWithSubchannel(subchannel);
       }
     }
 

--- a/xds/src/main/java/io/grpc/xds/orca/OrcaOobUtil.java
+++ b/xds/src/main/java/io/grpc/xds/orca/OrcaOobUtil.java
@@ -245,6 +245,7 @@ public final class OrcaOobUtil {
       delegate.updateBalancingState(newState, new OrcaOobPicker(newPicker));
     }
 
+    @VisibleForTesting
     static final class OrcaOobPicker extends SubchannelPicker {
       final SubchannelPicker delegate;
 

--- a/xds/src/main/java/io/grpc/xds/orca/OrcaOobUtil.java
+++ b/xds/src/main/java/io/grpc/xds/orca/OrcaOobUtil.java
@@ -257,7 +257,7 @@ public final class OrcaOobUtil {
         PickResult result = delegate.pickSubchannel(args);
         Subchannel subchannel = result.getSubchannel();
         if (subchannel instanceof SubchannelImpl) {
-          return result.withSubchannelReplacement(((SubchannelImpl) subchannel).delegate());
+          return result.copyWithSubchannel(((SubchannelImpl) subchannel).delegate());
         }
         return result;
       }

--- a/xds/src/main/java/io/grpc/xds/orca/OrcaOobUtil.java
+++ b/xds/src/main/java/io/grpc/xds/orca/OrcaOobUtil.java
@@ -245,8 +245,8 @@ public final class OrcaOobUtil {
       delegate.updateBalancingState(newState, new OrcaOobPicker(newPicker));
     }
 
-    private static final class OrcaOobPicker extends SubchannelPicker {
-      private final SubchannelPicker delegate;
+    static final class OrcaOobPicker extends SubchannelPicker {
+      final SubchannelPicker delegate;
 
       OrcaOobPicker(SubchannelPicker delegate) {
         this.delegate = delegate;

--- a/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/WeightedRoundRobinLoadBalancerTest.java
@@ -171,6 +171,19 @@ public class WeightedRoundRobinLoadBalancerTest {
     helper = mock(Helper.class, delegatesTo(testHelperInstance));
   }
 
+  private static WeightedRoundRobinPicker getWrrPicker(SubchannelPicker picker) {
+    if (picker.getClass().getName().endsWith("OrcaOobPicker")) {
+      try {
+        java.lang.reflect.Field f = picker.getClass().getDeclaredField("delegate");
+        f.setAccessible(true);
+        return (WeightedRoundRobinPicker) f.get(picker);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+    return (WeightedRoundRobinPicker) picker;
+  }
+
   @Before
   public void setup() {
     for (int i = 0; i < 3; i++) {
@@ -213,7 +226,7 @@ public class WeightedRoundRobinLoadBalancerTest {
     verify(helper).updateBalancingState(
         eq(ConnectivityState.TRANSIENT_FAILURE), pickerCaptor.capture());
     final WeightedRoundRobinPicker weightedPicker =
-        (WeightedRoundRobinPicker) pickerCaptor.getValue();
+        getWrrPicker(pickerCaptor.getValue());
     weightedPicker.pickSubchannel(mockArgs);
   }
 
@@ -274,9 +287,9 @@ public class WeightedRoundRobinLoadBalancerTest {
             eq(ConnectivityState.READY), pickerCaptor.capture());
     assertThat(pickerCaptor.getAllValues().size()).isEqualTo(2);
     WeightedRoundRobinPicker weightedPicker =
-        (WeightedRoundRobinPicker) pickerCaptor.getAllValues().get(0);
+        getWrrPicker(pickerCaptor.getAllValues().get(0));
     assertThat(weightedPicker.getChildren().size()).isEqualTo(1);
-    weightedPicker = (WeightedRoundRobinPicker) pickerCaptor.getAllValues().get(1);
+    weightedPicker = getWrrPicker(pickerCaptor.getAllValues().get(1));
     assertThat(weightedPicker.getChildren().size()).isEqualTo(2);
     String weightedPickerStr = weightedPicker.toString();
     assertThat(weightedPickerStr).contains("enableOobLoadReport=false");
@@ -337,7 +350,7 @@ public class WeightedRoundRobinLoadBalancerTest {
     verify(helper, times(2)).updateBalancingState(
             eq(ConnectivityState.READY), pickerCaptor.capture());
     WeightedRoundRobinPicker weightedPicker =
-        (WeightedRoundRobinPicker) pickerCaptor.getAllValues().get(1);
+        getWrrPicker(pickerCaptor.getAllValues().get(1));
     WeightedChildLbState weightedChild1 = (WeightedChildLbState) getChild(weightedPicker, 0);
     WeightedChildLbState weightedChild2 = (WeightedChildLbState) getChild(weightedPicker, 1);
     weightedChild1.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
@@ -361,7 +374,7 @@ public class WeightedRoundRobinLoadBalancerTest {
             .setAttributes(affinity).build()));
     verify(helper, times(3)).updateBalancingState(
             eq(ConnectivityState.READY), pickerCaptor2.capture());
-    weightedPicker = (WeightedRoundRobinPicker) pickerCaptor2.getAllValues().get(2);
+    weightedPicker = getWrrPicker(pickerCaptor2.getAllValues().get(2));
     pickResult = weightedPicker.pickSubchannel(mockArgs);
     assertThat(getAddresses(pickResult)).isEqualTo(servers.get(0));
     assertThat(pickResult.getStreamTracerFactory()).isNull();
@@ -395,7 +408,7 @@ public class WeightedRoundRobinLoadBalancerTest {
     verify(helper, times(3)).updateBalancingState(
             eq(ConnectivityState.READY), pickerCaptor.capture());
     WeightedRoundRobinPicker weightedPicker =
-        (WeightedRoundRobinPicker) pickerCaptor.getAllValues().get(2);
+        getWrrPicker(pickerCaptor.getAllValues().get(2));
     WeightedChildLbState weightedChild1 = (WeightedChildLbState) getChild(weightedPicker, 0);
     WeightedChildLbState weightedChild2 = (WeightedChildLbState) getChild(weightedPicker, 1);
     WeightedChildLbState weightedChild3 = (WeightedChildLbState) getChild(weightedPicker, 2);
@@ -595,7 +608,7 @@ public class WeightedRoundRobinLoadBalancerTest {
     verify(helper, times(2)).updateBalancingState(
             eq(ConnectivityState.READY), pickerCaptor.capture());
     WeightedRoundRobinPicker weightedPicker =
-        (WeightedRoundRobinPicker) pickerCaptor.getAllValues().get(1);
+        getWrrPicker(pickerCaptor.getAllValues().get(1));
     WeightedChildLbState weightedChild1 = (WeightedChildLbState) getChild(weightedPicker, 0);
     WeightedChildLbState weightedChild2 = (WeightedChildLbState) getChild(weightedPicker, 1);
     weightedChild1.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
@@ -655,9 +668,9 @@ public class WeightedRoundRobinLoadBalancerTest {
         eq(ConnectivityState.READY), pickerCaptor.capture());
     assertThat(pickerCaptor.getAllValues().size()).isEqualTo(2);
     WeightedRoundRobinPicker weightedPicker =
-        (WeightedRoundRobinPicker) pickerCaptor.getAllValues().get(0);
+        getWrrPicker(pickerCaptor.getAllValues().get(0));
     assertThat(weightedPicker.getChildren().size()).isEqualTo(1);
-    weightedPicker = (WeightedRoundRobinPicker) pickerCaptor.getAllValues().get(1);
+    weightedPicker = getWrrPicker(pickerCaptor.getAllValues().get(1));
     assertThat(weightedPicker.getChildren().size()).isEqualTo(2);
     WeightedChildLbState weightedChild1 = (WeightedChildLbState) getChild(weightedPicker, 0);
     WeightedChildLbState weightedChild2 = (WeightedChildLbState) getChild(weightedPicker, 1);
@@ -710,7 +723,7 @@ public class WeightedRoundRobinLoadBalancerTest {
     verify(helper, times(2)).updateBalancingState(
             eq(ConnectivityState.READY), pickerCaptor.capture());
     WeightedRoundRobinPicker weightedPicker =
-        (WeightedRoundRobinPicker) pickerCaptor.getAllValues().get(1);
+        getWrrPicker(pickerCaptor.getAllValues().get(1));
     WeightedChildLbState weightedChild1 = (WeightedChildLbState) getChild(weightedPicker, 0);
     WeightedChildLbState weightedChild2 = (WeightedChildLbState) getChild(weightedPicker, 1);
     weightedChild1.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
@@ -761,7 +774,7 @@ public class WeightedRoundRobinLoadBalancerTest {
     verify(helper, times(2)).updateBalancingState(
         eq(ConnectivityState.READY), pickerCaptor.capture());
     WeightedRoundRobinPicker weightedPicker =
-        (WeightedRoundRobinPicker) pickerCaptor.getAllValues().get(1);
+        getWrrPicker(pickerCaptor.getAllValues().get(1));
     int expectedTasks = isEnabledHappyEyeballs() ? 2 : 1;
     assertThat(fakeClock.forwardTime(10, TimeUnit.SECONDS)).isEqualTo(expectedTasks);
     Map<EquivalentAddressGroup, Integer> qpsByChannel = ImmutableMap.of(servers.get(0), 2,
@@ -816,7 +829,7 @@ public class WeightedRoundRobinLoadBalancerTest {
     verify(helper, times(3)).updateBalancingState(
             eq(ConnectivityState.READY), pickerCaptor.capture());
     WeightedRoundRobinPicker weightedPicker =
-        (WeightedRoundRobinPicker) pickerCaptor.getAllValues().get(2);
+        getWrrPicker(pickerCaptor.getAllValues().get(2));
     WeightedChildLbState weightedChild1 = (WeightedChildLbState) getChild(weightedPicker, 0);
     WeightedChildLbState weightedChild2 = (WeightedChildLbState) getChild(weightedPicker, 1);
     weightedChild1.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(
@@ -857,7 +870,7 @@ public class WeightedRoundRobinLoadBalancerTest {
     verify(helper, times(2)).updateBalancingState(
             eq(ConnectivityState.READY), pickerCaptor.capture());
     WeightedRoundRobinPicker weightedPicker =
-        (WeightedRoundRobinPicker) pickerCaptor.getAllValues().get(1);
+        getWrrPicker(pickerCaptor.getAllValues().get(1));
     WeightedChildLbState weightedChild1 = (WeightedChildLbState) getChild(weightedPicker, 0);
     WeightedChildLbState weightedChild2 = (WeightedChildLbState) getChild(weightedPicker, 1);
     weightedChild1.new OrcaReportListener(weightedConfig.errorUtilizationPenalty).onLoadReport(

--- a/xds/src/test/java/io/grpc/xds/orca/OrcaOobUtilAccessor.java
+++ b/xds/src/test/java/io/grpc/xds/orca/OrcaOobUtilAccessor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds.orca;
+
+import io.grpc.LoadBalancer;
+
+/**
+ * Accessor for white-box testing involving OrcaOobUtil.
+ */
+public final class OrcaOobUtilAccessor {
+  private OrcaOobUtilAccessor() {
+    // Do not instantiate
+  }
+
+  public static LoadBalancer.SubchannelPicker getDelegate(LoadBalancer.SubchannelPicker picker) {
+    if (picker instanceof OrcaOobUtil.OrcaReportingHelper.OrcaOobPicker) {
+      return ((OrcaOobUtil.OrcaReportingHelper.OrcaOobPicker) picker).delegate;
+    }
+    return picker;
+  }
+}

--- a/xds/src/test/java/io/grpc/xds/orca/OrcaOobUtilAccessor.java
+++ b/xds/src/test/java/io/grpc/xds/orca/OrcaOobUtilAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The gRPC Authors
+ * Copyright 2026 The gRPC Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR ensures that Load Balancing (LB) policies unwrap `ForwardingSubchannel` instances before returning them in a `PickResult`.

**Rationale:** Currently, the identity of a subchannel is "awkward" because decorators break object identity. This forces the core channel to use internal workarounds like `getInternalSubchannel()` to find the underlying implementation. Removing these wrappers during the pick process is a critical prerequisite for deleting Subchannel Attributes.

By enforcing unwrapping, `ManagedChannelImpl` can rely on the fact that a returned subchannel is the same instance it originally created. This allows the channel to use strongly-typed fields for state management (via "blind casting") rather than abusing attributes to re-discover information that should already be known. This also paves the way for the eventual removal of the `getInternalSubchannel()` internal API.

**New APIs:** To ensure we don't "drop data on the floor" during the unwrapping process, this PR adds two new non-static APIs to PickResult:
- copyWithSubchannel()
- copyWithStreamTracerFactory()

Unlike static factory methods, these instance methods follow a "copy-and-update" pattern that preserves all existing pick-level metadata (such as authority overrides or drop status) while only swapping the specific field required.