### PR TITLE
core: Clarify missing content-type on HTTP error responses

### DIFF
--- a/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
+++ b/core/src/main/java/io/grpc/internal/Http2ClientStreamTransportState.java
@@ -223,8 +223,11 @@ public abstract class Http2ClientStreamTransportState extends AbstractClientStre
     }
     String contentType = headers.get(GrpcUtil.CONTENT_TYPE_KEY);
     if (!GrpcUtil.isGrpcContentType(contentType)) {
-      return GrpcUtil.httpStatusToGrpcStatus(httpStatus)
-          .augmentDescription("invalid content-type: " + contentType);
+      Status status = GrpcUtil.httpStatusToGrpcStatus(httpStatus);
+      if (contentType == null) {
+        return status.augmentDescription("missing content-type in response headers");
+      }
+      return status.augmentDescription("invalid content-type: " + contentType);
     }
     return null;
   }

--- a/core/src/test/java/io/grpc/internal/Http2ClientStreamTransportStateTest.java
+++ b/core/src/test/java/io/grpc/internal/Http2ClientStreamTransportStateTest.java
@@ -302,6 +302,24 @@ public class Http2ClientStreamTransportStateTest {
   }
 
   @Test
+  public void transportTrailersReceived_missingContentTypeUsesHttpStatus() {
+    BaseTransportState state = new BaseTransportState(transportTracer);
+    state.setListener(mockListener);
+    Metadata trailers = new Metadata();
+    trailers.put(testStatusMashaller, "431");
+
+    state.transportTrailersReceived(trailers);
+
+    verify(mockListener, never()).headersRead(any(Metadata.class));
+    verify(mockListener).closed(statusCaptor.capture(), same(PROCESSED), same(trailers));
+    assertEquals(Code.INTERNAL, statusCaptor.getValue().getCode());
+    assertTrue(statusCaptor.getValue().getDescription().contains("HTTP status code 431"));
+    assertTrue(
+        statusCaptor.getValue().getDescription().contains(
+            "missing content-type in response headers"));
+  }
+
+  @Test
   public void transportTrailersReceived_missingHttpStatus() {
     BaseTransportState state = new BaseTransportState(transportTracer);
     state.setListener(mockListener);


### PR DESCRIPTION
## Summary

In this case, grpc-java preserves the HTTP status-based context, but may later append `invalid content-type: null`.

That seems misleading when the response is missing `content-type`, because the header appears to be absent rather than invalid, and the `null` value exposes a Java implementation detail.

This PR keeps the existing HTTP-to-gRPC status mapping unchanged and only adjusts the diagnostic for the missing `content-type` case.

 ## Changes
 
- keep the existing HTTP-to-gRPC status mapping unchanged
- keep the existing behavior for invalid non-null content-types unchanged
- replace `invalid content-type: null` with `missing content-type in response headers`

Ref #12418
