### PR TITLE
core: normalize service config number values

### DIFF
--- a/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
+++ b/core/src/main/java/io/grpc/internal/ManagedChannelImplBuilder.java
@@ -582,8 +582,8 @@ public final class ManagedChannelImplBuilder
         parsedMap.put(key, checkListEntryTypes((List<?>) value));
       } else if (value instanceof String) {
         parsedMap.put(key, value);
-      } else if (value instanceof Double) {
-        parsedMap.put(key, value);
+      } else if (value instanceof Number) {
+        parsedMap.put(key, ((Number) value).doubleValue());
       } else if (value instanceof Boolean) {
         parsedMap.put(key, value);
       } else {
@@ -606,8 +606,8 @@ public final class ManagedChannelImplBuilder
         parsedList.add(checkListEntryTypes((List<?>) value));
       } else if (value instanceof String) {
         parsedList.add(value);
-      } else if (value instanceof Double) {
-        parsedList.add(value);
+      } else if (value instanceof Number) {
+        parsedList.add(((Number) value).doubleValue());
       } else if (value instanceof Boolean) {
         parsedList.add(value);
       } else {

--- a/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
+++ b/core/src/test/java/io/grpc/internal/ManagedChannelImplBuilderTest.java
@@ -735,9 +735,31 @@ public class ManagedChannelImplBuilderTest {
   @Test
   public void defaultServiceConfig_intValue() {
     Map<String, Object> config = new HashMap<>();
+
     config.put("key", 3);
 
-    assertThrows(IllegalArgumentException.class, () -> builder.defaultServiceConfig(config));
+    builder.defaultServiceConfig(config);
+
+    assertThat(builder.defaultServiceConfig).containsEntry("key", 3D);
+  }
+
+  @Test
+  public void defaultServiceConfig_nestedIntValue() {
+    Map<String, Object> config = new HashMap<>();
+    List<Object> list = new ArrayList<>();
+    Map<String, Object> nested = new HashMap<>();
+
+    list.add(123);
+    nested.put("key", 456);
+    list.add(nested);
+    config.put("list", list);
+
+    builder.defaultServiceConfig(config);
+    
+    assertThat(builder.defaultServiceConfig)
+            .containsEntry(
+                    "list",
+                    Arrays.asList(123D, Collections.singletonMap("key", 456D)));
   }
 
   @Test


### PR DESCRIPTION
Fixes #12815

This updates default service config validation to accept numeric values represented as `Number`, not only `Double`.

Common JSON parsers may deserialize integer-looking JSON values such as `maxAttempts: 4` and `backoffMultiplier: 2` as `Integer`, which previously caused `defaultServiceConfig()` to fail with `IllegalArgumentException`.

The values are normalized to `Double` when copied into the validated service config, preserving the existing internal representation expected by the service config parsing code.

Tests were updated to cover direct and nested integer numeric values.

Tested with:

```bash
./gradlew :grpc-core:test --tests io.grpc.internal.ManagedChannelImplBuilderTest \
  -PskipAndroid=true \
  -PskipCodegen=true
```

### Note on existing Javadoc workaround

`ManagedChannelBuilder.defaultServiceConfig()` currently documents JSON numbers as `Double` and provides a recursive `convertNumbers()` helper for parsers that produce `Integer` or other `Number` values. This PR centralizes the same `Number.doubleValue()` normalization inside `defaultServiceConfig()` so callers do not need to duplicate the recursive conversion for nested maps/lists before passing common JSON parser output to the builder.