### PR TITLE
binder: Give clear error when message is larger than parcel

### DIFF
--- a/binder/src/main/java/io/grpc/binder/internal/Inbound.java
+++ b/binder/src/main/java/io/grpc/binder/internal/Inbound.java
@@ -399,6 +399,13 @@ abstract class Inbound<L extends StreamListener> implements StreamListener.Messa
       numBytes = parcel.dataPosition() - startPos;
     } else {
       numBytes = parcel.readInt();
+      if (numBytes > parcel.dataAvail()) {
+        throw Status.INTERNAL
+            .withDescription(
+                "Message size is larger than remaining parcel size: "
+                + numBytes + " > " + parcel.dataAvail())
+            .asException();
+      }
       block = BlockPool.acquireBlock(numBytes);
       if (numBytes > 0) {
         parcel.readByteArray(block);


### PR DESCRIPTION
Yes, it is lacking a test, but it seems we don't yet have good testing tools to help for tests like this.

b/507253841