### PR TITLE
Remove extraneous changes beyond avoiding the false positive warnings

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelOrphanWrapper.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelOrphanWrapper.java
@@ -73,13 +73,12 @@ final class ManagedChannelOrphanWrapper extends ForwardingManagedChannel {
 
   @Override
   public ManagedChannel shutdownNow() {
-    ManagedChannel result = super.shutdownNow();
     phantom.clearSafely();
     // This dummy check prevents the JIT from collecting 'this' too early
     if (this.getClass() == null) {
       throw new AssertionError();
     }
-    return result;
+    return super.shutdownNow();
   }
 
   @VisibleForTesting

--- a/core/src/main/java/io/grpc/internal/ManagedChannelOrphanWrapper.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelOrphanWrapper.java
@@ -62,13 +62,12 @@ final class ManagedChannelOrphanWrapper extends ForwardingManagedChannel {
 
   @Override
   public ManagedChannel shutdown() {
-    ManagedChannel result = super.shutdown();
     phantom.clearSafely();
     // This dummy check prevents the JIT from collecting 'this' too early
     if (this.getClass() == null) {
       throw new AssertionError();
     }
-    return result;
+    return super.shutdown();
   }
 
   @Override

--- a/core/src/main/java/io/grpc/internal/ManagedChannelOrphanWrapper.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelOrphanWrapper.java
@@ -72,13 +72,12 @@ final class ManagedChannelOrphanWrapper extends ForwardingManagedChannel {
 
   @Override
   public ManagedChannel shutdownNow() {
-    ManagedChannel result = super.shutdownNow();
     phantom.clearSafely();
     // This dummy check prevents the JIT from collecting 'this' too early
     if (this.getClass() == null) {
       throw new AssertionError();
     }
-    return result;
+    return super.shutdownNow();
   }
 
   @VisibleForTesting

--- a/core/src/main/java/io/grpc/internal/ManagedChannelOrphanWrapper.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelOrphanWrapper.java
@@ -73,12 +73,13 @@ final class ManagedChannelOrphanWrapper extends ForwardingManagedChannel {
 
   @Override
   public ManagedChannel shutdownNow() {
+    ManagedChannel result = super.shutdownNow();
     phantom.clearSafely();
     // This dummy check prevents the JIT from collecting 'this' too early
     if (this.getClass() == null) {
       throw new AssertionError();
     }
-    return super.shutdownNow();
+    return result;
   }
 
   @VisibleForTesting

--- a/core/src/test/java/io/grpc/internal/ManagedChannelOrphanWrapperTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelOrphanWrapperTest.java
@@ -141,31 +141,6 @@ public final class ManagedChannelOrphanWrapperTest {
   }
 
   @Test
-  public void orphanedChannel_triggerWarningAndCoverage() {
-    ManagedChannel mc = new TestManagedChannel();
-    final ReferenceQueue<ManagedChannelOrphanWrapper> refqueue = new ReferenceQueue<>();
-    ConcurrentMap<ManagedChannelReference, ManagedChannelReference> refs = 
-        new ConcurrentHashMap<>();
-    
-    // Create the wrapper but NEVER call shutdown
-    @SuppressWarnings("UnusedVariable")
-    ManagedChannelOrphanWrapper wrapper = new ManagedChannelOrphanWrapper(mc, refqueue, refs);
-    wrapper = null; // Make it eligible for GC
-
-    // Trigger GC and clean the queue to hit the !wasShutdown branch
-    final AtomicInteger numOrphans = new AtomicInteger();
-    GcFinalization.awaitDone(new FinalizationPredicate() {
-      @Override
-      public boolean isDone() {
-        numOrphans.getAndAdd(ManagedChannelReference.cleanQueue(refqueue));
-        return numOrphans.get() > 0;
-      }
-    });
-    
-    assertEquals(1, numOrphans.get());
-  }
-
-  @Test
   public void refCycleIsGCed() {
     ReferenceQueue<ManagedChannelOrphanWrapper> refqueue =
         new ReferenceQueue<>();


### PR DESCRIPTION
super.shutdown() is never expected to throw, so some of the changes were not required.
Also removing the redundant unit test.

Rework of PR #12705.