### PR TITLE
servlet: AsyncServletOutputStreamWriter detect and handle write when not ready

### DIFF
--- a/servlet/src/main/java/io/grpc/servlet/AsyncServletOutputStreamWriter.java
+++ b/servlet/src/main/java/io/grpc/servlet/AsyncServletOutputStreamWriter.java
@@ -217,7 +217,11 @@ final class AsyncServletOutputStreamWriter {
    */
   private void runOrBuffer(ActionItem actionItem) throws IOException {
     WriteState curState = writeState.get();
-    if (curState.readyAndDrained) { // write to the outputStream directly
+    
+    // Evaluate Tomcat's actual state alongside our cached state
+    boolean actualReady = curState.readyAndDrained && isReady.getAsBoolean();
+
+    if (actualReady) { // write to the outputStream directly
       actionItem.run();
       if (actionItem == completeAction) {
         return;
@@ -232,13 +236,21 @@ final class AsyncServletOutputStreamWriter {
     } else { // buffer to the writeChain
       writeChain.offer(actionItem);
       if (!writeState.compareAndSet(curState, curState.withReadyAndDrained(false))) {
-        checkState(
-            writeState.get().readyAndDrained,
-            "Bug: onWritePossible() should have changed readyAndDrained to true, but not");
-        ActionItem lastItem = writeChain.poll();
-        if (lastItem != null) {
-          checkState(lastItem == actionItem, "Bug: lastItem != actionItem");
-          runOrBuffer(lastItem);
+        // STATE CHANGED! Determine why the CAS failed based on our initial state.
+        if (curState.readyAndDrained) {
+          // We dropped here solely because isReady() was false.
+          // CAS failed because another concurrent thread already CAS'd it to false.
+          // This is completely safe. Tomcat will call onWritePossible(). Do nothing.
+        } else {
+          // Original logic: We started as false, CAS failed because onWritePossible set it to true.
+          checkState(
+              writeState.get().readyAndDrained,
+              "Bug: onWritePossible() should have changed readyAndDrained to true, but not");
+          ActionItem lastItem = writeChain.poll();
+          if (lastItem != null) {
+            checkState(lastItem == actionItem, "Bug: lastItem != actionItem");
+            runOrBuffer(lastItem);
+          }
         }
       } // state has not changed since
     }

--- a/servlet/src/main/java/io/grpc/servlet/AsyncServletOutputStreamWriter.java
+++ b/servlet/src/main/java/io/grpc/servlet/AsyncServletOutputStreamWriter.java
@@ -217,42 +217,54 @@ final class AsyncServletOutputStreamWriter {
    */
   private void runOrBuffer(ActionItem actionItem) throws IOException {
     WriteState curState = writeState.get();
-    
-    // Evaluate Tomcat's actual state alongside our cached state
-    boolean actualReady = curState.readyAndDrained && isReady.getAsBoolean();
 
-    if (actualReady) { // write to the outputStream directly
-      actionItem.run();
-      if (actionItem == completeAction) {
+    if (curState.readyAndDrained) {
+      if (isReady.getAsBoolean()) {
+        // Path 1: Container is truly ready. Write directly.
+        actionItem.run();
+        if (actionItem == completeAction) {
+          return;
+        }
+        if (!isReady.getAsBoolean()) {
+          boolean successful =
+              writeState.compareAndSet(curState, curState.withReadyAndDrained(false));
+          LockSupport.unpark(parkingThread);
+          checkState(successful, "Bug: curState is unexpectedly changed by another thread");
+          log.finest("the servlet output stream becomes not ready");
+        }
         return;
       }
-      if (!isReady.getAsBoolean()) {
-        boolean successful =
-            writeState.compareAndSet(curState, curState.withReadyAndDrained(false));
+    }
+
+    // Path 2: Container is secretly not ready (Tomcat bug) OR already known to be false.
+    // We must safely buffer the item and ensure the state reflects reality.
+    writeChain.offer(actionItem);
+    if (!writeState.compareAndSet(curState, curState.withReadyAndDrained(false))) {
+      // CAS failed. State changed mid-flight.
+      if (curState.readyAndDrained) {
+        // Started as true, but CAS failed because another thread 
+        // concurrently buffered and flipped it to false.
+        // Safe to do nothing. The winning thread handles the unpark.
+      } else {
+        // Started as false, CAS failed because onWritePossible flipped it to true.
+        // Original logic: retry the write since it's ready again.
+        checkState(
+            writeState.get().readyAndDrained,
+            "Bug: onWritePossible() should have changed readyAndDrained to true, but not");
+        ActionItem lastItem = writeChain.poll();
+        if (lastItem != null) {
+          checkState(lastItem == actionItem, "Bug: lastItem != actionItem");
+          runOrBuffer(lastItem);
+        }
+      }
+    } else {
+      // CAS succeeded! 
+      // CRITICAL FIX: If we just flipped the state from true to false,
+      //  we MUST wake up the container!
+      if (curState.readyAndDrained) {
         LockSupport.unpark(parkingThread);
-        checkState(successful, "Bug: curState is unexpectedly changed by another thread");
         log.finest("the servlet output stream becomes not ready");
       }
-    } else { // buffer to the writeChain
-      writeChain.offer(actionItem);
-      if (!writeState.compareAndSet(curState, curState.withReadyAndDrained(false))) {
-        // STATE CHANGED! Determine why the CAS failed based on our initial state.
-        if (curState.readyAndDrained) {
-          // We dropped here solely because isReady() was false.
-          // CAS failed because another concurrent thread already CAS'd it to false.
-          // This is completely safe. Tomcat will call onWritePossible(). Do nothing.
-        } else {
-          // Original logic: We started as false, CAS failed because onWritePossible set it to true.
-          checkState(
-              writeState.get().readyAndDrained,
-              "Bug: onWritePossible() should have changed readyAndDrained to true, but not");
-          ActionItem lastItem = writeChain.poll();
-          if (lastItem != null) {
-            checkState(lastItem == actionItem, "Bug: lastItem != actionItem");
-            runOrBuffer(lastItem);
-          }
-        }
-      } // state has not changed since
     }
   }
 

--- a/servlet/src/main/java/io/grpc/servlet/AsyncServletOutputStreamWriter.java
+++ b/servlet/src/main/java/io/grpc/servlet/AsyncServletOutputStreamWriter.java
@@ -226,7 +226,7 @@ final class AsyncServletOutputStreamWriter {
   private void runOrBuffer(ActionItem actionItem) throws IOException {
     WriteState curState = writeState.get();
 
-    // --- NEW: Tomcat Spontaneous State Change Mitigation ---
+    // Tomcat Spontaneous State Change Mitigation ---
     // If our cache says true, but the container is secretly not ready,
     // intercept the stale state and sync it before proceeding.
     if (curState.readyAndDrained && !isReady.getAsBoolean()) {
@@ -235,9 +235,7 @@ final class AsyncServletOutputStreamWriter {
       // direct write and falls into the buffer block
       curState = writeState.get(); 
     }
-    // -------------------------------------------------------
-
-    // The rest is the standard, original gRPC code!
+    // -------------------------------------------------------    
     if (curState.readyAndDrained) {
       actionItem.run();
       if (actionItem == completeAction) {

--- a/servlet/src/main/java/io/grpc/servlet/AsyncServletOutputStreamWriter.java
+++ b/servlet/src/main/java/io/grpc/servlet/AsyncServletOutputStreamWriter.java
@@ -35,7 +35,6 @@ import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nullable;
 import javax.servlet.AsyncContext;
 import javax.servlet.ServletOutputStream;
 
@@ -78,8 +77,6 @@ final class AsyncServletOutputStreamWriter {
   private final Queue<ActionItem> writeChain = new ConcurrentLinkedQueue<>();
   // for a theoretical race condition that onWritePossible() is called immediately after isReady()
   // returns false and before writeState.compareAndSet()
-  @Nullable
-  private volatile Thread parkingThread;
 
   AsyncServletOutputStreamWriter(
       AsyncContext asyncContext,
@@ -202,11 +199,9 @@ final class AsyncServletOutputStreamWriter {
     // readyAndDrained should have been set to false already.
     // Just in case due to a race condition readyAndDrained is still true at this moment and is
     // being set to false by runOrBuffer() concurrently.
-    parkingThread = Thread.currentThread();
     while (writeState.get().readyAndDrained) {
       LockSupport.parkNanos(TimeUnit.MINUTES.toNanos(1)); // should return immediately
     }
-    parkingThread = null;
   }
 
   /**
@@ -218,52 +213,41 @@ final class AsyncServletOutputStreamWriter {
   private void runOrBuffer(ActionItem actionItem) throws IOException {
     WriteState curState = writeState.get();
 
+    // --- NEW: Tomcat Spontaneous State Change Mitigation ---
+    // If our cache says true, but the container is secretly not ready,
+    // intercept the stale state and sync it before proceeding.
+    if (curState.readyAndDrained && !isReady.getAsBoolean()) {
+      boolean successful = writeState.compareAndSet(curState, curState.withReadyAndDrained(false));
+      checkState(successful, "Bug: curState is unexpectedly changed by another thread");
+      // Update local state so it gracefully bypasses the 
+      // direct write and falls into the buffer block
+      curState = writeState.get(); 
+    }
+    // -------------------------------------------------------
+
+    // The rest is the standard, original gRPC code!
     if (curState.readyAndDrained) {
-      if (isReady.getAsBoolean()) {
-        // Path 1: Container is truly ready. Write directly.
-        actionItem.run();
-        if (actionItem == completeAction) {
-          return;
-        }
-        if (!isReady.getAsBoolean()) {
-          boolean successful =
-              writeState.compareAndSet(curState, curState.withReadyAndDrained(false));
-          LockSupport.unpark(parkingThread);
-          checkState(successful, "Bug: curState is unexpectedly changed by another thread");
-          log.finest("the servlet output stream becomes not ready");
-        }
+      actionItem.run();
+      if (actionItem == completeAction) {
         return;
       }
+      if (!isReady.getAsBoolean()) {
+        boolean successful =
+            writeState.compareAndSet(curState, curState.withReadyAndDrained(false));
+        checkState(successful, "Bug: curState is unexpectedly changed by another thread");
+      }
+      return;
     }
 
-    // Path 2: Container is secretly not ready (Tomcat bug) OR already known to be false.
-    // We must safely buffer the item and ensure the state reflects reality.
     writeChain.offer(actionItem);
     if (!writeState.compareAndSet(curState, curState.withReadyAndDrained(false))) {
-      // CAS failed. State changed mid-flight.
-      if (curState.readyAndDrained) {
-        // Started as true, but CAS failed because another thread 
-        // concurrently buffered and flipped it to false.
-        // Safe to do nothing. The winning thread handles the unpark.
-      } else {
-        // Started as false, CAS failed because onWritePossible flipped it to true.
-        // Original logic: retry the write since it's ready again.
-        checkState(
-            writeState.get().readyAndDrained,
-            "Bug: onWritePossible() should have changed readyAndDrained to true, but not");
-        ActionItem lastItem = writeChain.poll();
-        if (lastItem != null) {
-          checkState(lastItem == actionItem, "Bug: lastItem != actionItem");
-          runOrBuffer(lastItem);
-        }
-      }
-    } else {
-      // CAS succeeded! 
-      // CRITICAL FIX: If we just flipped the state from true to false,
-      //  we MUST wake up the container!
-      if (curState.readyAndDrained) {
-        LockSupport.unpark(parkingThread);
-        log.finest("the servlet output stream becomes not ready");
+      checkState(
+          writeState.get().readyAndDrained,
+          "Bug: onWritePossible() should have changed readyAndDrained to true, but not");
+      ActionItem lastItem = writeChain.poll();
+      if (lastItem != null) {
+        checkState(lastItem == actionItem, "Bug: lastItem != actionItem");
+        runOrBuffer(lastItem);
       }
     }
   }

--- a/servlet/src/main/java/io/grpc/servlet/AsyncServletOutputStreamWriter.java
+++ b/servlet/src/main/java/io/grpc/servlet/AsyncServletOutputStreamWriter.java
@@ -35,6 +35,7 @@ import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 import javax.servlet.AsyncContext;
 import javax.servlet.ServletOutputStream;
 
@@ -77,6 +78,9 @@ final class AsyncServletOutputStreamWriter {
   private final Queue<ActionItem> writeChain = new ConcurrentLinkedQueue<>();
   // for a theoretical race condition that onWritePossible() is called immediately after isReady()
   // returns false and before writeState.compareAndSet()
+
+  @Nullable
+  private volatile Thread parkingThread;
 
   AsyncServletOutputStreamWriter(
       AsyncContext asyncContext,
@@ -199,9 +203,18 @@ final class AsyncServletOutputStreamWriter {
     // readyAndDrained should have been set to false already.
     // Just in case due to a race condition readyAndDrained is still true at this moment and is
     // being set to false by runOrBuffer() concurrently.
+    parkingThread = Thread.currentThread();
     while (writeState.get().readyAndDrained) {
       LockSupport.parkNanos(TimeUnit.MINUTES.toNanos(1)); // should return immediately
     }
+    parkingThread = null;
+  }
+
+  private void markNotReadyAndUnpark(WriteState curState) {
+    boolean successful = writeState.compareAndSet(curState, curState.withReadyAndDrained(false));
+    checkState(successful, "Bug: curState is unexpectedly changed by another thread");
+    LockSupport.unpark(parkingThread);
+    log.finest("the servlet output stream becomes not ready");
   }
 
   /**
@@ -217,8 +230,7 @@ final class AsyncServletOutputStreamWriter {
     // If our cache says true, but the container is secretly not ready,
     // intercept the stale state and sync it before proceeding.
     if (curState.readyAndDrained && !isReady.getAsBoolean()) {
-      boolean successful = writeState.compareAndSet(curState, curState.withReadyAndDrained(false));
-      checkState(successful, "Bug: curState is unexpectedly changed by another thread");
+      markNotReadyAndUnpark(curState);
       // Update local state so it gracefully bypasses the 
       // direct write and falls into the buffer block
       curState = writeState.get(); 
@@ -232,9 +244,7 @@ final class AsyncServletOutputStreamWriter {
         return;
       }
       if (!isReady.getAsBoolean()) {
-        boolean successful =
-            writeState.compareAndSet(curState, curState.withReadyAndDrained(false));
-        checkState(successful, "Bug: curState is unexpectedly changed by another thread");
+        markNotReadyAndUnpark(curState);
       }
       return;
     }


### PR DESCRIPTION
Fixes #12723 

### What was happening
In `AsyncServletOutputStreamWriter#runOrBuffer`, the application thread relies on the cached `readyAndDrained `state to determine if it can write directly to the `ServletOutputStream`.

In highly concurrent scenarios (observed in `TomcatTransportTest`), this cached state can become stale. The servlet container may have already transitioned to a 'not ready' state, but the corresponding callback has not yet updated gRPC's internal state. When the application thread attempts to write based on the stale `true `value, the container throws an `IllegalStateException`.

### The Fix
This PR updates the primary execution path in `runOrBuffer` to explicitly evaluate `isReady.getAsBoolean()` alongside the cached state. 

If the cached state is true but the container is actually not ready, the thread gracefully drops into the `else` block, buffers the action into the `writeChain`, and attempts to update `readyAndDrained` to `false`.

### Handling Concurrent CAS Failures
By forcing threads into the `else` block when `isReady()` evaluates to false, we introduce a safe race condition: multiple threads might try to execute `writeState.compareAndSet(true, false)` simultaneously. 

To prevent the losing threads from crashing on the subsequent `checkState`, an explicit check for the initial state (`if (curState.readyAndDrained)`) was added inside the CAS failure block. If a thread started as `true` but failed the CAS, it simply means another concurrent thread already safely toggled the state to `false`. The thread performs a safe no-op and exits, allowing Tomcat's `onWritePossible()` to eventually drain the queue.

Passed local testing via:
`./gradlew :grpc-servlet:tomcat9Test --tests "*TomcatTransportTest*" -PskipAndroid=true -PskipCodegen=true`