### PR TITLE
core: Wait for backoff timer on address update in pick_first

### DIFF
--- a/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
+++ b/core/src/main/java/io/grpc/internal/PickFirstLeafLoadBalancer.java
@@ -496,7 +496,7 @@ final class PickFirstLeafLoadBalancer extends LoadBalancer {
    */
   @Override
   public void requestConnection() {
-    if (!addressIndex.isValid() || rawConnectivityState == SHUTDOWN) {
+    if (!addressIndex.isValid() || rawConnectivityState == SHUTDOWN || reconnectTask != null) {
       return;
     }
 

--- a/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
@@ -1446,6 +1446,11 @@ public class PickFirstLeafLoadBalancerTest {
     loadBalancer.acceptResolvedAddresses(
         ResolvedAddresses.newBuilder().setAddresses(newServers).setAttributes(affinity).build());
 
+    if (serializeRetries) {
+      inOrder.verify(mockSubchannel3, never()).start(stateListenerCaptor.capture());
+      fakeClock.forwardTime(1, TimeUnit.SECONDS);
+    }
+
     // subchannel 3 still attempts a connection even though we stay in transient failure
     assertEquals(TRANSIENT_FAILURE, loadBalancer.getConcludedConnectivityState());
     inOrder.verify(mockSubchannel3).start(stateListenerCaptor.capture());

--- a/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
+++ b/core/src/test/java/io/grpc/internal/PickFirstLeafLoadBalancerTest.java
@@ -1448,7 +1448,7 @@ public class PickFirstLeafLoadBalancerTest {
 
     if (serializeRetries) {
       inOrder.verify(mockSubchannel3, never()).start(stateListenerCaptor.capture());
-      fakeClock.forwardTime(1, TimeUnit.SECONDS);
+      forwardTimeByBackoffDelay();
     }
 
     // subchannel 3 still attempts a connection even though we stay in transient failure


### PR DESCRIPTION
The backoff timer is only used when serializeRetries=true, and that exists to match the old/current pick_first's behavior as closely as possible. InternalSubchannel.updateAddresses() would take no action when in TRANSIENT_FAILURE; it would update the addresses and just wait for the backoff timer to expire.

Note that this only impacts serializeRetries=true; in the other cases we do want to start trying to the new addresses immediately, because the backoff timers are in the subchannels.