### PR TITLE
Add RFC 3986 URI support to "googleapis" 

### DIFF
--- a/api/src/main/java/io/grpc/Uri.java
+++ b/api/src/main/java/io/grpc/Uri.java
@@ -356,6 +356,15 @@ public final class Uri {
   /**
    * Returns the percent-decoded "Authority" component of this URI, or null if not present.
    *
+   * <p>NB: This method's decoding is lossy -- It only exists for compatibility with {@link
+   * java.net.URI}. Prefer {@link #getRawAuthority()} or work instead with authority in terms of its
+   * individual components ({@link #getUserInfo()}, {@link #getHost()} and {@link #getPort()}). The
+   * problem with getAuthority() is that it returns the delimited concatenation of the percent-
+   * decoded userinfo, host and port components. But both userinfo and host can contain the '@'
+   * character, which becomes indistinguishable from the userinfo/host delimiter after decoding. For
+   * example, URIs <code>scheme://x@y%40z</code> and <code>scheme://x%40y@z</code> have different
+   * userinfo and host components but getAuthority() returns "x@y@z" for both of them.
+   *
    * <p>NB: This method assumes the "host" component was encoded as UTF-8, as mandated by RFC 3986.
    * This method also assumes the "user information" part of authority was encoded as UTF-8,
    * although RFC 3986 doesn't specify an encoding.

--- a/api/src/main/java/io/grpc/Uri.java
+++ b/api/src/main/java/io/grpc/Uri.java
@@ -257,7 +257,7 @@ public final class Uri {
       int hostStart = userInfoEnd >= 0 ? userInfoEnd + 1 : 0;
       int portStartColon = findPortStartColon(authority, hostStart);
       if (portStartColon < 0) {
-        builder.setRawHost(authority.substring(hostStart, authority.length()));
+        builder.setRawHost(authority.substring(hostStart));
       } else {
         builder.setRawHost(authority.substring(hostStart, portStartColon));
         builder.setRawPort(authority.substring(portStartColon + 1));

--- a/api/src/main/java/io/grpc/Uri.java
+++ b/api/src/main/java/io/grpc/Uri.java
@@ -245,23 +245,7 @@ public final class Uri {
           break;
         }
       }
-      String authority = s.substring(authorityStart, i);
-
-      // 3.2.1. UserInfo. Easy, because '@' cannot appear unencoded inside userinfo or host.
-      int userInfoEnd = authority.indexOf('@');
-      if (userInfoEnd >= 0) {
-        builder.setRawUserInfo(authority.substring(0, userInfoEnd));
-      }
-
-      // 3.2.2/3. Host/Port.
-      int hostStart = userInfoEnd >= 0 ? userInfoEnd + 1 : 0;
-      int portStartColon = findPortStartColon(authority, hostStart);
-      if (portStartColon < 0) {
-        builder.setRawHost(authority.substring(hostStart));
-      } else {
-        builder.setRawHost(authority.substring(hostStart, portStartColon));
-        builder.setRawPort(authority.substring(portStartColon + 1));
-      }
+      builder.setRawAuthority(s.substring(authorityStart, i));
     }
 
     // 3.3. Path: Whatever is left before '?' or '#'.
@@ -960,6 +944,51 @@ public final class Uri {
         }
       }
       this.port = port;
+      return this;
+    }
+
+    /**
+     * Specifies the userinfo, host and port URI components all at once using a single string.
+     *
+     * <p>This setter is "raw" in the sense that special characters in userinfo and host must be
+     * passed in percent-encoded. See <a
+     * href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.2">RFC 3986 3.2</a> for the set
+     * of characters allowed in each component of an authority.
+     *
+     * <p>There's no "cooked" method to set authority like for other URI components because
+     * authority is a *compound* URI component whose userinfo, host and port components are
+     * delimited with special characters '@' and ':'. But the first two of those components can
+     * themselves contain these delimiters so we need percent-encoding to parse them unambiguously.
+     *
+     * @param authority an RFC 3986 authority string that will be used to set userinfo, host and
+     *     port, or null to clear all three of those components
+     */
+    @CanIgnoreReturnValue
+    public Builder setRawAuthority(@Nullable String authority) {
+      if (authority == null) {
+        setUserInfo(null);
+        setHost((String) null);
+        setPort(-1);
+      } else {
+        // UserInfo. Easy because '@' cannot appear unencoded inside userinfo or host.
+        int userInfoEnd = authority.indexOf('@');
+        if (userInfoEnd >= 0) {
+          setRawUserInfo(authority.substring(0, userInfoEnd));
+        } else {
+          setUserInfo(null);
+        }
+
+        // Host/Port.
+        int hostStart = userInfoEnd >= 0 ? userInfoEnd + 1 : 0;
+        int portStartColon = findPortStartColon(authority, hostStart);
+        if (portStartColon < 0) {
+          setRawHost(authority.substring(hostStart));
+          setPort(-1);
+        } else {
+          setRawHost(authority.substring(hostStart, portStartColon));
+          setRawPort(authority.substring(portStartColon + 1));
+        }
+      }
       return this;
     }
 

--- a/api/src/test/java/io/grpc/UriTest.java
+++ b/api/src/test/java/io/grpc/UriTest.java
@@ -628,6 +628,53 @@ public final class UriTest {
   }
 
   @Test
+  public void builder_canClearAuthorityComponents() {
+    Uri uri = Uri.create("s://user@host:80/path").toBuilder().setRawAuthority(null).build();
+    assertThat(uri.toString()).isEqualTo("s:/path");
+  }
+
+  @Test
+  public void builder_canSetEmptyAuthority() {
+    Uri uri = Uri.create("s://user@host:80/path").toBuilder().setRawAuthority("").build();
+    assertThat(uri.toString()).isEqualTo("s:///path");
+  }
+
+  @Test
+  public void builder_canSetRawAuthority() {
+    Uri uri = Uri.newBuilder().setScheme("http").setRawAuthority("user@host:1234").build();
+    assertThat(uri.getUserInfo()).isEqualTo("user");
+    assertThat(uri.getHost()).isEqualTo("host");
+    assertThat(uri.getPort()).isEqualTo(1234);
+  }
+
+  @Test
+  public void builder_setRawAuthorityPercentDecodes() {
+    Uri uri =
+        Uri.newBuilder()
+            .setScheme("http")
+            .setRawAuthority("user:user%40user@host%40host%3Ahost")
+            .build();
+    assertThat(uri.getUserInfo()).isEqualTo("user:user@user");
+    assertThat(uri.getHost()).isEqualTo("host@host:host");
+    assertThat(uri.getPort()).isEqualTo(-1);
+  }
+
+  @Test
+  public void builder_setRawAuthorityReplacesAllComponents() {
+    Uri uri =
+        Uri.newBuilder()
+            .setScheme("http")
+            .setUserInfo("user")
+            .setHost("host")
+            .setPort(1234)
+            .setRawAuthority("other")
+            .build();
+    assertThat(uri.getUserInfo()).isNull();
+    assertThat(uri.getHost()).isEqualTo("other");
+    assertThat(uri.getPort()).isEqualTo(-1);
+  }
+
+  @Test
   public void toString_percentEncodingMultiChar() throws URISyntaxException {
     Uri uri =
         Uri.newBuilder()

--- a/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdExperimentalNameResolverProvider.java
+++ b/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdExperimentalNameResolverProvider.java
@@ -20,6 +20,7 @@ import io.grpc.Internal;
 import io.grpc.NameResolver;
 import io.grpc.NameResolver.Args;
 import io.grpc.NameResolverProvider;
+import io.grpc.Uri;
 import java.net.URI;
 
 /**
@@ -32,6 +33,11 @@ public final class GoogleCloudToProdExperimentalNameResolverProvider extends Nam
 
   @Override
   public NameResolver newNameResolver(URI targetUri, Args args) {
+    return delegate.newNameResolver(targetUri, args);
+  }
+
+  @Override
+  public NameResolver newNameResolver(Uri targetUri, Args args) {
     return delegate.newNameResolver(targetUri, args);
   }
 

--- a/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdNameResolver.java
+++ b/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdNameResolver.java
@@ -29,6 +29,7 @@ import io.grpc.NameResolver;
 import io.grpc.NameResolverRegistry;
 import io.grpc.Status;
 import io.grpc.SynchronizationContext;
+import io.grpc.Uri;
 import io.grpc.alts.InternalCheckGcpEnvironment;
 import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.SharedResourceHolder;
@@ -49,6 +50,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.Executor;
 import java.util.logging.Level;
@@ -114,6 +116,7 @@ final class GoogleCloudToProdNameResolver extends NameResolver {
         NameResolverRegistry.getDefaultRegistry().asFactory());
   }
 
+  // TODO(jdcormie): Remove after io.grpc.Uri migration.
   @VisibleForTesting
   GoogleCloudToProdNameResolver(URI targetUri, Args args, Resource<Executor> executorResource,
       NameResolver.Factory nameResolverFactory) {
@@ -137,6 +140,45 @@ final class GoogleCloudToProdNameResolver extends NameResolver {
     metricRecorder = args.getMetricRecorder();
     delegate = checkNotNull(nameResolverFactory, "nameResolverFactory").newNameResolver(
         targetUri, args);
+    executor = args.getOffloadExecutor();
+    usingExecutorResource = executor == null;
+  }
+
+  GoogleCloudToProdNameResolver(Uri targetUri, Args args, Resource<Executor> executorResource) {
+    this(targetUri, args, executorResource, NameResolverRegistry.getDefaultRegistry().asFactory());
+  }
+
+  @VisibleForTesting
+  GoogleCloudToProdNameResolver(
+      Uri targetUri,
+      Args args,
+      Resource<Executor> executorResource,
+      NameResolver.Factory nameResolverFactory) {
+    this.executorResource = checkNotNull(executorResource, "executorResource");
+    Preconditions.checkArgument(
+        targetUri.isPathAbsolute(),
+        "the path component of the target (%s) must start with '/'",
+        targetUri);
+    List<String> pathSegments = targetUri.getPathSegments();
+    Preconditions.checkArgument(
+        pathSegments.size() == 1,
+        "the path component of the target (%s) must have exactly one segment",
+        targetUri);
+    authority = GrpcUtil.checkAuthority(pathSegments.get(0));
+    syncContext = checkNotNull(args, "args").getSynchronizationContext();
+    Uri.Builder modifiedTargetBuilder = targetUri.toBuilder().setScheme(schemeOverride);
+    if (schemeOverride.equals("xds")) {
+      modifiedTargetBuilder.setRawAuthority(C2P_AUTHORITY);
+      args =
+          args.toBuilder()
+              .setArg(XdsNameResolverProvider.XDS_CLIENT_SUPPLIER, () -> xdsClient)
+              .build();
+    }
+    targetUri = modifiedTargetBuilder.build();
+    target = targetUri.toString();
+    metricRecorder = args.getMetricRecorder();
+    delegate =
+        checkNotNull(nameResolverFactory, "nameResolverFactory").newNameResolver(targetUri, args);
     executor = args.getOffloadExecutor();
     usingExecutorResource = executor == null;
   }

--- a/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdNameResolverProvider.java
+++ b/googleapis/src/main/java/io/grpc/googleapis/GoogleCloudToProdNameResolverProvider.java
@@ -21,6 +21,7 @@ import io.grpc.Internal;
 import io.grpc.NameResolver;
 import io.grpc.NameResolver.Args;
 import io.grpc.NameResolverProvider;
+import io.grpc.Uri;
 import io.grpc.internal.GrpcUtil;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -46,8 +47,18 @@ public final class GoogleCloudToProdNameResolverProvider extends NameResolverPro
     this.scheme = Preconditions.checkNotNull(scheme, "scheme");
   }
 
+  // TODO(jdcormie): Remove after io.grpc.Uri migration is complete.
   @Override
   public NameResolver newNameResolver(URI targetUri, Args args) {
+    if (scheme.equals(targetUri.getScheme())) {
+      return new GoogleCloudToProdNameResolver(
+          targetUri, args, GrpcUtil.SHARED_CHANNEL_EXECUTOR);
+    }
+    return null;
+  }
+
+  @Override
+  public NameResolver newNameResolver(Uri targetUri, Args args) {
     if (scheme.equals(targetUri.getScheme())) {
       return new GoogleCloudToProdNameResolver(
           targetUri, args, GrpcUtil.SHARED_CHANNEL_EXECUTOR);

--- a/googleapis/src/test/java/io/grpc/googleapis/GoogleCloudToProdNameResolverProviderTest.java
+++ b/googleapis/src/test/java/io/grpc/googleapis/GoogleCloudToProdNameResolverProviderTest.java
@@ -23,20 +23,23 @@ import static org.mockito.Mockito.mock;
 import io.grpc.ChannelLogger;
 import io.grpc.InternalServiceProviders;
 import io.grpc.NameResolver;
+import io.grpc.NameResolver.Args;
 import io.grpc.NameResolver.ServiceConfigParser;
 import io.grpc.NameResolverProvider;
 import io.grpc.SynchronizationContext;
+import io.grpc.Uri;
 import io.grpc.internal.FakeClock;
 import io.grpc.internal.GrpcUtil;
 import java.net.URI;
+import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
-/**
- * Unit tests for {@link GoogleCloudToProdNameResolverProvider}.
- */
-@RunWith(JUnit4.class)
+/** Unit tests for {@link GoogleCloudToProdNameResolverProvider}. */
+@RunWith(Parameterized.class)
 public class GoogleCloudToProdNameResolverProviderTest {
   private final SynchronizationContext syncContext = new SynchronizationContext(
       new Thread.UncaughtExceptionHandler() {
@@ -58,6 +61,13 @@ public class GoogleCloudToProdNameResolverProviderTest {
 
   private GoogleCloudToProdNameResolverProvider provider =
       new GoogleCloudToProdNameResolverProvider();
+
+  @Parameters(name = "enableRfc3986UrisParam={0}")
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(new Object[][] {{true}, {false}});
+  }
+
+  @Parameter public boolean enableRfc3986UrisParam;
 
   @Test
   public void provided() {
@@ -84,16 +94,24 @@ public class GoogleCloudToProdNameResolverProviderTest {
   }
 
   @Test
-  public void newNameResolver() {
-    assertThat(provider
-        .newNameResolver(URI.create("google-c2p:///foo.googleapis.com"), args))
+  public void shouldProvideNameResolverOfExpectedType() {
+    assertThat(newNameResolver(provider, "google-c2p:///foo.googleapis.com", args))
         .isInstanceOf(GoogleCloudToProdNameResolver.class);
   }
 
   @Test
-  public void experimentalNewNameResolver() {
-    assertThat(new GoogleCloudToProdExperimentalNameResolverProvider()
-        .newNameResolver(URI.create("google-c2p-experimental:///foo.googleapis.com"), args))
+  public void shouldProvideExperimentalNameResolverOfExpectedType() {
+    assertThat(
+            newNameResolver(
+                new GoogleCloudToProdExperimentalNameResolverProvider(),
+                "google-c2p-experimental:///foo.googleapis.com",
+                args))
         .isInstanceOf(GoogleCloudToProdNameResolver.class);
+  }
+
+  private NameResolver newNameResolver(NameResolverProvider provider, String uri, Args args) {
+    return enableRfc3986UrisParam
+        ? provider.newNameResolver(Uri.create(uri), args)
+        : provider.newNameResolver(URI.create(uri), args);
   }
 }

--- a/googleapis/src/test/java/io/grpc/googleapis/GoogleCloudToProdNameResolverTest.java
+++ b/googleapis/src/test/java/io/grpc/googleapis/GoogleCloudToProdNameResolverTest.java
@@ -34,6 +34,7 @@ import io.grpc.NameResolverRegistry;
 import io.grpc.Status;
 import io.grpc.Status.Code;
 import io.grpc.SynchronizationContext;
+import io.grpc.Uri;
 import io.grpc.googleapis.GoogleCloudToProdNameResolver.HttpConnectionProvider;
 import io.grpc.internal.FakeClock;
 import io.grpc.internal.GrpcUtil;
@@ -43,6 +44,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -53,20 +55,22 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
-@RunWith(JUnit4.class)
+@RunWith(Parameterized.class)
 public class GoogleCloudToProdNameResolverTest {
 
   @Rule
   public final MockitoRule mocks = MockitoJUnit.rule();
 
-  private static final URI TARGET_URI = URI.create("google-c2p:///googleapis.com");
+  private static final String TARGET_URI = "google-c2p:///googleapis.com";
   private static final String ZONE = "us-central1-a";
   private static final int DEFAULT_PORT = 887;
 
@@ -107,6 +111,13 @@ public class GoogleCloudToProdNameResolverTest {
   private boolean originalIsOnGcp;
   private GoogleCloudToProdNameResolver resolver;
   private String responseToIpV6 = "1:1:1";
+
+  @Parameters(name = "enableRfc3986UrisParam={0}")
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(new Object[][] {{true}, {false}});
+  }
+
+  @Parameter public boolean enableRfc3986UrisParam;
 
   @Before
   public void setUp() {
@@ -149,8 +160,12 @@ public class GoogleCloudToProdNameResolverTest {
   }
 
   private void createResolver() {
-    resolver = new GoogleCloudToProdNameResolver(
-        TARGET_URI, args, fakeExecutorResource, nsRegistry.asFactory());
+    resolver =
+        enableRfc3986UrisParam
+            ? new GoogleCloudToProdNameResolver(
+                Uri.create(TARGET_URI), args, fakeExecutorResource, nsRegistry.asFactory())
+            : new GoogleCloudToProdNameResolver(
+                URI.create(TARGET_URI), args, fakeExecutorResource, nsRegistry.asFactory());
   }
 
   @Test


### PR DESCRIPTION
I added io.grpc.Uri.Builder#setRawAuthority to implement GoogleCloudToProdNameResolver's overrideAuthority() function. Thinking about this made me notice a related problem with Uri#getAuthority.