### PR TITLE
servlet: Remove ModelCheckingCTest reference

### DIFF
--- a/servlet/src/threadingTest/java/io/grpc/servlet/AsyncServletOutputStreamWriterConcurrencyTest.java
+++ b/servlet/src/threadingTest/java/io/grpc/servlet/AsyncServletOutputStreamWriterConcurrencyTest.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
-import org.jetbrains.kotlinx.lincheck.strategy.managed.modelchecking.ModelCheckingCTest;
 import org.jetbrains.lincheck.datastructures.BooleanGen;
 import org.jetbrains.lincheck.datastructures.ModelCheckingOptions;
 import org.jetbrains.lincheck.datastructures.Operation;
@@ -49,7 +48,6 @@ import org.junit.runners.JUnit4;
  * test all possibly interleaves (on context switch) between the two threads, and then verify the
  * operations are linearizable in each interleave scenario.
  */
-@ModelCheckingCTest
 @Param(name = "keepReady", gen = BooleanGen.class)
 @RunWith(JUnit4.class)
 public class AsyncServletOutputStreamWriterConcurrencyTest {


### PR DESCRIPTION
In lincheck 3.4 this annotation is marked deprecated, and what to use as a replacement was thoroughly undocumented in the issue, the PR, the commit, the documentation, and the release notes. But it seems it has been unused since 8ac5599b9 when the test was converted to using ModelCheckingOptions.check().