### PR TITLE
bazel: Upgrade googleapis to commit 1dbb1a14

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -49,7 +49,7 @@ IO_GRPC_GRPC_JAVA_ARTIFACTS = [
 bazel_dep(name = "abseil-cpp", version = "20250512.1")
 bazel_dep(name = "bazel_jar_jar", version = "0.1.11.bcr.1")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
-bazel_dep(name = "googleapis", version = "0.0.0-20240326-1c8d509c5", repo_name = "com_google_googleapis")
+bazel_dep(name = "googleapis", version = "0.0.0-20260514-1dbb1a14", repo_name = "com_google_googleapis")
 bazel_dep(name = "grpc-proto", version = "0.0.0-20240627-ec30f58.bcr.1", repo_name = "io_grpc_grpc_proto")
 bazel_dep(name = "protobuf", version = "33.4", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -95,10 +95,10 @@ def grpc_java_repositories():
     if not native.existing_rule("com_google_googleapis"):
         http_archive(
             name = "com_google_googleapis",
-            sha256 = "49930468563dd48283e8301e8d4e71436bf6d27ac27c235224cc1a098710835d",
-            strip_prefix = "googleapis-ca1372c6d7bcb199638ebfdb40d2b2660bab7b88",
+            sha256 = "397fd8eb8a1a62dcf144216d9775816fad7a3fcff0ced1614bee529003c30d9e",
+            strip_prefix = "googleapis-1dbb1a14e079f78d9214f8e48bf083f32e3ddb96",
             urls = [
-                "https://github.com/googleapis/googleapis/archive/ca1372c6d7bcb199638ebfdb40d2b2660bab7b88.tar.gz",
+                "https://github.com/googleapis/googleapis/archive/1dbb1a14e079f78d9214f8e48bf083f32e3ddb96.tar.gz",
             ],
         )
     if not native.existing_rule("io_grpc_grpc_proto"):


### PR DESCRIPTION
Upgrading fixes a rules_go incompatibility with Bazel 9.1 (as mentioned in the Bazel 9.1 release notes), although this specific version was selected simply because it was the newest.

Googleapis greatly reduced their dependencies, so we no longer have transitive dependencies on grpc (C repo) and rules_go, which cleans up our dependencies considerably.