### PR TITLE
bazel build support for Android (bzlmod mode only)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,3 @@
 build --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
 
-common:skip_android --deleted_packages=android
+common:skip_android --deleted_packages=android,binder

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,3 @@
 build --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
+
+common:skip_android --deleted_packages=android

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -100,10 +100,10 @@ jobs:
         key: ${{ runner.os }}-bazel-${{ env.USE_BAZEL_VERSION }}-${{ hashFiles('WORKSPACE', 'repositories.bzl') }}
 
     - name: Run bazel build
-      run: bazelisk build //... --enable_bzlmod=${{ matrix.bzlmod }} --enable_workspace=${{ !matrix.bzlmod }}
+      run: bazelisk build //... --config=skip_android --enable_bzlmod=${{ matrix.bzlmod }} --enable_workspace=${{ !matrix.bzlmod }}
 
     - name: Run bazel test
-      run: bazelisk test //... --enable_bzlmod=${{ matrix.bzlmod }} --enable_workspace=${{ !matrix.bzlmod }}
+      run: bazelisk test //... --config=skip_android --enable_bzlmod=${{ matrix.bzlmod }} --enable_workspace=${{ !matrix.bzlmod }}
 
     - name: Run example bazel build
       run: bazelisk build //... --enable_bzlmod=${{ matrix.bzlmod }} --enable_workspace=${{ !matrix.bzlmod }}

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -150,3 +150,17 @@ $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses
 
 # Add 'export ANDROID_HOME=$HOME/Android/Sdk' to your .bashrc or equivalent
 ```
+
+Building with Bazel
+===================
+
+grpc-java can also be built using [Bazel](https://bazel.build/). We support
+the two most recent major versions of Bazel.
+[Install bazelisk](https://github.com/bazelbuild/bazelisk#installation)
+to ensure you're always building using the latest supported version, then try:
+
+```
+$ bazelisk build //...
+```
+
+You cannot run the tests from Bazel at this time.

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -163,4 +163,13 @@ to ensure you're always building using the latest supported version, then try:
 $ bazelisk build //...
 ```
 
+Some parts of grpc-java depend on Android. Bazel can build these parts too but,
+for size, licensing and maintenance reasons, it requires a locally installed
+Android SDK. If you don't have the SDK and/or don't care about Android, use the
+`skip_android` configuration to skip building the Android parts:
+
+```sh
+$ bazelisk build //... --config=skip_android
+```
+
 You cannot run the tests from Bazel at this time.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -55,9 +55,17 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "googleapis", version = "0.0.0-20260514-1dbb1a14", repo_name = "com_google_googleapis")
 bazel_dep(name = "grpc-proto", version = "0.0.0-20240627-ec30f58.bcr.1", repo_name = "io_grpc_grpc_proto")
 bazel_dep(name = "protobuf", version = "33.4", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_android", version = "0.7.2")
 bazel_dep(name = "rules_cc", version = "0.0.9")
 bazel_dep(name = "rules_java", version = "9.1.0")
 bazel_dep(name = "rules_jvm_external", version = "6.0")
+
+android_sdk_repository_extension = use_extension(
+    "@rules_android//rules/android_sdk_repository:rule.bzl",
+    "android_sdk_repository_extension",
+)
+use_repo(android_sdk_repository_extension, "androidsdk")
+register_toolchains("@androidsdk//:sdk-toolchain", "@androidsdk//:all")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
@@ -68,6 +76,30 @@ maven.install(
     strict_visibility = True,
 )
 use_repo(maven, "maven")
+
+# Define a separate, dev-only extension import for Android deps.
+# This prevents downstream non-Android users from having to resolve
+# Google Maven (which is required for androidx.*) or rules_android transitively.
+grpc_android_maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven", dev_dependency = True)
+grpc_android_maven.install(
+    name = "grpc_android_maven",
+    artifacts = [
+        "androidx.annotation:annotation:1.6.0",
+        "androidx.annotation:annotation-jvm:1.6.0",
+        "androidx.core:core:1.13.1",
+        "androidx.lifecycle:lifecycle-common:2.6.2",
+    ],
+    repositories = [
+        "https://repo.maven.apache.org/maven2/",
+        "https://maven.google.com",
+    ],
+    strict_visibility = True,
+    # For Bazel 8+ compatibility.
+    use_starlark_android_rules = True,
+    # Set this explicitly since the default guess is incorrect under Bzlmod.
+    aar_import_bzl_label = "@rules_android//rules:rules.bzl",
+)
+use_repo(grpc_android_maven, "grpc_android_maven")
 
 maven.override(
     coordinates = "com.google.protobuf:protobuf-java",

--- a/android/BUILD.bazel
+++ b/android/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@rules_android//rules:rules.bzl", "android_library")
+load("@rules_jvm_external//:defs.bzl", "artifact")
+
+licenses(["notice"])
+
+android_library(
+    name = "android",
+    srcs = glob([
+        "src/main/java/**/*.java",
+    ]),
+    manifest = "src/main/AndroidManifest.xml",
+    custom_package = "io.grpc.android",
+    # TODO(jdcormie): Figure out how to expose this publicly without making
+    # existing non-android users configure rules_android and maven.google.com.
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//api",
+        "//core:internal",
+        artifact("com.google.code.findbugs:jsr305"),
+        artifact("com.google.errorprone:error_prone_annotations"),
+        artifact("com.google.guava:guava"),
+    ],
+)

--- a/binder/BUILD.bazel
+++ b/binder/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@rules_android//rules:rules.bzl", "android_library")
+load("@rules_jvm_external//:defs.bzl", "artifact")
+
+licenses(["notice"])
+
+android_library(
+    name = "binder",
+    srcs = glob([
+        "src/main/java/**/*.java",
+    ]),
+    manifest = "src/main/AndroidManifest.xml",
+    custom_package = "io.grpc.binder",
+    # TODO(jdcormie): Figure out how to make this public without forcing
+    # existing non-android users to configure rules_android and Google's maven.
+    visibility = ["//:__subpackages__"],
+    exports = ["@grpc_android_maven//:androidx_annotation_annotation"],
+    deps = [
+        "//api",
+        "//core:internal",
+        # Resolve android deps from the isolated grpc_android_maven repository.
+        "@grpc_android_maven//:androidx_annotation_annotation",
+        "@grpc_android_maven//:androidx_annotation_annotation_jvm",
+        "@grpc_android_maven//:androidx_core_core",
+        "@grpc_android_maven//:androidx_lifecycle_lifecycle_common",
+        artifact("com.google.code.findbugs:jsr305"),
+        artifact("com.google.errorprone:error_prone_annotations"),
+        artifact("com.google.guava:guava"),
+    ],
+)

--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -47,7 +47,8 @@ export PATH=/tmp/bazelisk:$PATH
 
 export USE_BAZEL_VERSION=9.1.0
 bazelisk build \
-  //android
+  //android \
+  //binder
 
 curl -Ls https://github.com/Kitware/CMake/releases/download/v3.26.3/cmake-3.26.3-linux-x86_64.tar.gz | \
     tar xz -C /tmp

--- a/buildscripts/kokoro/android.sh
+++ b/buildscripts/kokoro/android.sh
@@ -19,7 +19,9 @@ cat <<EOF >> gradle.properties
 org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m
 EOF
 
-export ANDROID_HOME=/tmp/Android/Sdk
+# https://bazel.build/versions/9.1.0/docs/sandboxing gives each worker its own
+# isolated and ephemeral /tmp. Install the Android SDK anywhere but there.
+export ANDROID_HOME=$HOME/Android/Sdk
 mkdir -p "${ANDROID_HOME}/cmdline-tools"
 curl -Ls -o cmdline.zip \
     "https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip"
@@ -27,6 +29,26 @@ unzip -qd "${ANDROID_HOME}/cmdline-tools" cmdline.zip
 rm cmdline.zip
 mv "${ANDROID_HOME}/cmdline-tools/cmdline-tools" "${ANDROID_HOME}/cmdline-tools/latest"
 (yes || true) | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses
+
+# Bazel/android_rules requires build-tools at least version 35.0.0 and, unlike
+# gradle, won't download anything for itself.
+# TODO(jdcormie): Keep this version in sync with AGP's default and any
+# `buildToolsVersion` config.
+"${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --install "build-tools;35.0.1"
+
+# TODO(jdcormie): Use the same SDK version as build.gradle's compileSdkVersion.
+"${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --install "platforms;android-34"
+
+# Bazelisk takes care of installing Bazel.
+mkdir -p /tmp/bazelisk
+curl -Ls -o /tmp/bazelisk/bazelisk https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-amd64
+chmod +x /tmp/bazelisk/bazelisk
+export PATH=/tmp/bazelisk:$PATH
+
+export USE_BAZEL_VERSION=9.1.0
+bazelisk build \
+  //android
+
 curl -Ls https://github.com/Kitware/CMake/releases/download/v3.26.3/cmake-3.26.3-linux-x86_64.tar.gz | \
     tar xz -C /tmp
 export PATH=/tmp/cmake-3.26.3-linux-x86_64/bin:$PATH


### PR DESCRIPTION
Makes //android and //binder available to external consumers of grpc-java via bazel/bzlmod/BCR.

errorprone checks on android code are now actually enforced, at the cost of longer kokoro/android.sh runtime.

WORKSPACE support is also possible but it ended up looking too hairy for me to put my name on.