### PR TITLE
netty: Allow disabling server `keep-alive` enforcement via `permitKeepAliveTime`

### DIFF
--- a/core/src/main/java/io/grpc/internal/GrpcUtil.java
+++ b/core/src/main/java/io/grpc/internal/GrpcUtil.java
@@ -242,6 +242,16 @@ public final class GrpcUtil {
   public static final long DEFAULT_SERVER_KEEPALIVE_TIMEOUT_NANOS = TimeUnit.SECONDS.toNanos(20L);
 
   /**
+   * The default minimum time between client keepalive pings permitted by server.
+   */
+  public static final long DEFAULT_SERVER_PERMIT_KEEPALIVE_TIME_NANOS = TimeUnit.MINUTES.toNanos(5);
+
+  /**
+   * The magic permit keepalive time value that disables server keepalive enforcement.
+   */
+  public static final long SERVER_PERMIT_KEEPALIVE_TIME_NANOS_DISABLED = Long.MAX_VALUE;
+
+  /**
    * The magic keepalive time value that disables keepalive.
    */
   public static final long SERVER_KEEPALIVE_TIME_NANOS_DISABLED = Long.MAX_VALUE;

--- a/core/src/main/java/io/grpc/internal/KeepAliveEnforcer.java
+++ b/core/src/main/java/io/grpc/internal/KeepAliveEnforcer.java
@@ -46,7 +46,8 @@ public final class KeepAliveEnforcer {
     Preconditions.checkArgument(minTime >= 0, "minTime must be non-negative: %s", minTime);
 
     this.permitWithoutCalls = permitWithoutCalls;
-    this.minTimeNanos = Math.min(unit.toNanos(minTime), IMPLICIT_PERMIT_TIME_NANOS);
+    this.minTimeNanos = minTime == Long.MAX_VALUE ? Long.MAX_VALUE
+            : Math.min(unit.toNanos(minTime),IMPLICIT_PERMIT_TIME_NANOS);
     this.ticker = ticker;
     this.epoch = ticker.nanoTime();
     lastValidPingTime = epoch;
@@ -55,6 +56,9 @@ public final class KeepAliveEnforcer {
   /** Returns {@code false} when client is misbehaving and should be disconnected. */
   @CheckReturnValue
   public boolean pingAcceptable() {
+    if (minTimeNanos == Long.MAX_VALUE) {
+      return true;
+    }
     long now = ticker.nanoTime();
     boolean valid;
     if (!hasOutstandingCalls && !permitWithoutCalls) {

--- a/core/src/test/java/io/grpc/internal/KeepAliveEnforcerTest.java
+++ b/core/src/test/java/io/grpc/internal/KeepAliveEnforcerTest.java
@@ -166,6 +166,20 @@ public class KeepAliveEnforcerTest {
   }
 
   @Test
+  public void permitAllWhenDisabled() {
+    KeepAliveEnforcer enforcer = new KeepAliveEnforcer(
+        false, Long.MAX_VALUE, TimeUnit.NANOSECONDS, ticker);
+    enforcer.onTransportIdle();
+    for (int i = 0; i < LARGE_NUMBER; i++) {
+      assertThat(enforcer.pingAcceptable()).isTrue();
+    }
+    enforcer.onTransportActive();
+    for (int i = 0; i < LARGE_NUMBER; i++) {
+      assertThat(enforcer.pingAcceptable()).isTrue();
+    }
+  }
+
+  @Test
   public void resetCounters_resetsStrikes() {
     KeepAliveEnforcer enforcer = new KeepAliveEnforcer(false, 1, TimeUnit.NANOSECONDS, ticker);
     enforcer.onTransportActive();

--- a/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyServerBuilder.java
@@ -22,7 +22,9 @@ import static com.google.common.base.Preconditions.checkState;
 import static io.grpc.internal.GrpcUtil.DEFAULT_MAX_MESSAGE_SIZE;
 import static io.grpc.internal.GrpcUtil.DEFAULT_SERVER_KEEPALIVE_TIMEOUT_NANOS;
 import static io.grpc.internal.GrpcUtil.DEFAULT_SERVER_KEEPALIVE_TIME_NANOS;
+import static io.grpc.internal.GrpcUtil.DEFAULT_SERVER_PERMIT_KEEPALIVE_TIME_NANOS;
 import static io.grpc.internal.GrpcUtil.SERVER_KEEPALIVE_TIME_NANOS_DISABLED;
+import static io.grpc.internal.GrpcUtil.SERVER_PERMIT_KEEPALIVE_TIME_NANOS_DISABLED;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -113,7 +115,7 @@ public final class NettyServerBuilder extends ForwardingServerBuilder<NettyServe
   private long maxConnectionAgeInNanos = MAX_CONNECTION_AGE_NANOS_DISABLED;
   private long maxConnectionAgeGraceInNanos = MAX_CONNECTION_AGE_GRACE_NANOS_INFINITE;
   private boolean permitKeepAliveWithoutCalls;
-  private long permitKeepAliveTimeInNanos = TimeUnit.MINUTES.toNanos(5);
+  private long permitKeepAliveTimeInNanos = DEFAULT_SERVER_PERMIT_KEEPALIVE_TIME_NANOS;
   private int maxRstCount;
   private long maxRstPeriodNanos;
   private Attributes eagAttributes = Attributes.EMPTY;
@@ -656,6 +658,9 @@ public final class NettyServerBuilder extends ForwardingServerBuilder<NettyServe
     checkArgument(keepAliveTime >= 0, "permit keepalive time must be non-negative: %s",
         keepAliveTime);
     permitKeepAliveTimeInNanos = timeUnit.toNanos(keepAliveTime);
+    if (permitKeepAliveTimeInNanos >= AS_LARGE_AS_INFINITE) {
+      permitKeepAliveTimeInNanos = SERVER_PERMIT_KEEPALIVE_TIME_NANOS_DISABLED;
+    }
     return this;
   }
 


### PR DESCRIPTION
This change effectively makes the `permitKeepAliveTime` change consistent, similar to `keepAliveTime`. We can now disable this mechanism.

Currently, we can't do this, because even if we pass `Long.MAX_VALUE`, `KeepAliveEnforcer` will substitute its own value.
