### PR TITLE
android-interop-testing: Remove usage of MultiDexApplication

### DIFF
--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-base:18.0.1'
 
     implementation project(':grpc-android'),
+            project(':grpc-api'),
             project(':grpc-core'),
             project(':grpc-census'),
             project(':grpc-okhttp'),

--- a/android-interop-testing/build.gradle
+++ b/android-interop-testing/build.gradle
@@ -33,15 +33,11 @@ android {
 
     defaultConfig {
         applicationId "io.grpc.android.integrationtest"
-        // Held back to 20 as Gradle fails to build at the 21 level. This is
-        // presumably a Gradle bug that can be revisited later.
-        // Maybe this issue: https://github.com/gradle/gradle/issues/20778
-        minSdkVersion 20
+        minSdkVersion 23
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        multiDexEnabled = true
     }
     buildTypes {
         debug { minifyEnabled false }
@@ -62,7 +58,6 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0'
-    implementation 'androidx.multidex:multidex:2.0.0'
     implementation libraries.androidx.annotation
     implementation 'com.google.android.gms:play-services-base:18.0.1'
 

--- a/android-interop-testing/src/androidTest/AndroidManifest.xml
+++ b/android-interop-testing/src/androidTest/AndroidManifest.xml
@@ -5,8 +5,7 @@
         android:name="androidx.test.runner.AndroidJUnitRunner"
         android:targetPackage="io.grpc.android.integrationtest" />
 
-    <application
-        android:name="android.support.multidex.MultiDexApplication" >
+    <application>
     </application>
 
 </manifest>

--- a/android-interop-testing/src/main/AndroidManifest.xml
+++ b/android-interop-testing/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/Base.V7.Theme.AppCompat.Light"
-        android:name="androidx.multidex.MultiDexApplication">
+        android:theme="@style/Base.V7.Theme.AppCompat.Light">
         <activity
             android:name=".TesterActivity"
             android:exported="true">

--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -18,7 +18,6 @@ android {
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        multiDexEnabled = true
     }
     lintOptions { abortOnError = false }
     publishing {

--- a/examples/android/clientcache/app/build.gradle
+++ b/examples/android/clientcache/app/build.gradle
@@ -10,9 +10,8 @@ android {
 
     defaultConfig {
         applicationId "io.grpc.clientcacheexample"
-        minSdkVersion 21
+        minSdkVersion 23
         targetSdkVersion 33
-        multiDexEnabled true
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Since we're only supporting API levels 23+, all the supported Android versions handle multidex natively, and without any bugs to workaround.

See also b/476359563

-----

cl/872773139. CC @kannanjgithub 