### PR TITLE
Revert "netty: Preserve early server handshake failure cause in logs"

### DIFF
--- a/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerHandler.java
@@ -124,12 +124,6 @@ class NettyServerHandler extends AbstractNettyHandler {
   private static final boolean DISABLE_CONNECTION_HEADER_CHECK = Boolean.parseBoolean(
       System.getProperty("io.grpc.netty.disableConnectionHeaderCheck", "false"));
 
-  /**
-   * A message that simply passes through the channel without any real processing. It is useful to
-   * check if buffers have been drained and test the health of the channel in a single operation.
-   */
-  static final Object NOOP_MESSAGE = new Object();
-
   private final Http2Connection.PropertyKey streamKey;
   private final ServerTransportListener transportListener;
   private final int maxMessageSize;
@@ -715,8 +709,6 @@ class NettyServerHandler extends AbstractNettyHandler {
       gracefulClose(ctx, (GracefulServerCloseCommand) msg, promise);
     } else if (msg instanceof ForcefulCloseCommand) {
       forcefulClose(ctx, (ForcefulCloseCommand) msg, promise);
-    } else if (msg == NOOP_MESSAGE) {
-      ctx.write(Unpooled.EMPTY_BUFFER, promise);
     } else {
       AssertionError e =
           new AssertionError("Write called for unexpected type: " + msg.getClass().getName());

--- a/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerTransport.java
@@ -160,18 +160,6 @@ class NettyServerTransport implements ServerTransport {
     channel.closeFuture().addListener(terminationNotifier);
 
     channel.pipeline().addLast(bufferingHandler);
-
-    channel.writeAndFlush(NettyServerHandler.NOOP_MESSAGE).addListener(new ChannelFutureListener() {
-      @Override
-      public void operationComplete(ChannelFuture future) throws Exception {
-        if (!future.isSuccess()) {
-          // grpcHandler (NettyServerHandler) may not be in the pipeline yet on early negotiation
-          // failure, so connectionError() can remain null. Notify termination here with the write
-          // failure cause to preserve/log the original transport termination reason.
-          notifyTerminated(future.cause());
-        }
-      }
-    });
   }
 
   @Override

--- a/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyServerHandlerTest.java
@@ -1347,25 +1347,6 @@ public class NettyServerHandlerTest extends NettyHandlerTestBase<NettyServerHand
     assertFalse(channel().isOpen());
   }
 
-  @Test
-  public void write_noopMessage_writesEmptyBuffer() throws Exception {
-    manualSetUp();
-
-    ChannelPromise promise = newPromise();
-    handler().write(ctx(), NettyServerHandler.NOOP_MESSAGE, promise);
-    channel().flush();
-
-    assertTrue(promise.isSuccess());
-
-    Object outbound = channel().readOutbound();
-    assertTrue(outbound instanceof ByteBuf);
-    ByteBuf buf = (ByteBuf) outbound;
-    assertEquals(0, buf.readableBytes());
-    buf.release();
-
-    assertNull(channel().readOutbound());
-  }
-
   private void madeYouReset(int burstSize) throws Exception {
     when(streamTracerFactory.newServerStreamTracer(anyString(), any(Metadata.class)))
         .thenAnswer((args) -> new TestServerStreamTracer());


### PR DESCRIPTION
This reverts commit 50ead96f4718569782cc7a3f694c9aa755722bac. Some users are seeing errors during app development: cl/876319409 b/488103229. Seems related to some internal Google-specific stuff.

FYI @kannanjgithub, @becomeStar (I don't think there's anything more you can do here at the moment; we need to look into it on our side, as it is some very specialized code that is impacted.)