### PR TITLE
Document how to build with Bazel

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -150,3 +150,17 @@ $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager --licenses
 
 # Add 'export ANDROID_HOME=$HOME/Android/Sdk' to your .bashrc or equivalent
 ```
+
+Building with Bazel
+===================
+
+grpc-java can also be built using [Bazel](https://bazel.build/). We support
+the two most recent major versions of Bazel.
+[Install bazelisk](https://github.com/bazelbuild/bazelisk#installation)
+to ensure you're always building using the latest supported version, then try:
+
+```
+$ bazelisk build //...
+```
+
+You cannot run the tests from Bazel at this time.


### PR DESCRIPTION
Add .bazelversion files so that workflows and contributors automatically use the same supported/tested version of bazel.

`examples/` needs its own copy because it's technically a separate workspace. This could have been a symlink but decided against this to avoid causing problems on Windows. I guess technically examples could use a different version ...