### PR TITLE
Expose InternalServer as a transport attribute in ServerImpl

### DIFF
--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -94,6 +94,8 @@ import java.util.logging.Logger;
 public final class ServerImpl extends io.grpc.Server implements InternalInstrumented<ServerStats> {
   private static final Logger log = Logger.getLogger(ServerImpl.class.getName());
   private static final ServerStreamListener NOOP_LISTENER = new NoopListener();
+  static final Attributes.Key<InternalServer> TRANSPORT_SERVER_ATTR =
+      Attributes.Key.create("io.grpc.Grpc.TRANSPORT_ATTR_SERVER_TRANSPORT");
 
   private final InternalLogId logId;
   private final ObjectPool<? extends Executor> executorPool;
@@ -437,6 +439,10 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
     public Attributes transportReady(Attributes attributes) {
       handshakeTimeoutFuture.cancel(false);
       handshakeTimeoutFuture = null;
+
+      final Attributes.Builder builder = attributes.toBuilder();
+      builder.set(TRANSPORT_SERVER_ATTR, transportServer);
+      attributes = builder.build();
 
       for (ServerTransportFilter filter : transportFilters) {
         attributes = Preconditions.checkNotNull(filter.transportReady(attributes),


### PR DESCRIPTION
This change exposes the InternalServer as a transport-level attribute on ServerTransportListenerImpl, making it available to ServerTransportFilter implementations and downstream consumers via Attributes.

**Changes**

1. Added a static Attributes.Key<InternalServer> named TRANSPORT_SERVER_ATTR with the key "io.grpc.Grpc.TRANSPORT_ATTR_SERVER_TRANSPORT"
2. In transportReady(), the transportServer reference is set on the Attributes before transport filters are invoked, so it is accessible throughout the request lifecycle
3. 
**Why**
We need access to the underlying ServerTransport from within a ServerInterceptor to force-close the transport connection when an external session expires.

In our use case, we have a ServerInterceptor that authenticates incoming RPCs against an external session management system. When a session isestablished, we register a close handler on it. If the external session is later invalidated or expires, the close handler fires and needs to shut down the underlying transport so the client is forced to reconnect and re-authenticate.

Currently, there is no way for a ServerInterceptor to access the transport layer to force-close a connection. The interceptor can reject individual RPCs via call.close(Status.UNAUTHENTICATED, ...), but it cannot terminate the transport itself. 