### PR TITLE
compiler: Avoid compile error on weird proto file names

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -47,6 +47,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
 ]
 # GRPC_DEPS_END
 
+bazel_dep(name = "abseil-cpp", version = "20250512.1")
 bazel_dep(name = "bazel_jar_jar", version = "0.1.11.bcr.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "googleapis", version = "0.0.0-20240326-1c8d509c5", repo_name = "com_google_googleapis")

--- a/compiler/BUILD.bazel
+++ b/compiler/BUILD.bazel
@@ -13,6 +13,7 @@ cc_binary(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "@abseil-cpp//absl/strings",
         "@com_google_protobuf//:protoc_lib",
     ],
 )

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -46,7 +46,7 @@
 #include <map>
 #include <set>
 #include <vector>
-#include <absl/strings/escaping.h>
+#include "absl/strings/escaping.h"
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/descriptor.pb.h>
 #include <google/protobuf/io/printer.h>

--- a/compiler/src/java_plugin/cpp/java_generator.cpp
+++ b/compiler/src/java_plugin/cpp/java_generator.cpp
@@ -46,6 +46,7 @@
 #include <map>
 #include <set>
 #include <vector>
+#include <absl/strings/escaping.h>
 #include <google/protobuf/descriptor.h>
 #include <google/protobuf/descriptor.pb.h>
 #include <google/protobuf/io/printer.h>
@@ -1206,7 +1207,7 @@ static void PrintService(const ServiceDescriptor* service,
                          bool disable_version,
                          GeneratedAnnotation generated_annotation) {
   (*vars)["service_name"] = service->name();
-  (*vars)["file_name"] = service->file()->name();
+  (*vars)["file_name"] = absl::Utf8SafeCEscape(service->file()->name());
   (*vars)["service_class_name"] = ServiceClassName(service);
   (*vars)["grpc_version"] = "";
   #ifdef GRPC_VERSION


### PR DESCRIPTION
This only matters when `@generated=javax` is used, so it shouldn't matter much.

It isn't guaranteed that javac will interpret the file as UTF-8, but it is exceedingly common, and it doesn't seem too much to ask if you are using weird file names.