### PR TITLE
build: Bump Ubuntu image to use for the build

### DIFF
--- a/buildscripts/grpc-java-artifacts/Dockerfile.multiarch.base
+++ b/buildscripts/grpc-java-artifacts/Dockerfile.multiarch.base
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:24.04
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \


### PR DESCRIPTION
Change Ubunto version to use for the build from the deprecated 18.04 to 18.04 as the official package mirrors have been mmoved to the old-releases archive and build [fails](https://btx.cloud.google.com/invocations/4f2d1726-c4a1-4653-866c-5d8dba8afbd1/log) due to missing artifacts.