### PR TITLE
core: fix false-positive orphan warning in ManagedChannelOrphanWrapper

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelOrphanWrapper.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelOrphanWrapper.java
@@ -62,14 +62,24 @@ final class ManagedChannelOrphanWrapper extends ForwardingManagedChannel {
 
   @Override
   public ManagedChannel shutdown() {
+    ManagedChannel result = super.shutdown();
     phantom.clearSafely();
-    return super.shutdown();
+    // This dummy check prevents the JIT from collecting 'this' too early
+    if (this.getClass() == null) {
+      throw new AssertionError();
+    }
+    return result;
   }
 
   @Override
   public ManagedChannel shutdownNow() {
+    ManagedChannel result = super.shutdownNow();
     phantom.clearSafely();
-    return super.shutdownNow();
+    // This dummy check prevents the JIT from collecting 'this' too early
+    if (this.getClass() == null) {
+      throw new AssertionError();
+    }
+    return result;
   }
 
   @VisibleForTesting
@@ -151,8 +161,9 @@ final class ManagedChannelOrphanWrapper extends ForwardingManagedChannel {
       int orphanedChannels = 0;
       while ((ref = (ManagedChannelReference) refqueue.poll()) != null) {
         RuntimeException maybeAllocationSite = ref.allocationSite.get();
+        boolean wasShutdown = ref.shutdown.get();
         ref.clearInternal(); // technically the reference is gone already.
-        if (!ref.shutdown.get()) {
+        if (!wasShutdown) {
           orphanedChannels++;
           Level level = Level.SEVERE;
           if (logger.isLoggable(level)) {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelOrphanWrapperTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelOrphanWrapperTest.java
@@ -141,6 +141,30 @@ public final class ManagedChannelOrphanWrapperTest {
   }
 
   @Test
+  public void orphanedChannel_triggerWarningAndCoverage() {
+    ManagedChannel mc = new TestManagedChannel();
+    final ReferenceQueue<ManagedChannelOrphanWrapper> refqueue = new ReferenceQueue<>();
+    ConcurrentMap<ManagedChannelReference, ManagedChannelReference> refs = 
+        new ConcurrentHashMap<>();
+    
+    // Create the wrapper but NEVER call shutdown
+    ManagedChannelOrphanWrapper wrapper = new ManagedChannelOrphanWrapper(mc, refqueue, refs);
+    wrapper = null; // Make it eligible for GC
+
+    // Trigger GC and clean the queue to hit the !wasShutdown branch
+    final AtomicInteger numOrphans = new AtomicInteger();
+    GcFinalization.awaitDone(new FinalizationPredicate() {
+      @Override
+      public boolean isDone() {
+        numOrphans.getAndAdd(ManagedChannelReference.cleanQueue(refqueue));
+        return numOrphans.get() > 0;
+      }
+    });
+    
+    assertEquals(1, numOrphans.get());
+  }
+
+  @Test
   public void refCycleIsGCed() {
     ReferenceQueue<ManagedChannelOrphanWrapper> refqueue =
         new ReferenceQueue<>();

--- a/core/src/test/java/io/grpc/internal/ManagedChannelOrphanWrapperTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelOrphanWrapperTest.java
@@ -125,7 +125,7 @@ public final class ManagedChannelOrphanWrapperTest {
     });
 
     try {
-      wrapper.shutdownNow(); 
+      wrapper.shutdown(); 
       wrapper = null; 
       
       // Wait for the WRAPPER itself to be garbage collected

--- a/core/src/test/java/io/grpc/internal/ManagedChannelOrphanWrapperTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelOrphanWrapperTest.java
@@ -102,6 +102,45 @@ public final class ManagedChannelOrphanWrapperTest {
   }
 
   @Test
+  public void shutdownNow_withDelegateStillReferenced_doesNotLogWarning() {
+    ManagedChannel mc = new TestManagedChannel();
+    final ReferenceQueue<ManagedChannelOrphanWrapper> refqueue = new ReferenceQueue<>();
+    ConcurrentMap<ManagedChannelReference, ManagedChannelReference> refs =
+        new ConcurrentHashMap<>();
+    
+    ManagedChannelOrphanWrapper wrapper = new ManagedChannelOrphanWrapper(mc, refqueue, refs);
+    WeakReference<ManagedChannelOrphanWrapper> wrapperWeakRef = new WeakReference<>(wrapper);
+
+    final List<LogRecord> records = new ArrayList<>();
+    Logger orphanLogger = Logger.getLogger(ManagedChannelOrphanWrapper.class.getName());
+    Filter oldFilter = orphanLogger.getFilter();
+    orphanLogger.setFilter(new Filter() {
+      @Override
+      public boolean isLoggable(LogRecord record) {
+        synchronized (records) { 
+          records.add(record); 
+        }
+        return false;
+      }
+    });
+
+    try {
+      wrapper.shutdownNow(); 
+      wrapper = null; 
+      
+      // Wait for the WRAPPER itself to be garbage collected
+      GcFinalization.awaitClear(wrapperWeakRef);
+      ManagedChannelReference.cleanQueue(refqueue);
+
+      synchronized (records) {
+        assertEquals("Warning was logged even though shutdownNow() was called!", 0, records.size());
+      }
+    } finally {
+      orphanLogger.setFilter(oldFilter);
+    }
+  }
+
+  @Test
   public void refCycleIsGCed() {
     ReferenceQueue<ManagedChannelOrphanWrapper> refqueue =
         new ReferenceQueue<>();

--- a/core/src/test/java/io/grpc/internal/ManagedChannelOrphanWrapperTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelOrphanWrapperTest.java
@@ -102,7 +102,7 @@ public final class ManagedChannelOrphanWrapperTest {
   }
 
   @Test
-  public void shutdownNow_withDelegateStillReferenced_doesNotLogWarning() {
+  public void shutdown_withDelegateStillReferenced_doesNotLogWarning() {
     ManagedChannel mc = new TestManagedChannel();
     final ReferenceQueue<ManagedChannelOrphanWrapper> refqueue = new ReferenceQueue<>();
     ConcurrentMap<ManagedChannelReference, ManagedChannelReference> refs =

--- a/core/src/test/java/io/grpc/internal/ManagedChannelOrphanWrapperTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelOrphanWrapperTest.java
@@ -148,6 +148,7 @@ public final class ManagedChannelOrphanWrapperTest {
         new ConcurrentHashMap<>();
     
     // Create the wrapper but NEVER call shutdown
+    @SuppressWarnings("UnusedVariable")
     ManagedChannelOrphanWrapper wrapper = new ManagedChannelOrphanWrapper(mc, refqueue, refs);
     wrapper = null; // Make it eligible for GC
 


### PR DESCRIPTION
Fixes #12641

This PR addresses a race condition where `ManagedChannelOrphanWrapper` could incorrectly log a "not shutdown properly" warning during garbage collection when using `directExecutor()`.

**Changes:**
* **Reference Management**: Moved `phantom.clearSafely()` to execute after the `super.shutdown()` calls.
* **Reachability Fence**: Added a reachability fence (`this.getClass()`) in `shutdown()` and `shutdownNow()` to ensure the wrapper remains alive until the methods return, preventing the JIT from marking it for early collection.
* **Verification Test**: Added a test case to verify that no orphan warnings are logged when a reference is held on the stack. *(Note: As this bug requires JIT warm-up to manifest, this test verifies standard execution behavior rather than acting as a strict regression test).*

**Testing:**
Verified with `./gradlew :grpc-core:test --tests ManagedChannelOrphanWrapperTest -PskipAndroid=true`.