### PR TITLE
okhttp: enable TLS 1.3 for servers on Android

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -208,7 +208,7 @@ public final class OkHttpChannelBuilder extends ForwardingChannelBuilder2<OkHttp
    */
   private final boolean useGetForSafeMethods = false;
 
-  private static ConnectionSpec initialConnectionSpec() {
+  static ConnectionSpec initialConnectionSpec() {
     return (OkHttpProtocolNegotiator.get() instanceof OkHttpProtocolNegotiator.AndroidNegotiator)
         ? INTERNAL_DEFAULT_CONNECTION_SPEC
         : INTERNAL_LEGACY_CONNECTION_SPEC;

--- a/okhttp/src/main/java/io/grpc/okhttp/SslSocketFactoryServerCredentials.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/SslSocketFactoryServerCredentials.java
@@ -41,7 +41,7 @@ public final class SslSocketFactoryServerCredentials {
     private final ConnectionSpec connectionSpec;
 
     ServerCredentials(SSLSocketFactory factory) {
-      this(factory, OkHttpChannelBuilder.INTERNAL_LEGACY_CONNECTION_SPEC);
+      this(factory, OkHttpChannelBuilder.initialConnectionSpec());
     }
 
     ServerCredentials(SSLSocketFactory factory, ConnectionSpec connectionSpec) {


### PR DESCRIPTION
f43013161 enabled TLS 1.3 for okhttp clients on Android.

CC @bengtsson1-flir