### PR TITLE
Drop support for Android API levels 21-22

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ gRPC-Java - An RPC library and framework
 Supported Platforms
 -------------------
 
-gRPC-Java supports Java 8 and later. Android minSdkVersion 21 (Lollipop) and
+gRPC-Java supports Java 8 and later. Android minSdkVersion 23 (Marshmallow) and
 later are supported with [Java 8 language desugaring][android-java-8].
 
 TLS usage on Android typically requires Play Services Dynamic Security Provider.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,7 @@ android {
     }
     compileSdkVersion 34
     defaultConfig {
-        minSdkVersion 22
+        minSdkVersion 23
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -13,7 +13,7 @@ android {
         targetCompatibility 1.8
     }
     defaultConfig {
-        minSdkVersion 22
+        minSdkVersion 23
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -14,7 +14,7 @@ android {
     namespace = 'io.grpc.cronet'
     compileSdkVersion 33
     defaultConfig {
-        minSdkVersion 22
+        minSdkVersion 23
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
+++ b/cronet/src/main/java/io/grpc/cronet/CronetChannelBuilder.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 
 import android.net.Network;
-import android.os.Build;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.MoreExecutors;
@@ -340,9 +339,7 @@ public final class CronetChannelBuilder extends ForwardingChannelBuilder2<Cronet
         builder.setTrafficStatsUid(trafficStatsUid);
       }
       if (network != null) {
-        if (Build.VERSION.SDK_INT >= 23) {
-          builder.bindToNetwork(network.getNetworkHandle());
-        }
+        builder.bindToNetwork(network.getNetworkHandle());
       }
       return builder;
     }

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId "io.grpc.helloworldexample"
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId "io.grpc.routeguideexample"
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Google Play Services needs min Android API level of 23 (Android 6.0 Marshmallow).

Fixes [#11474](https://github.com/grpc/grpc-java/issues/11474).