### PR TITLE
core: fix MetricRecorderImpl#metricSinks ConcurrentModificationException

### DIFF
--- a/core/src/main/java/io/grpc/internal/MetricRecorderImpl.java
+++ b/core/src/main/java/io/grpc/internal/MetricRecorderImpl.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import io.grpc.CallbackMetricInstrument;
 import io.grpc.DoubleCounterMetricInstrument;
 import io.grpc.DoubleHistogramMetricInstrument;
@@ -49,7 +50,7 @@ final class MetricRecorderImpl implements MetricRecorder {
 
   @VisibleForTesting
   MetricRecorderImpl(List<MetricSink> metricSinks, MetricInstrumentRegistry registry) {
-    this.metricSinks = metricSinks;
+    this.metricSinks = ImmutableList.copyOf(metricSinks);
     this.registry = registry;
   }
 


### PR DESCRIPTION
```
java.util.ConcurrentModificationException
    at java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1013)
    at java.base/java.util.ArrayList$Itr.next(ArrayList.java:967)
    at io.grpc.internal.MetricRecorderImpl.addLongCounter(MetricRecorderImpl.java:95)
    at io.grpc.internal.SubchannelMetrics.recordConnectionAttemptSucceeded(SubchannelMetrics.java:82)
    at io.grpc.internal.InternalSubchannel$TransportListener$1.run(InternalSubchannel.java:605)
    at io.grpc.SynchronizationContext.drain(SynchronizationContext.java:96)
    at io.grpc.SynchronizationContext.execute(SynchronizationContext.java:128)
    at io.grpc.internal.InternalSubchannel$TransportListener.transportReady(InternalSubchannel.java:591)
    at io.grpc.netty.shaded.io.grpc.netty.ClientTransportLifecycleManager.notifyReady(ClientTransportLifecycleManager.java:51)
```

Fix #12727