### PR TITLE
core: throw IOException when ProxySelector returns null or empty list

### DIFF
--- a/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
+++ b/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
@@ -207,6 +207,14 @@ class ProxyDetectorImpl implements ProxyDetector {
     }
 
     List<Proxy> proxies = proxySelector.select(uri);
+    // ProxySelector.select(URI) is contractually required to return a non-null, non-empty list.
+    // Surface the offending implementation's class name so a broken ProxySelector can be fixed.
+    if (proxies == null || proxies.isEmpty()) {
+      throw new IOException(
+          "ProxySelector " + proxySelector.getClass().getName()
+              + " returned " + (proxies == null ? "null" : "an empty list")
+              + ", which violates the java.net.ProxySelector#select(URI) contract");
+    }
     if (proxies.size() > 1) {
       log.warning("More than 1 proxy detected, gRPC will select the first one");
     }

--- a/core/src/test/java/io/grpc/internal/ProxyDetectorImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ProxyDetectorImplTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -33,6 +34,7 @@ import com.google.common.collect.ImmutableList;
 import io.grpc.HttpConnectProxiedSocketAddress;
 import io.grpc.ProxiedSocketAddress;
 import io.grpc.ProxyDetector;
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.PasswordAuthentication;
@@ -40,6 +42,7 @@ import java.net.Proxy;
 import java.net.ProxySelector;
 import java.net.SocketAddress;
 import java.net.URI;
+import java.util.Collections;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -190,5 +193,25 @@ public class ProxyDetectorImplTest {
         },
         authenticator);
     assertNull(proxyDetector.proxyFor(destination));
+  }
+
+  @Test
+  public void throwsWhenProxySelectorReturnsEmptyList() throws Exception {
+    when(proxySelector.select(any(URI.class))).thenReturn(Collections.<Proxy>emptyList());
+
+    IOException e =
+        assertThrows(IOException.class, () -> proxyDetector.proxyFor(destination));
+    assertTrue(e.getMessage(), e.getMessage().contains("empty list"));
+    assertTrue(e.getMessage(), e.getMessage().contains(proxySelector.getClass().getName()));
+  }
+
+  @Test
+  public void throwsWhenProxySelectorReturnsNullList() throws Exception {
+    when(proxySelector.select(any(URI.class))).thenReturn(null);
+
+    IOException e =
+        assertThrows(IOException.class, () -> proxyDetector.proxyFor(destination));
+    assertTrue(e.getMessage(), e.getMessage().contains("null"));
+    assertTrue(e.getMessage(), e.getMessage().contains(proxySelector.getClass().getName()));
   }
 }


### PR DESCRIPTION
ProxySelector.select(URI) is contractually required to return a non-null,
non-empty list. Some implementations violate this, which previously caused
an opaque crash in ProxyDetectorImpl:

```
java.lang.IndexOutOfBoundsException: Index: 0
    at java.util.Collections$EmptyList.get
    at io.grpc.internal.ProxyDetectorImpl.detectProxy
```

Detect this case explicitly and throw an IOException naming the offending
ProxySelector class, so a broken implementation can be identified and
fixed by its author rather than silently worked around in every caller.