### PR TITLE
xds: add missing `@RunWith` Annotation

### DIFF
--- a/xds/src/test/java/io/grpc/xds/internal/headermutations/HeaderMutationsTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/headermutations/HeaderMutationsTest.java
@@ -22,7 +22,10 @@ import com.google.common.collect.ImmutableList;
 import io.grpc.xds.internal.grpcservice.HeaderValue;
 import io.grpc.xds.internal.headermutations.HeaderValueOption.HeaderAppendAction;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class HeaderMutationsTest {
   @Test
   public void testCreate() {


### PR DESCRIPTION
Test class may not be run because it is missing a `@RunWith` annotation.