### PR TITLE
Revert "Replace javax ThreadSafe annotation with errorprone ThreadSafe (#12742)

### DIFF
--- a/api/src/main/java/io/grpc/Channel.java
+++ b/api/src/main/java/io/grpc/Channel.java
@@ -16,7 +16,7 @@
 
 package io.grpc;
 
-import com.google.errorprone.annotations.ThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A virtual connection to a conceptual endpoint, to perform RPCs. A channel is free to have zero or

--- a/api/src/main/java/io/grpc/ChannelLogger.java
+++ b/api/src/main/java/io/grpc/ChannelLogger.java
@@ -16,7 +16,7 @@
 
 package io.grpc;
 
-import com.google.errorprone.annotations.ThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A Channel-specific logger provided by GRPC library to {@link LoadBalancer} implementations.

--- a/api/src/main/java/io/grpc/ClientInterceptor.java
+++ b/api/src/main/java/io/grpc/ClientInterceptor.java
@@ -16,7 +16,7 @@
 
 package io.grpc;
 
-import com.google.errorprone.annotations.ThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Interface for intercepting outgoing calls before they are dispatched by a {@link Channel}.

--- a/api/src/main/java/io/grpc/ClientStreamTracer.java
+++ b/api/src/main/java/io/grpc/ClientStreamTracer.java
@@ -19,7 +19,7 @@ package io.grpc;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
-import com.google.errorprone.annotations.ThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * {@link StreamTracer} for the client-side.

--- a/api/src/main/java/io/grpc/CompressorRegistry.java
+++ b/api/src/main/java/io/grpc/CompressorRegistry.java
@@ -19,10 +19,10 @@ package io.grpc;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.errorprone.annotations.ThreadSafe;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Encloses classes related to the compression and decompression of messages.

--- a/api/src/main/java/io/grpc/DecompressorRegistry.java
+++ b/api/src/main/java/io/grpc/DecompressorRegistry.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Joiner;
-import com.google.errorprone.annotations.ThreadSafe;
 import java.nio.charset.Charset;
 import java.util.Collections;
 import java.util.HashSet;
@@ -28,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Encloses classes related to the compression and decompression of messages.

--- a/api/src/main/java/io/grpc/HandlerRegistry.java
+++ b/api/src/main/java/io/grpc/HandlerRegistry.java
@@ -16,10 +16,10 @@
 
 package io.grpc;
 
-import com.google.errorprone.annotations.ThreadSafe;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Registry of services and their methods used by servers to dispatching incoming calls.

--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -22,7 +22,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
-import com.google.errorprone.annotations.ThreadSafe;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,6 +32,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A pluggable component that receives resolved addresses from {@link NameResolver} and provides the
@@ -64,7 +64,7 @@ import javax.annotation.concurrent.NotThreadSafe;
  * allows implementations to schedule tasks to be run in the same Synchronization Context, with or
  * without a delay, thus those tasks don't need to worry about synchronizing with the balancer
  * methods.
- *
+ * 
  * <p>However, the actual running thread may be the network thread, thus the following rules must be
  * followed to prevent blocking or even dead-locking in a network:
  *
@@ -417,7 +417,7 @@ public abstract class LoadBalancer {
    *
    * <p>This method should always return a constant value.  It's not specified when this will be
    * called.
-   *
+   * 
    * <p>Note that this method is only called when implementing {@code handleResolvedAddresses()}
    * instead of {@code acceptResolvedAddresses()}.
    *
@@ -640,7 +640,7 @@ public abstract class LoadBalancer {
      *                            stream is created at all in some cases.
      * @since 1.3.0
      */
-    // TODO(shivaspeaks): Need to deprecate old APIs and create new ones,
+    // TODO(shivaspeaks): Need to deprecate old APIs and create new ones, 
     // per https://github.com/grpc/grpc-java/issues/12662.
     public static PickResult withSubchannel(
         Subchannel subchannel, @Nullable ClientStreamTracer.Factory streamTracerFactory) {
@@ -1332,7 +1332,7 @@ public abstract class LoadBalancer {
   }
 
   /**
-   * A logical connection to a server, or a group of equivalent servers represented by an {@link
+   * A logical connection to a server, or a group of equivalent servers represented by an {@link 
    * EquivalentAddressGroup}.
    *
    * <p>It maintains at most one physical connection (aka transport) for sending new RPCs, while

--- a/api/src/main/java/io/grpc/LoadBalancerRegistry.java
+++ b/api/src/main/java/io/grpc/LoadBalancerRegistry.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.errorprone.annotations.ThreadSafe;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -31,6 +30,7 @@ import java.util.ServiceLoader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Registry of {@link LoadBalancerProvider}s.  The {@link #getDefaultRegistry default instance}

--- a/api/src/main/java/io/grpc/ManagedChannel.java
+++ b/api/src/main/java/io/grpc/ManagedChannel.java
@@ -16,8 +16,8 @@
 
 package io.grpc;
 
-import com.google.errorprone.annotations.ThreadSafe;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A {@link Channel} that provides lifecycle management.

--- a/api/src/main/java/io/grpc/ManagedChannelRegistry.java
+++ b/api/src/main/java/io/grpc/ManagedChannelRegistry.java
@@ -18,7 +18,6 @@ package io.grpc;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.errorprone.annotations.ThreadSafe;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.net.SocketAddress;
 import java.net.URI;
@@ -33,6 +32,7 @@ import java.util.List;
 import java.util.ServiceLoader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Registry of {@link ManagedChannelProvider}s. The {@link #getDefaultRegistry default instance}

--- a/api/src/main/java/io/grpc/NameResolver.java
+++ b/api/src/main/java/io/grpc/NameResolver.java
@@ -23,7 +23,6 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.base.Objects;
 import com.google.errorprone.annotations.InlineMe;
-import com.google.errorprone.annotations.ThreadSafe;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -36,6 +35,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A pluggable component that resolves a target {@link URI} and return addresses to the caller.
@@ -78,7 +78,7 @@ public abstract class NameResolver {
    * Starts the resolution. The method is not supposed to throw any exceptions. That might cause the
    * Channel that the name resolver is serving to crash. Errors should be propagated
    * through {@link Listener#onError}.
-   *
+   * 
    * <p>An instance may not be started more than once, by any overload of this method, even after
    * an intervening call to {@link #shutdown}.
    *
@@ -114,7 +114,7 @@ public abstract class NameResolver {
    * Starts the resolution. The method is not supposed to throw any exceptions. That might cause the
    * Channel that the name resolver is serving to crash. Errors should be propagated
    * through {@link Listener2#onError}.
-   *
+   * 
    * <p>An instance may not be started more than once, by any overload of this method, even after
    * an intervening call to {@link #shutdown}.
    *

--- a/api/src/main/java/io/grpc/NameResolverRegistry.java
+++ b/api/src/main/java/io/grpc/NameResolverRegistry.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
-import com.google.errorprone.annotations.ThreadSafe;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.net.URI;
 import java.util.ArrayList;
@@ -34,6 +33,7 @@ import java.util.ServiceLoader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Registry of {@link NameResolverProvider}s.  The {@link #getDefaultRegistry default instance}

--- a/api/src/main/java/io/grpc/Server.java
+++ b/api/src/main/java/io/grpc/Server.java
@@ -16,12 +16,12 @@
 
 package io.grpc;
 
-import com.google.errorprone.annotations.ThreadSafe;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Server for listening for and dispatching incoming calls. It is not expected to be implemented by

--- a/api/src/main/java/io/grpc/ServerCallHandler.java
+++ b/api/src/main/java/io/grpc/ServerCallHandler.java
@@ -16,7 +16,7 @@
 
 package io.grpc;
 
-import com.google.errorprone.annotations.ThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Interface to initiate processing of incoming remote calls. Advanced applications and generated

--- a/api/src/main/java/io/grpc/ServerInterceptor.java
+++ b/api/src/main/java/io/grpc/ServerInterceptor.java
@@ -16,7 +16,7 @@
 
 package io.grpc;
 
-import com.google.errorprone.annotations.ThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Interface for intercepting incoming calls before they are dispatched by

--- a/api/src/main/java/io/grpc/ServerRegistry.java
+++ b/api/src/main/java/io/grpc/ServerRegistry.java
@@ -18,7 +18,6 @@ package io.grpc;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.errorprone.annotations.ThreadSafe;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -28,6 +27,7 @@ import java.util.List;
 import java.util.ServiceLoader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Registry of {@link ServerProvider}s. The {@link #getDefaultRegistry default instance} loads

--- a/api/src/main/java/io/grpc/ServerStreamTracer.java
+++ b/api/src/main/java/io/grpc/ServerStreamTracer.java
@@ -16,8 +16,8 @@
 
 package io.grpc;
 
-import com.google.errorprone.annotations.ThreadSafe;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Listens to events on a stream to collect metrics.

--- a/api/src/main/java/io/grpc/StreamTracer.java
+++ b/api/src/main/java/io/grpc/StreamTracer.java
@@ -16,7 +16,7 @@
 
 package io.grpc;
 
-import com.google.errorprone.annotations.ThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Listens to events on a stream to collect metrics.

--- a/api/src/main/java/io/grpc/SynchronizationContext.java
+++ b/api/src/main/java/io/grpc/SynchronizationContext.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static io.grpc.TimeUtils.convertToNanos;
 
-import com.google.errorprone.annotations.ThreadSafe;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.time.Duration;
 import java.util.Queue;
@@ -30,6 +29,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A synchronization context is a queue of tasks that run in sequence.  It offers following

--- a/binder/src/main/java/io/grpc/binder/internal/BinderClientTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderClientTransport.java
@@ -32,7 +32,6 @@ import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.errorprone.annotations.CheckReturnValue;
-import com.google.errorprone.annotations.ThreadSafe;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
@@ -63,6 +62,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /** Concrete client-side transport implementation. */
 @ThreadSafe

--- a/binder/src/main/java/io/grpc/binder/internal/BinderServer.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderServer.java
@@ -25,7 +25,6 @@ import android.os.IBinder;
 import android.os.Parcel;
 import android.os.RemoteException;
 import com.google.common.collect.ImmutableList;
-import com.google.errorprone.annotations.ThreadSafe;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.grpc.Attributes;
 import io.grpc.Grpc;
@@ -50,6 +49,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A gRPC InternalServer which accepts connections via a host AndroidService.

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -30,7 +30,6 @@ import androidx.annotation.BinderThread;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Verify;
 import com.google.common.util.concurrent.ListenableFuture;
-import com.google.errorprone.annotations.ThreadSafe;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.grpc.Attributes;
 import io.grpc.Grpc;
@@ -55,6 +54,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Base class for binder-based gRPC transport.

--- a/binder/src/main/java/io/grpc/binder/internal/ServiceBinding.java
+++ b/binder/src/main/java/io/grpc/binder/internal/ServiceBinding.java
@@ -33,7 +33,6 @@ import android.os.UserHandle;
 import androidx.annotation.AnyThread;
 import androidx.annotation.MainThread;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.errorprone.annotations.ThreadSafe;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.grpc.Status;
 import io.grpc.StatusException;
@@ -42,6 +41,7 @@ import java.util.concurrent.Executor;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Manages an Android binding that's restricted to at most one connection to the remote Service.

--- a/core/src/main/java/io/grpc/internal/AtomicBackoff.java
+++ b/core/src/main/java/io/grpc/internal/AtomicBackoff.java
@@ -17,10 +17,10 @@
 package io.grpc.internal;
 
 import com.google.common.base.Preconditions;
-import com.google.errorprone.annotations.ThreadSafe;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A {@code long} atomically updated due to errors caused by the value being too small.

--- a/core/src/main/java/io/grpc/internal/ClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ClientTransport.java
@@ -16,7 +16,6 @@
 
 package io.grpc.internal;
 
-import com.google.errorprone.annotations.ThreadSafe;
 import io.grpc.CallOptions;
 import io.grpc.ClientStreamTracer;
 import io.grpc.InternalChannelz.SocketStats;
@@ -25,6 +24,7 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import java.util.concurrent.Executor;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * The client-side transport typically encapsulating a single connection to a remote

--- a/core/src/main/java/io/grpc/internal/ConnectionClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ConnectionClientTransport.java
@@ -16,8 +16,8 @@
 
 package io.grpc.internal;
 
-import com.google.errorprone.annotations.ThreadSafe;
 import io.grpc.Attributes;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A {@link ManagedClientTransport} that is based on a connection.

--- a/core/src/main/java/io/grpc/internal/InternalServer.java
+++ b/core/src/main/java/io/grpc/internal/InternalServer.java
@@ -16,13 +16,13 @@
 
 package io.grpc.internal;
 
-import com.google.errorprone.annotations.ThreadSafe;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalInstrumented;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.util.List;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * An object that accepts new incoming connections on one or more listening socket addresses.

--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -30,7 +30,6 @@ import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.errorprone.annotations.ForOverride;
-import com.google.errorprone.annotations.ThreadSafe;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
 import io.grpc.ChannelLogger;
@@ -63,6 +62,7 @@ import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Transports for a single {@link SocketAddress}.

--- a/core/src/main/java/io/grpc/internal/KeepAliveManager.java
+++ b/core/src/main/java/io/grpc/internal/KeepAliveManager.java
@@ -22,12 +22,12 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import com.google.common.util.concurrent.MoreExecutors;
-import com.google.errorprone.annotations.ThreadSafe;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.grpc.Status;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Manages keepalive pings.
@@ -308,3 +308,4 @@ public class KeepAliveManager {
     }
   }
 }
+

--- a/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImpl.java
@@ -32,7 +32,6 @@ import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
-import com.google.errorprone.annotations.ThreadSafe;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.grpc.Attributes;
 import io.grpc.CallCredentials;
@@ -119,6 +118,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /** A communication channel for making outgoing RPCs. */
 @ThreadSafe
@@ -695,7 +695,7 @@ final class ManagedChannelImpl extends ManagedChannel implements
   InternalConfigSelector getConfigSelector() {
     return realChannel.configSelector.get();
   }
-
+  
   @VisibleForTesting
   boolean hasThrottle() {
     return this.transportProvider.throttle != null;

--- a/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
+++ b/core/src/main/java/io/grpc/internal/ManagedClientTransport.java
@@ -17,10 +17,10 @@
 package io.grpc.internal;
 
 import com.google.errorprone.annotations.CheckReturnValue;
-import com.google.errorprone.annotations.ThreadSafe;
 import io.grpc.Attributes;
 import io.grpc.Status;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A {@link ClientTransport} that has life-cycle management.

--- a/core/src/main/java/io/grpc/internal/ObjectPool.java
+++ b/core/src/main/java/io/grpc/internal/ObjectPool.java
@@ -16,7 +16,7 @@
 
 package io.grpc.internal;
 
-import com.google.errorprone.annotations.ThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * An object pool.

--- a/core/src/main/java/io/grpc/internal/SharedResourceHolder.java
+++ b/core/src/main/java/io/grpc/internal/SharedResourceHolder.java
@@ -17,12 +17,12 @@
 package io.grpc.internal;
 
 import com.google.common.base.Preconditions;
-import com.google.errorprone.annotations.ThreadSafe;
 import java.util.IdentityHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A holder for shared resource singletons.

--- a/core/src/main/java/io/grpc/internal/StatsTraceContext.java
+++ b/core/src/main/java/io/grpc/internal/StatsTraceContext.java
@@ -19,7 +19,6 @@ package io.grpc.internal;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.errorprone.annotations.ThreadSafe;
 import io.grpc.Attributes;
 import io.grpc.ClientStreamTracer;
 import io.grpc.Context;
@@ -32,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * The stats and tracing information for a stream.

--- a/core/src/main/java/io/grpc/internal/TransportProvider.java
+++ b/core/src/main/java/io/grpc/internal/TransportProvider.java
@@ -16,8 +16,8 @@
 
 package io.grpc.internal;
 
-import com.google.errorprone.annotations.ThreadSafe;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Provides transports for sending RPCs.

--- a/gcp-observability/src/main/java/io/grpc/gcp/observability/ObservabilityConfig.java
+++ b/gcp-observability/src/main/java/io/grpc/gcp/observability/ObservabilityConfig.java
@@ -16,12 +16,12 @@
 
 package io.grpc.gcp.observability;
 
-import com.google.errorprone.annotations.ThreadSafe;
 import io.grpc.Internal;
 import io.opencensus.trace.Sampler;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.concurrent.ThreadSafe;
 
 @Internal
 public interface ObservabilityConfig {

--- a/grpclb/src/main/java/io/grpc/grpclb/GrpclbClientLoadRecorder.java
+++ b/grpclb/src/main/java/io/grpc/grpclb/GrpclbClientLoadRecorder.java
@@ -18,7 +18,6 @@ package io.grpc.grpclb;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.errorprone.annotations.ThreadSafe;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import com.google.protobuf.util.Timestamps;
 import io.grpc.ClientStreamTracer;
@@ -31,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Record and aggregate client-side load data for GRPCLB.  This records load occurred during the

--- a/inprocess/src/main/java/io/grpc/inprocess/InProcessServer.java
+++ b/inprocess/src/main/java/io/grpc/inprocess/InProcessServer.java
@@ -19,7 +19,6 @@ package io.grpc.inprocess;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.MoreObjects;
-import com.google.errorprone.annotations.ThreadSafe;
 import io.grpc.InternalChannelz.SocketStats;
 import io.grpc.InternalInstrumented;
 import io.grpc.ServerStreamTracer;
@@ -34,6 +33,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ScheduledExecutorService;
+import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
 final class InProcessServer implements InternalServer {

--- a/inprocess/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/inprocess/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -24,7 +24,6 @@ import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.errorprone.annotations.CheckReturnValue;
-import com.google.errorprone.annotations.ThreadSafe;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
@@ -78,6 +77,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe
 final class InProcessTransport implements ServerTransport, ConnectionClientTransport {

--- a/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
+++ b/interop-testing/src/main/java/io/grpc/testing/integration/XdsTestClient.java
@@ -27,7 +27,6 @@ import com.google.common.util.concurrent.ListenableScheduledFuture;
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
-import com.google.errorprone.annotations.ThreadSafe;
 import com.google.protobuf.ByteString;
 import io.grpc.BindableService;
 import io.grpc.CallOptions;
@@ -78,6 +77,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 /** Client for xDS interop tests. */

--- a/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
+++ b/rls/src/main/java/io/grpc/rls/CachingRlsLbClient.java
@@ -29,7 +29,6 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.SettableFuture;
 import com.google.errorprone.annotations.CheckReturnValue;
-import com.google.errorprone.annotations.ThreadSafe;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.grpc.ChannelLogger;
 import io.grpc.ChannelLogger.ChannelLogLevel;
@@ -78,6 +77,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A CachingRlsLbClient is a core implementation of RLS loadbalancer supports dynamic request

--- a/rls/src/main/java/io/grpc/rls/Throttler.java
+++ b/rls/src/main/java/io/grpc/rls/Throttler.java
@@ -16,7 +16,7 @@
 
 package io.grpc.rls;
 
-import com.google.errorprone.annotations.ThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A strategy for deciding when to throttle requests at the client.

--- a/s2a/BUILD.bazel
+++ b/s2a/BUILD.bazel
@@ -11,6 +11,7 @@ java_library(
         "//core",
         "//core:internal",
         "//netty",
+        artifact("com.google.code.findbugs:jsr305"),
         artifact("com.google.errorprone:error_prone_annotations"),
         artifact("com.google.guava:guava"),
         artifact("org.checkerframework:checker-qual"),
@@ -36,7 +37,7 @@ java_library(
     ]),
     deps = [
         ":s2a_identity",
-        artifact("com.google.errorprone:error_prone_annotations"),
+        artifact("com.google.code.findbugs:jsr305"),
         artifact("com.google.guava:guava"),
     ],
 )

--- a/s2a/src/main/java/io/grpc/s2a/internal/channel/S2AHandshakerServiceChannel.java
+++ b/s2a/src/main/java/io/grpc/s2a/internal/channel/S2AHandshakerServiceChannel.java
@@ -19,12 +19,12 @@ package io.grpc.s2a.internal.channel;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
-import com.google.errorprone.annotations.ThreadSafe;
 import io.grpc.Channel;
 import io.grpc.ChannelCredentials;
 import io.grpc.ManagedChannel;
 import io.grpc.internal.SharedResourceHolder.Resource;
 import io.grpc.netty.NettyChannelBuilder;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Provides APIs for managing gRPC channels to an S2A server. Each channel is local and plaintext.

--- a/s2a/src/main/java/io/grpc/s2a/internal/handshaker/tokenmanager/AccessTokenManager.java
+++ b/s2a/src/main/java/io/grpc/s2a/internal/handshaker/tokenmanager/AccessTokenManager.java
@@ -16,9 +16,9 @@
 
 package io.grpc.s2a.internal.handshaker.tokenmanager;
 
-import com.google.errorprone.annotations.ThreadSafe;
 import io.grpc.s2a.internal.handshaker.S2AIdentity;
 import java.util.Optional;
+import javax.annotation.concurrent.ThreadSafe;
 
 /** Manages access tokens for authenticating to the S2A. */
 @ThreadSafe

--- a/services/BUILD.bazel
+++ b/services/BUILD.bazel
@@ -29,7 +29,7 @@ java_library(
     deps = [
         ":channelz",
         "//api",
-        artifact("com.google.errorprone:error_prone_annotations"),
+        artifact("com.google.code.findbugs:jsr305"),
     ],
 )
 
@@ -44,6 +44,7 @@ java_library(
     deps = [
         "//api",
         "//context",
+        artifact("com.google.code.findbugs:jsr305"),
         artifact("com.google.errorprone:error_prone_annotations"),
         artifact("com.google.guava:guava"),
     ],
@@ -81,7 +82,6 @@ java_library(
         "@com_google_protobuf//:protobuf_java_util",
         "@io_grpc_grpc_proto//:binarylog_java_proto",
         artifact("com.google.code.findbugs:jsr305"),
-        artifact("com.google.errorprone:error_prone_annotations"),
         artifact("com.google.guava:guava"),
     ],
 )
@@ -100,6 +100,7 @@ java_library(
         "@com_google_protobuf//:protobuf_java",
         "@com_google_protobuf//:protobuf_java_util",
         "@io_grpc_grpc_proto//:channelz_java_proto",
+        artifact("com.google.code.findbugs:jsr305"),
         artifact("com.google.guava:guava"),
     ],
 )

--- a/services/src/main/java/io/grpc/protobuf/services/BinlogHelper.java
+++ b/services/src/main/java/io/grpc/protobuf/services/BinlogHelper.java
@@ -24,7 +24,6 @@ import static io.grpc.protobuf.services.BinaryLogProvider.BYTEARRAY_MARSHALLER;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
-import com.google.errorprone.annotations.ThreadSafe;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Duration;
 import com.google.protobuf.util.Durations;
@@ -70,6 +69,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A binary log class that is configured for a specific {@link MethodDescriptor}.

--- a/services/src/main/java/io/grpc/services/AdminInterface.java
+++ b/services/src/main/java/io/grpc/services/AdminInterface.java
@@ -16,7 +16,6 @@
 
 package io.grpc.services;
 
-import com.google.errorprone.annotations.ThreadSafe;
 import io.grpc.BindableService;
 import io.grpc.ExperimentalApi;
 import io.grpc.ServerServiceDefinition;
@@ -28,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Admin Interface provides a class of services for exposing the overall state of gRPC

--- a/services/src/main/java/io/grpc/services/CallMetricRecorder.java
+++ b/services/src/main/java/io/grpc/services/CallMetricRecorder.java
@@ -18,13 +18,13 @@ package io.grpc.services;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.errorprone.annotations.InlineMe;
-import com.google.errorprone.annotations.ThreadSafe;
 import io.grpc.Context;
 import io.grpc.ExperimentalApi;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Utility to record call metrics for load-balancing. One instance per call.

--- a/stub/src/main/java/io/grpc/stub/AbstractAsyncStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractAsyncStub.java
@@ -17,10 +17,10 @@
 package io.grpc.stub;
 
 import com.google.errorprone.annotations.CheckReturnValue;
-import com.google.errorprone.annotations.ThreadSafe;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.stub.ClientCalls.StubType;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Stub implementations for async stubs.

--- a/stub/src/main/java/io/grpc/stub/AbstractBlockingStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractBlockingStub.java
@@ -17,10 +17,10 @@
 package io.grpc.stub;
 
 import com.google.errorprone.annotations.CheckReturnValue;
-import com.google.errorprone.annotations.ThreadSafe;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.stub.ClientCalls.StubType;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Stub implementations for blocking stubs.

--- a/stub/src/main/java/io/grpc/stub/AbstractFutureStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractFutureStub.java
@@ -17,10 +17,10 @@
 package io.grpc.stub;
 
 import com.google.errorprone.annotations.CheckReturnValue;
-import com.google.errorprone.annotations.ThreadSafe;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import io.grpc.stub.ClientCalls.StubType;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Stub implementations for future stubs.

--- a/stub/src/main/java/io/grpc/stub/AbstractStub.java
+++ b/stub/src/main/java/io/grpc/stub/AbstractStub.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static io.grpc.InternalTimeUtils.convert;
 
 import com.google.errorprone.annotations.CheckReturnValue;
-import com.google.errorprone.annotations.ThreadSafe;
 import io.grpc.CallCredentials;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -33,6 +32,7 @@ import java.time.Duration;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 /**

--- a/util/src/main/java/io/grpc/util/MutableHandlerRegistry.java
+++ b/util/src/main/java/io/grpc/util/MutableHandlerRegistry.java
@@ -16,7 +16,6 @@
 
 package io.grpc.util;
 
-import com.google.errorprone.annotations.ThreadSafe;
 import io.grpc.BindableService;
 import io.grpc.ExperimentalApi;
 import io.grpc.HandlerRegistry;
@@ -29,6 +28,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Default implementation of {@link HandlerRegistry}.

--- a/xds/src/main/java/io/grpc/xds/SharedCallCounterMap.java
+++ b/xds/src/main/java/io/grpc/xds/SharedCallCounterMap.java
@@ -19,7 +19,6 @@ package io.grpc.xds;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.errorprone.annotations.ThreadSafe;
 import io.grpc.xds.XdsNameResolverProvider.CallCounterProvider;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
@@ -27,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * The global map for holding circuit breaker atomic counters.

--- a/xds/src/main/java/io/grpc/xds/SharedXdsClientPoolProvider.java
+++ b/xds/src/main/java/io/grpc/xds/SharedXdsClientPoolProvider.java
@@ -20,7 +20,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.errorprone.annotations.ThreadSafe;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.grpc.CallCredentials;
 import io.grpc.MetricRecorder;
@@ -41,6 +40,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * The global factory for creating a singleton {@link XdsClient} instance to be used by all gRPC

--- a/xds/src/main/java/io/grpc/xds/ThreadSafeRandom.java
+++ b/xds/src/main/java/io/grpc/xds/ThreadSafeRandom.java
@@ -16,8 +16,8 @@
 
 package io.grpc.xds;
 
-import com.google.errorprone.annotations.ThreadSafe;
 import java.util.concurrent.ThreadLocalRandom;
+import javax.annotation.concurrent.ThreadSafe;
 
 @ThreadSafe // Except for impls/mocks in tests
 interface ThreadSafeRandom {

--- a/xds/src/main/java/io/grpc/xds/XdsCredentialsRegistry.java
+++ b/xds/src/main/java/io/grpc/xds/XdsCredentialsRegistry.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
-import com.google.errorprone.annotations.ThreadSafe;
 import com.google.errorprone.annotations.concurrent.GuardedBy;
 import io.grpc.InternalServiceProviders;
 import java.util.ArrayList;
@@ -34,6 +33,7 @@ import java.util.ServiceLoader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Registry of {@link XdsCredentialsProvider}s. The {@link #getDefaultRegistry default
@@ -133,7 +133,7 @@ final class XdsCredentialsRegistry {
 
   /**
    * Returns effective providers map from scheme to the highest priority
-   * XdsCredsProvider of that scheme.
+   * XdsCredsProvider of that scheme. 
    */
   @VisibleForTesting
   synchronized Map<String, XdsCredentialsProvider> providers() {
@@ -142,7 +142,7 @@ final class XdsCredentialsRegistry {
 
   /**
    * Returns the effective provider for the given xds credential name, or {@code null} if no
-   * suitable provider can be found.
+   * suitable provider can be found. 
    * Each provider declares its name via {@link XdsCredentialsProvider#getName}.
    */
   @Nullable
@@ -157,7 +157,7 @@ final class XdsCredentialsRegistry {
     // https://sourceforge.net/p/proguard/bugs/418/
     ArrayList<Class<?>> list = new ArrayList<>();
     try {
-      list.add(Class.forName("io.grpc.xds.internal.GoogleDefaultXdsCredentialsProvider"));
+      list.add(Class.forName("io.grpc.xds.internal.GoogleDefaultXdsCredentialsProvider")); 
     } catch (ClassNotFoundException e) {
       logger.log(Level.WARNING, "Unable to find GoogleDefaultXdsCredentialsProvider", e);
     }
@@ -173,7 +173,7 @@ final class XdsCredentialsRegistry {
     } catch (ClassNotFoundException e) {
       logger.log(Level.WARNING, "Unable to find TlsXdsCredentialsProvider", e);
     }
-
+      
     return Collections.unmodifiableList(list);
   }
 

--- a/xds/src/main/java/io/grpc/xds/client/LoadStatsManager2.java
+++ b/xds/src/main/java/io/grpc/xds/client/LoadStatsManager2.java
@@ -23,7 +23,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Supplier;
 import com.google.common.collect.Sets;
-import com.google.errorprone.annotations.ThreadSafe;
 import io.grpc.Internal;
 import io.grpc.Status;
 import io.grpc.internal.GrpcUtil;
@@ -43,6 +42,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Manages client side traffic stats. Drop stats are maintained in cluster (with edsServiceName)

--- a/xds/src/main/java/io/grpc/xds/internal/security/ReferenceCountingMap.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/ReferenceCountingMap.java
@@ -21,9 +21,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.errorprone.annotations.CheckReturnValue;
-import com.google.errorprone.annotations.ThreadSafe;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * A map for managing reference-counted shared resources - typically providers.

--- a/xds/src/main/java/io/grpc/xds/internal/security/certprovider/CertificateProviderRegistry.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/certprovider/CertificateProviderRegistry.java
@@ -19,9 +19,9 @@ package io.grpc.xds.internal.security.certprovider;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.errorprone.annotations.ThreadSafe;
 import java.util.LinkedHashMap;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /** Maintains {@link CertificateProvider}s for all registered plugins. */
 @ThreadSafe

--- a/xds/src/main/java/io/grpc/xds/internal/security/certprovider/CertificateProviderStore.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/certprovider/CertificateProviderStore.java
@@ -17,13 +17,13 @@
 package io.grpc.xds.internal.security.certprovider;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.errorprone.annotations.ThreadSafe;
 import io.grpc.xds.internal.security.ReferenceCountingMap;
 import io.grpc.xds.internal.security.certprovider.CertificateProvider.Watcher;
 import java.io.Closeable;
 import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Global map of all ref-counted {@link CertificateProvider}s that have been instantiated in


### PR DESCRIPTION
This reverts commit ef3531325ba98fa043f6f7f16fa0715e9296d7a3 because it breaks Google internal build. Error Prone adds a lot of restrictions, which we may or may not want. We'd need to look at each case and decide what to do.
cc @Kainsin 

Internal reference: http://fusion2/ca3b6f0a-4e9d-469e-bcc4-f32a8bfa8104