### PR TITLE
examples: Reflow manualflowcontrol; check isReady() earlier

### DIFF
--- a/examples/src/main/java/io/grpc/examples/manualflowcontrol/README.md
+++ b/examples/src/main/java/io/grpc/examples/manualflowcontrol/README.md
@@ -25,7 +25,13 @@ value.
 
 ### Outgoing Flow Control
 
-The underlying layer (such as Netty) manages a buffer for outgoing messages. If you write messages faster than they can be sent over the network, this buffer will grow, which can eventually lead to an OutOfMemoryError. The outgoing onNext method invocation does not block when this happens. Therefore, you should explicitly check that the stream is ready for writing via `CallStreamObserver.isReady()` before calling onNext to avoid buffering excessive amounts of data in memory.
+The underlying layer (such as Netty) manages a buffer for outgoing messages. If
+you write messages faster than they can be sent over the network, this buffer
+will grow, which can eventually lead to an OutOfMemoryError. The outgoing onNext
+method invocation does not block when this happens. Therefore, you should
+explicitly check that the stream is ready for writing via
+`CallStreamObserver.isReady()` before generating messages to avoid buffering
+excessive amounts of data in memory.
 
 ### Incoming Manual Flow Control
 


### PR DESCRIPTION
This change is mostly to flow the paragraph across multiple lines like all other text in this file. But I did also replace checking for isReady() before calling onNext() with checking before creating messages. If you already have the message created, it doesn't change much to go ahead and enqueue it, but don't go create another message immediately.