### PR TITLE
Upgrading Build Environment to Ubuntu 24.04

### DIFF
--- a/buildscripts/grpc-java-artifacts/Dockerfile.multiarch.base
+++ b/buildscripts/grpc-java-artifacts/Dockerfile.multiarch.base
@@ -1,4 +1,7 @@
-FROM ubuntu:18.04
+FROM ubuntu:24.04
+
+# Redirect to the internal mirror to bypass the Kokoro network block
+RUN sed -i 's|http://archive.ubuntu.com/ubuntu/|http://mirror.bazel.build/archive.ubuntu.com/ubuntu/|g' /etc/apt/sources.list
 
 RUN export DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
@@ -9,8 +12,8 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
         curl \
         g++-aarch64-linux-gnu \
         g++-powerpc64le-linux-gnu \
-        openjdk-8-jdk \
-        pkg-config \
+        openjdk-11-jdk \
+        pkgconf \
         && \
     rm -rf /var/lib/apt/lists/*
     


### PR DESCRIPTION
**1. Transition to Ubuntu 24.04**
Ubuntu 18.04 has reached End-of-Life (EOL), making standard package repositories unreliable. More critically, legacy versions like 18.04 and 20.04 lack modern root SSL certificates required to securely communicate with internal build infrastructure, leading to handshake failures. Moving to Ubuntu 24.04 provides a modern baseline with updated certificate stores that trust required mirrors out-of-the-box.

**2. Mandatory Use of Internal Mirrors** 
The Kokoro grpc-ubuntu22 worker pool operates under strict egress restrictions that block connections to public Ubuntu archives (e.g., archive.ubuntu.com), resulting in Connection failed errors. To bypass this firewall, we must redirect apt traffic to the internal Google mirror (mirror.bazel.build) using a sed command in the Dockerfile.

**3. Bumping JDK to Version 11** 
Ubuntu 24.04 no longer includes the ancient openjdk-8-jdk in its default repositories. To ensure compatibility with the new OS and maintain a supportable toolchain, we have bumped the version to openjdk-11-jdk.

**4. Transition from pkg-config to pkgconf** 
Following modern Debian/Ubuntu packaging standards, we have replaced pkg-config with pkgconf which is the preferred, actively maintained implementation for package discovery in newer Ubuntu releases.