### PR TITLE
xds: Hold parsed service config in CdsUpdate

### DIFF
--- a/core/src/main/java/io/grpc/internal/JsonUtil.java
+++ b/core/src/main/java/io/grpc/internal/JsonUtil.java
@@ -122,33 +122,6 @@ public class JsonUtil {
   }
 
   /**
-   * Gets a number from an object for the given key.  If the key is not present, this returns null.
-   * If the value does not represent a float, throws an exception.
-   */
-  @Nullable
-  public static Float getNumberAsFloat(Map<String, ?> obj, String key) {
-    assert key != null;
-    if (!obj.containsKey(key)) {
-      return null;
-    }
-    Object value = obj.get(key);
-    if (value instanceof Float) {
-      return (Float) value;
-    }
-    if (value instanceof String) {
-      try {
-        return Float.parseFloat((String) value);
-      } catch (NumberFormatException e) {
-        throw new IllegalArgumentException(
-            String.format("string value '%s' for key '%s' cannot be parsed as a float", value,
-                key));
-      }
-    }
-    throw new IllegalArgumentException(
-        String.format("value %s for key '%s' is not a float", value, key));
-  }
-
-  /**
    * Gets a number from an object for the given key, casted to an integer.  If the key is not
    * present, this returns null.  If the value does not represent an integer, throws an exception.
    */

--- a/core/src/test/java/io/grpc/internal/JsonUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/JsonUtilTest.java
@@ -50,7 +50,6 @@ public class JsonUtilTest {
     assertThat(JsonUtil.getNumberAsLong(map, "key_number_1")).isEqualTo(1L);
 
     assertThat(JsonUtil.getNumberAsDouble(map, "key_string_2.0")).isEqualTo(2D);
-    assertThat(JsonUtil.getNumberAsFloat(map, "key_string_2.0")).isEqualTo(2F);
     try {
       JsonUtil.getNumberAsInteger(map, "key_string_2.0");
       fail("expecting to throw but did not");
@@ -69,10 +68,8 @@ public class JsonUtilTest {
     assertThat(JsonUtil.getNumberAsDouble(map, "key_string_3")).isEqualTo(3D);
     assertThat(JsonUtil.getNumberAsInteger(map, "key_string_3")).isEqualTo(3);
     assertThat(JsonUtil.getNumberAsLong(map, "key_string_3")).isEqualTo(3L);
-    assertThat(JsonUtil.getNumberAsFloat(map, "key_string_3")).isEqualTo(3F);
 
     assertThat(JsonUtil.getNumberAsDouble(map, "key_string_nan")).isNaN();
-    assertThat(JsonUtil.getNumberAsFloat(map, "key_string_nan")).isNaN();
     try {
       JsonUtil.getNumberAsInteger(map, "key_string_nan");
       fail("expecting to throw but did not");
@@ -123,41 +120,18 @@ public class JsonUtilTest {
       assertThat(e).hasMessageThat().isEqualTo(
           "value 'six' for key 'key_string_six' is not a long integer");
     }
-    try {
-      JsonUtil.getNumberAsFloat(map, "key_string_six");
-      fail("expecting to throw but did not");
-    } catch (RuntimeException e) {
-      assertThat(e).hasMessageThat().isEqualTo(
-          "string value 'six' for key 'key_string_six' cannot be parsed as a float");
-    }
-
-    assertThat(JsonUtil.getNumberAsFloat(map, "key_number_7")).isEqualTo(7F);
 
     assertThat(JsonUtil.getNumberAsDouble(map, "key_string_infinity")).isPositiveInfinity();
     assertThat(JsonUtil.getNumberAsDouble(map, "key_string_minus_infinity")).isNegativeInfinity();
     assertThat(JsonUtil.getNumberAsDouble(map, "key_string_exponent")).isEqualTo(2.998e8D);
 
-    assertThat(JsonUtil.getNumberAsFloat(map, "key_string_infinity")).isPositiveInfinity();
-    assertThat(JsonUtil.getNumberAsFloat(map, "key_string_minus_infinity")).isNegativeInfinity();
-    assertThat(JsonUtil.getNumberAsFloat(map, "key_string_exponent")).isEqualTo(2.998e8F);
-
     assertThat(JsonUtil.getNumberAsDouble(map, "key_string_minus_zero")).isZero();
     assertThat(JsonUtil.getNumberAsInteger(map, "key_string_minus_zero")).isEqualTo(0);
     assertThat(JsonUtil.getNumberAsLong(map, "key_string_minus_zero")).isEqualTo(0L);
-    assertThat(JsonUtil.getNumberAsFloat(map, "key_string_minus_zero")).isZero();
 
     assertThat(JsonUtil.getNumberAsDouble(map, "key_nonexistent")).isNull();
     assertThat(JsonUtil.getNumberAsInteger(map, "key_nonexistent")).isNull();
     assertThat(JsonUtil.getNumberAsLong(map, "key_nonexistent")).isNull();
-    assertThat(JsonUtil.getNumberAsFloat(map, "key_nonexistent")).isNull();
-
-    try {
-      JsonUtil.getNumberAsFloat(map, "key_string_boolean");
-      fail("expecting to throw but did not");
-    } catch (RuntimeException e) {
-      assertThat(e).hasMessageThat().isEqualTo(
-          "value true for key 'key_string_boolean' is not a float");
-    }
   }
 
   @Test

--- a/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
+++ b/xds/src/main/java/io/grpc/xds/CdsLoadBalancer2.java
@@ -32,7 +32,6 @@ import io.grpc.InternalLogId;
 import io.grpc.LoadBalancer;
 import io.grpc.LoadBalancerProvider;
 import io.grpc.LoadBalancerRegistry;
-import io.grpc.NameResolver;
 import io.grpc.Status;
 import io.grpc.StatusOr;
 import io.grpc.internal.GrpcUtil;
@@ -126,24 +125,12 @@ final class CdsLoadBalancer2 extends LoadBalancer {
     }
     XdsClusterConfig clusterConfig = clusterConfigOr.getValue();
 
-    NameResolver.ConfigOrError configOrError;
     if (clusterConfig.getChildren() instanceof EndpointConfig) {
-      // The LB policy config is provided in service_config.proto/JSON format.
-      configOrError =
-              GracefulSwitchLoadBalancer.parseLoadBalancingPolicyConfig(
-                      Arrays.asList(clusterConfig.getClusterResource().lbPolicyConfig()),
-                      lbRegistry);
-      if (configOrError.getError() != null) {
-        // Should be impossible, because XdsClusterResource validated this
-        return fail(Status.INTERNAL.withDescription(
-                errorPrefix() + "Unable to parse the LB config: " + configOrError.getError()));
-      }
-
       StatusOr<EdsUpdate> edsUpdate = getEdsUpdate(xdsConfig, clusterName);
       StatusOr<ClusterResolutionResult> statusOrResult = clusterState.edsUpdateToResult(
           clusterName,
           clusterConfig.getClusterResource(),
-          configOrError.getConfig(),
+          clusterConfig.getClusterResource().lbPolicyConfig(),
           edsUpdate);
       if (!statusOrResult.hasValue()) {
         Status status = Status.UNAVAILABLE

--- a/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/LeastRequestLoadBalancer.java
@@ -300,6 +300,20 @@ final class LeastRequestLoadBalancer extends MultiChildLoadBalancer {
     }
 
     @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof LeastRequestConfig)) {
+        return false;
+      }
+      LeastRequestConfig that = (LeastRequestConfig) o;
+      return this.choiceCount == that.choiceCount;
+    }
+
+    @Override
+    public int hashCode() {
+      return choiceCount;
+    }
+
+    @Override
     public String toString() {
       return MoreObjects.toStringHelper(this)
           .add("choiceCount", choiceCount)

--- a/xds/src/main/java/io/grpc/xds/LoadBalancerConfigFactory.java
+++ b/xds/src/main/java/io/grpc/xds/LoadBalancerConfigFactory.java
@@ -155,7 +155,7 @@ class LoadBalancerConfigFactory {
       configBuilder.put(WEIGHT_UPDATE_PERIOD, weightUpdatePeriod);
     }
     if (errorUtilizationPenalty != null) {
-      configBuilder.put(ERROR_UTILIZATION_PENALTY, errorUtilizationPenalty);
+      configBuilder.put(ERROR_UTILIZATION_PENALTY, errorUtilizationPenalty.doubleValue());
     }
     if (metricNamesForComputingUtilization != null
         && !metricNamesForComputingUtilization.isEmpty()) {

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancer.java
@@ -828,6 +828,19 @@ final class WeightedRoundRobinLoadBalancer extends MultiChildLoadBalancer {
           parsedMetricNamesForComputingUtilization);
     }
 
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("blackoutPeriodNanos", blackoutPeriodNanos)
+          .add("weightExpirationPeriodNanos", weightExpirationPeriodNanos)
+          .add("enableOobLoadReport", enableOobLoadReport)
+          .add("oobReportingPeriodNanos", oobReportingPeriodNanos)
+          .add("weightUpdatePeriodNanos", weightUpdatePeriodNanos)
+          .add("errorUtilizationPenalty", errorUtilizationPenalty)
+          .add("parsedMetricNamesForComputingUtilization", parsedMetricNamesForComputingUtilization)
+          .toString();
+    }
+
     static final class Builder {
       long blackoutPeriodNanos = 10_000_000_000L; // 10s
       long weightExpirationPeriodNanos = 180_000_000_000L; // 3min

--- a/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancerProvider.java
+++ b/xds/src/main/java/io/grpc/xds/WeightedRoundRobinLoadBalancerProvider.java
@@ -79,7 +79,8 @@ public final class WeightedRoundRobinLoadBalancerProvider extends LoadBalancerPr
     Long oobReportingPeriodNanos = JsonUtil.getStringAsDuration(rawConfig, "oobReportingPeriod");
     Boolean enableOobLoadReport = JsonUtil.getBoolean(rawConfig, "enableOobLoadReport");
     Long weightUpdatePeriodNanos = JsonUtil.getStringAsDuration(rawConfig, "weightUpdatePeriod");
-    Float errorUtilizationPenalty = JsonUtil.getNumberAsFloat(rawConfig, "errorUtilizationPenalty");
+    Double errorUtilizationPenalty =
+        JsonUtil.getNumberAsDouble(rawConfig, "errorUtilizationPenalty");
     List<String> metricNamesForComputingUtilization = JsonUtil.getListOfStrings(rawConfig,
         "metricNamesForComputingUtilization");
 
@@ -104,7 +105,7 @@ public final class WeightedRoundRobinLoadBalancerProvider extends LoadBalancerPr
       }
     }
     if (errorUtilizationPenalty != null) {
-      configBuilder.setErrorUtilizationPenalty(errorUtilizationPenalty);
+      configBuilder.setErrorUtilizationPenalty(errorUtilizationPenalty.floatValue());
     }
     if (metricNamesForComputingUtilization != null
         && GrpcUtil.getFlag("GRPC_EXPERIMENTAL_WRR_CUSTOM_METRICS", false)) {

--- a/xds/src/main/java/io/grpc/xds/XdsClusterResource.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClusterResource.java
@@ -43,8 +43,7 @@ import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.CommonTlsContext;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.NameResolver;
 import io.grpc.internal.GrpcUtil;
-import io.grpc.internal.ServiceConfigUtil;
-import io.grpc.internal.ServiceConfigUtil.LbConfig;
+import io.grpc.util.GracefulSwitchLoadBalancer;
 import io.grpc.xds.EnvoyServerProtoData.OutlierDetection;
 import io.grpc.xds.EnvoyServerProtoData.UpstreamTlsContext;
 import io.grpc.xds.XdsClusterResource.CdsUpdate;
@@ -165,18 +164,16 @@ class XdsClusterResource extends XdsResourceType<CdsUpdate> {
     ImmutableMap<String, ?> lbPolicyConfig = LoadBalancerConfigFactory.newConfig(cluster,
         enableLeastRequest);
 
-    // Validate the LB config by trying to parse it with the corresponding LB provider.
-    LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(lbPolicyConfig);
-    NameResolver.ConfigOrError configOrError = loadBalancerRegistry.getProvider(
-        lbConfig.getPolicyName()).parseLoadBalancingPolicyConfig(
-        lbConfig.getRawConfigValue());
+    NameResolver.ConfigOrError configOrError
+        = GracefulSwitchLoadBalancer.parseLoadBalancingPolicyConfig(
+            ImmutableList.of(lbPolicyConfig), loadBalancerRegistry);
     if (configOrError.getError() != null) {
       throw new ResourceInvalidException(
           "Failed to parse lb config for cluster '" + cluster.getName() + "': "
           + configOrError.getError());
     }
 
-    updateBuilder.lbPolicyConfig(lbPolicyConfig);
+    updateBuilder.lbPolicyConfig(configOrError.getConfig(), lbPolicyConfig);
     updateBuilder.filterMetadata(
         ImmutableMap.copyOf(cluster.getMetadata().getFilterMetadataMap()));
 
@@ -582,16 +579,22 @@ class XdsClusterResource extends XdsResourceType<CdsUpdate> {
 
     abstract ClusterType clusterType();
 
-    abstract ImmutableMap<String, ?> lbPolicyConfig();
+    /** Graceful switch configuration. */
+    Object lbPolicyConfig() {
+      return internalLbPolicyConfig().getValue();
+    }
 
-    // Only valid if lbPolicy is "ring_hash_experimental".
-    abstract long minRingSize();
+    /**
+     * Use {@link #lbPolicyConfig()} instead. This avoids using the LB policy configs' equals() when
+     * XdsClient squelches config updates that are identical to the current value. LB policies are
+     * not required to implement equals for their configs. Instead, {link
+     * #internalLbPolicyConfigJson()} is used to detect changes.
+     */
+    abstract IgnoreEquals<Object> internalLbPolicyConfig();
 
-    // Only valid if lbPolicy is "ring_hash_experimental".
-    abstract long maxRingSize();
-
-    // Only valid if lbPolicy is "least_request_experimental".
-    abstract int choiceCount();
+    /** Use {@code lbPolicyConfig} instead. */
+    @Nullable
+    abstract ImmutableMap<String, ?> internalLbPolicyConfigJson();
 
     // Alternative resource name to be used in EDS requests.
     /// Only valid for EDS cluster.
@@ -640,9 +643,6 @@ class XdsClusterResource extends XdsResourceType<CdsUpdate> {
     private static Builder newBuilder(String clusterName) {
       return new AutoValue_XdsClusterResource_CdsUpdate.Builder()
           .clusterName(clusterName)
-          .minRingSize(0)
-          .maxRingSize(0)
-          .choiceCount(0)
           .filterMetadata(ImmutableMap.of())
           .parsedMetadata(ImmutableMap.of())
           .isHttp11ProxyAvailable(false)
@@ -703,10 +703,7 @@ class XdsClusterResource extends XdsResourceType<CdsUpdate> {
       return MoreObjects.toStringHelper(this)
           .add("clusterName", clusterName())
           .add("clusterType", clusterType())
-          .add("lbPolicyConfig", lbPolicyConfig())
-          .add("minRingSize", minRingSize())
-          .add("maxRingSize", maxRingSize())
-          .add("choiceCount", choiceCount())
+          .add("lbPolicyConfigJson", internalLbPolicyConfigJson())
           .add("edsServiceName", edsServiceName())
           .add("dnsHostName", dnsHostName())
           .add("lrsServerInfo", lrsServerInfo())
@@ -725,31 +722,31 @@ class XdsClusterResource extends XdsResourceType<CdsUpdate> {
       // Private, use one of the static factory methods instead.
       protected abstract Builder clusterType(ClusterType clusterType);
 
-      protected abstract Builder lbPolicyConfig(ImmutableMap<String, ?> lbPolicyConfig);
-
-      Builder roundRobinLbPolicy() {
-        return this.lbPolicyConfig(ImmutableMap.of("round_robin", ImmutableMap.of()));
+      /**
+       * The config to use, and the JSON representation that produced that config. The JSON
+       * representation is only used to detect if the configuration changed, since LB policies don't
+       * have to implement equals() for their parsed configs.
+       */
+      protected Builder lbPolicyConfig(
+          Object gracefulSwitchConfig, ImmutableMap<String, ?> jsonConfig) {
+        return internalLbPolicyConfig(new IgnoreEquals<>(gracefulSwitchConfig))
+            .internalLbPolicyConfigJson(jsonConfig);
       }
 
-      Builder ringHashLbPolicy(Long minRingSize, Long maxRingSize) {
-        return this.lbPolicyConfig(ImmutableMap.of("ring_hash_experimental",
-            ImmutableMap.of("minRingSize", minRingSize.doubleValue(), "maxRingSize",
-                maxRingSize.doubleValue())));
+      protected Builder lbPolicyConfigJsonForTesting(ImmutableMap<String, ?> jsonConfig) {
+        NameResolver.ConfigOrError result =
+            GracefulSwitchLoadBalancer.parseLoadBalancingPolicyConfig(
+                ImmutableList.of(jsonConfig));
+        if (result.getError() != null) {
+          throw new IllegalArgumentException(
+              "Bad JSON config: " + result.getError() + " json: " + jsonConfig);
+        }
+        return lbPolicyConfig(result.getConfig(), jsonConfig);
       }
 
-      Builder leastRequestLbPolicy(Integer choiceCount) {
-        return this.lbPolicyConfig(ImmutableMap.of("least_request_experimental",
-            ImmutableMap.of("choiceCount", choiceCount.doubleValue())));
-      }
+      protected abstract Builder internalLbPolicyConfig(IgnoreEquals<Object> gracefulSwitchConfig);
 
-      // Private, use leastRequestLbPolicy(int).
-      protected abstract Builder choiceCount(int choiceCount);
-
-      // Private, use ringHashLbPolicy(long, long).
-      protected abstract Builder minRingSize(long minRingSize);
-
-      // Private, use ringHashLbPolicy(long, long).
-      protected abstract Builder maxRingSize(long maxRingSize);
+      protected abstract Builder internalLbPolicyConfigJson(ImmutableMap<String, ?> jsonConfig);
 
       // Private, use CdsUpdate.forEds() instead.
       protected abstract Builder edsServiceName(String edsServiceName);
@@ -781,6 +778,37 @@ class XdsClusterResource extends XdsResourceType<CdsUpdate> {
           BackendMetricPropagation backendMetricPropagation);
 
       abstract CdsUpdate build();
+    }
+  }
+
+  /** Always equal to this same type. */
+  static final class IgnoreEquals<V> {
+    private final V value;
+
+    IgnoreEquals(V value) {
+      this.value = value;
+    }
+
+    public V getValue() {
+      return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof IgnoreEquals)) {
+        return false;
+      }
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      return 0;
+    }
+
+    @Override
+    public String toString() {
+      return "IgnoreEquals{" + value + "}";
     }
   }
 }

--- a/xds/src/test/java/io/grpc/xds/GcpAuthenticationFilterTest.java
+++ b/xds/src/test/java/io/grpc/xds/GcpAuthenticationFilterTest.java
@@ -71,7 +71,6 @@ import io.grpc.xds.client.EnvoyProtoData.Node;
 import io.grpc.xds.client.Locality;
 import io.grpc.xds.client.XdsResourceType;
 import io.grpc.xds.client.XdsResourceType.ResourceInvalidException;
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -147,7 +146,7 @@ public class GcpAuthenticationFilterTest {
   }
 
   @Test
-  public void testClientInterceptor_success() throws IOException, ResourceInvalidException {
+  public void testClientInterceptor_success() throws ResourceInvalidException {
     XdsConfig.XdsClusterConfig clusterConfig = new XdsConfig.XdsClusterConfig(
         CLUSTER_NAME,
         cdsUpdate,
@@ -176,7 +175,7 @@ public class GcpAuthenticationFilterTest {
 
   @Test
   public void testClientInterceptor_createsAndReusesCachedCredentials()
-      throws IOException, ResourceInvalidException {
+      throws ResourceInvalidException {
     XdsConfig.XdsClusterConfig clusterConfig = new XdsConfig.XdsClusterConfig(
         CLUSTER_NAME,
         cdsUpdate,
@@ -323,8 +322,7 @@ public class GcpAuthenticationFilterTest {
   }
 
   @Test
-  public void testClientInterceptor_notAudienceWrapper()
-      throws IOException, ResourceInvalidException {
+  public void testClientInterceptor_notAudienceWrapper() throws ResourceInvalidException {
     XdsConfig.XdsClusterConfig clusterConfig = new XdsConfig.XdsClusterConfig(
         CLUSTER_NAME,
         getCdsUpdateWithIncorrectAudienceWrapper(),
@@ -352,7 +350,7 @@ public class GcpAuthenticationFilterTest {
   }
 
   @Test
-  public void testLruCacheAcrossInterceptors() throws IOException, ResourceInvalidException {
+  public void testLruCacheAcrossInterceptors() throws ResourceInvalidException {
     XdsConfig.XdsClusterConfig clusterConfig = new XdsConfig.XdsClusterConfig(
         CLUSTER_NAME, cdsUpdate, new EndpointConfig(StatusOr.fromValue(edsUpdate)));
     XdsConfig defaultXdsConfig = new XdsConfig.XdsConfigBuilder()
@@ -386,7 +384,7 @@ public class GcpAuthenticationFilterTest {
   }
 
   @Test
-  public void testLruCacheEvictionOnResize() throws IOException, ResourceInvalidException {
+  public void testLruCacheEvictionOnResize() throws ResourceInvalidException {
     XdsConfig.XdsClusterConfig clusterConfig = new XdsConfig.XdsClusterConfig(
         CLUSTER_NAME, cdsUpdate, new EndpointConfig(StatusOr.fromValue(edsUpdate)));
     XdsConfig defaultXdsConfig = new XdsConfig.XdsConfigBuilder()
@@ -494,35 +492,27 @@ public class GcpAuthenticationFilterTest {
   private static CdsUpdate getCdsUpdate() {
     ImmutableMap.Builder<String, Object> parsedMetadata = ImmutableMap.builder();
     parsedMetadata.put("FILTER_INSTANCE_NAME", new AudienceWrapper("TEST_AUDIENCE"));
-    try {
-      CdsUpdate.Builder cdsUpdate = CdsUpdate.forEds(
-              CLUSTER_NAME, EDS_NAME, null, null, null, null, false, null)
-          .lbPolicyConfig(getWrrLbConfigAsMap());
-      return cdsUpdate.parsedMetadata(parsedMetadata.build()).build();
-    } catch (IOException ex) {
-      return null;
-    }
+    CdsUpdate.Builder cdsUpdate = CdsUpdate.forEds(
+            CLUSTER_NAME, EDS_NAME, null, null, null, null, false, null)
+        .lbPolicyConfigJsonForTesting(getWrrLbConfigAsMap());
+    return cdsUpdate.parsedMetadata(parsedMetadata.build()).build();
   }
 
   private static CdsUpdate getCdsUpdate2() {
     ImmutableMap.Builder<String, Object> parsedMetadata = ImmutableMap.builder();
     parsedMetadata.put("FILTER_INSTANCE_NAME", new AudienceWrapper("NEW_TEST_AUDIENCE"));
-    try {
-      CdsUpdate.Builder cdsUpdate = CdsUpdate.forEds(
-              CLUSTER_NAME, EDS_NAME, null, null, null, null, false, null)
-          .lbPolicyConfig(getWrrLbConfigAsMap());
-      return cdsUpdate.parsedMetadata(parsedMetadata.build()).build();
-    } catch (IOException ex) {
-      return null;
-    }
+    CdsUpdate.Builder cdsUpdate = CdsUpdate.forEds(
+            CLUSTER_NAME, EDS_NAME, null, null, null, null, false, null)
+        .lbPolicyConfigJsonForTesting(getWrrLbConfigAsMap());
+    return cdsUpdate.parsedMetadata(parsedMetadata.build()).build();
   }
 
-  private static CdsUpdate getCdsUpdateWithIncorrectAudienceWrapper() throws IOException {
+  private static CdsUpdate getCdsUpdateWithIncorrectAudienceWrapper() {
     ImmutableMap.Builder<String, Object> parsedMetadata = ImmutableMap.builder();
     parsedMetadata.put("FILTER_INSTANCE_NAME", "TEST_AUDIENCE");
     CdsUpdate.Builder cdsUpdate = CdsUpdate.forEds(
             CLUSTER_NAME, EDS_NAME, null, null, null, null, false, null)
-        .lbPolicyConfig(getWrrLbConfigAsMap());
+        .lbPolicyConfigJsonForTesting(getWrrLbConfigAsMap());
     return cdsUpdate.parsedMetadata(parsedMetadata.build()).build();
   }
 

--- a/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplDataTest.java
@@ -116,14 +116,12 @@ import io.grpc.EquivalentAddressGroup;
 import io.grpc.InsecureChannelCredentials;
 import io.grpc.LoadBalancerRegistry;
 import io.grpc.Status.Code;
-import io.grpc.internal.JsonUtil;
-import io.grpc.internal.ServiceConfigUtil;
-import io.grpc.internal.ServiceConfigUtil.LbConfig;
 import io.grpc.lookup.v1.GrpcKeyBuilder;
 import io.grpc.lookup.v1.GrpcKeyBuilder.Name;
 import io.grpc.lookup.v1.NameMatcher;
 import io.grpc.lookup.v1.RouteLookupClusterSpecifier;
 import io.grpc.lookup.v1.RouteLookupConfig;
+import io.grpc.util.GracefulSwitchLoadBalancer;
 import io.grpc.xds.ClusterSpecifierPlugin.NamedPluginConfig;
 import io.grpc.xds.ClusterSpecifierPlugin.PluginConfig;
 import io.grpc.xds.Endpoints.LbEndpoint;
@@ -138,7 +136,6 @@ import io.grpc.xds.VirtualHost.Route.RouteAction.ClusterWeight;
 import io.grpc.xds.VirtualHost.Route.RouteAction.HashPolicy;
 import io.grpc.xds.VirtualHost.Route.RouteMatch;
 import io.grpc.xds.VirtualHost.Route.RouteMatch.PathMatcher;
-import io.grpc.xds.WeightedRoundRobinLoadBalancer.WeightedRoundRobinLoadBalancerConfig;
 import io.grpc.xds.XdsClusterResource.CdsUpdate;
 import io.grpc.xds.client.BackendMetricPropagation;
 import io.grpc.xds.client.Bootstrapper.ServerInfo;
@@ -2239,8 +2236,9 @@ public class GrpcXdsClientImplDataTest {
     CdsUpdate update = XdsClusterResource.processCluster(
         cluster, null, LRS_SERVER_INFO,
         LoadBalancerRegistry.getDefaultRegistry());
-    LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(update.lbPolicyConfig());
-    assertThat(lbConfig.getPolicyName()).isEqualTo("ring_hash_experimental");
+    assertThat(update.lbPolicyConfig()).isEqualTo(
+        GracefulSwitchLoadBalancer.parseLoadBalancingPolicyConfig(Arrays.asList(
+          ImmutableMap.of("ring_hash_experimental", ImmutableMap.of()))).getConfig());
   }
 
   @Test
@@ -2261,11 +2259,11 @@ public class GrpcXdsClientImplDataTest {
     CdsUpdate update = XdsClusterResource.processCluster(
         cluster, null, LRS_SERVER_INFO,
         LoadBalancerRegistry.getDefaultRegistry());
-    LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(update.lbPolicyConfig());
-    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
-    List<LbConfig> childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
-        JsonUtil.getListOfObjects(lbConfig.getRawConfigValue(), "childPolicy"));
-    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("least_request_experimental");
+    assertThat(update.lbPolicyConfig()).isEqualTo(
+        GracefulSwitchLoadBalancer.parseLoadBalancingPolicyConfig(Arrays.asList(
+          ImmutableMap.of("wrr_locality_experimental", ImmutableMap.of("childPolicy",
+            Arrays.asList(ImmutableMap.of("least_request_experimental",
+                ImmutableMap.of())))))).getConfig());
   }
 
   @Test
@@ -2312,20 +2310,16 @@ public class GrpcXdsClientImplDataTest {
     CdsUpdate update = XdsClusterResource.processCluster(
             cluster, null, LRS_SERVER_INFO,
             LoadBalancerRegistry.getDefaultRegistry());
-    LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(update.lbPolicyConfig());
-    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
-    List<LbConfig> childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
-            JsonUtil.getListOfObjects(lbConfig.getRawConfigValue(), "childPolicy"));
-    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("weighted_round_robin");
-    WeightedRoundRobinLoadBalancerConfig result = (WeightedRoundRobinLoadBalancerConfig)
-        new WeightedRoundRobinLoadBalancerProvider().parseLoadBalancingPolicyConfig(
-        childConfigs.get(0).getRawConfigValue()).getConfig();
-    assertThat(result.blackoutPeriodNanos).isEqualTo(17_000_000_000L);
-    assertThat(result.enableOobLoadReport).isTrue();
-    assertThat(result.oobReportingPeriodNanos).isEqualTo(10_000_000_000L);
-    assertThat(result.weightUpdatePeriodNanos).isEqualTo(1_000_000_000L);
-    assertThat(result.weightExpirationPeriodNanos).isEqualTo(180_000_000_000L);
-    assertThat(result.errorUtilizationPenalty).isEqualTo(1.75F);
+    assertThat(update.lbPolicyConfig()).isEqualTo(
+        GracefulSwitchLoadBalancer.parseLoadBalancingPolicyConfig(Arrays.asList(
+          ImmutableMap.of("wrr_locality_experimental", ImmutableMap.of("childPolicy",
+            Arrays.asList(ImmutableMap.of("weighted_round_robin", ImmutableMap.of(
+                "blackoutPeriod", "17s",
+                "enableOobLoadReport", true,
+                "oobReportingPeriod", "10s",
+                "weightUpdatePeriod", "1s",
+                "errorUtilizationPenalty", 1.75
+              ))))))).getConfig());
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplTestBase.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplTestBase.java
@@ -68,11 +68,9 @@ import io.grpc.internal.BackoffPolicy;
 import io.grpc.internal.FakeClock;
 import io.grpc.internal.FakeClock.ScheduledTask;
 import io.grpc.internal.FakeClock.TaskFilter;
-import io.grpc.internal.JsonUtil;
-import io.grpc.internal.ServiceConfigUtil;
-import io.grpc.internal.ServiceConfigUtil.LbConfig;
 import io.grpc.internal.TimeProvider;
 import io.grpc.testing.GrpcCleanupRule;
+import io.grpc.util.GracefulSwitchLoadBalancer;
 import io.grpc.xds.Endpoints.DropOverload;
 import io.grpc.xds.Endpoints.LbEndpoint;
 import io.grpc.xds.Endpoints.LocalityLbEndpoints;
@@ -601,11 +599,10 @@ public abstract class GrpcXdsClientImplTestBase {
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
     assertThat(cdsUpdate.edsServiceName()).isNull();
-    LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
-    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
-    List<LbConfig> childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
-        JsonUtil.getListOfObjects(lbConfig.getRawConfigValue(), "childPolicy"));
-    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
+    assertThat(cdsUpdate.lbPolicyConfig()).isEqualTo(
+        GracefulSwitchLoadBalancer.parseLoadBalancingPolicyConfig(ImmutableList.of(
+          ImmutableMap.of("wrr_locality_experimental", ImmutableMap.of("childPolicy",
+            ImmutableList.of(ImmutableMap.of("round_robin", ImmutableMap.of())))))).getConfig());
     assertThat(cdsUpdate.lrsServerInfo()).isNull();
     assertThat(cdsUpdate.maxConcurrentRequests()).isNull();
     assertThat(cdsUpdate.upstreamTlsContext()).isNull();
@@ -2572,12 +2569,11 @@ public abstract class GrpcXdsClientImplTestBase {
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
     assertThat(cdsUpdate.edsServiceName()).isNull();
-    LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
-    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
-    List<LbConfig> childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
-        JsonUtil.getListOfObjects(lbConfig.getRawConfigValue(), "childPolicy"));
-    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("least_request_experimental");
-    assertThat(childConfigs.get(0).getRawConfigValue().get("choiceCount")).isEqualTo(3);
+    assertThat(cdsUpdate.lbPolicyConfig()).isEqualTo(
+        GracefulSwitchLoadBalancer.parseLoadBalancingPolicyConfig(ImmutableList.of(
+          ImmutableMap.of("wrr_locality_experimental", ImmutableMap.of("childPolicy",
+            ImmutableList.of(ImmutableMap.of("least_request_experimental", ImmutableMap.of(
+                "choiceCount", 3.0))))))).getConfig());
     assertThat(cdsUpdate.lrsServerInfo()).isNull();
     assertThat(cdsUpdate.maxConcurrentRequests()).isNull();
     assertThat(cdsUpdate.upstreamTlsContext()).isNull();
@@ -2606,12 +2602,10 @@ public abstract class GrpcXdsClientImplTestBase {
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
     assertThat(cdsUpdate.edsServiceName()).isNull();
-    LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
-    assertThat(lbConfig.getPolicyName()).isEqualTo("ring_hash_experimental");
-    assertThat(JsonUtil.getNumberAsLong(lbConfig.getRawConfigValue(), "minRingSize")).isEqualTo(
-        10L);
-    assertThat(JsonUtil.getNumberAsLong(lbConfig.getRawConfigValue(), "maxRingSize")).isEqualTo(
-        100L);
+    assertThat(cdsUpdate.lbPolicyConfig()).isEqualTo(
+        GracefulSwitchLoadBalancer.parseLoadBalancingPolicyConfig(ImmutableList.of(
+          ImmutableMap.of("ring_hash_experimental", ImmutableMap.of(
+            "minRingSize", 10.0, "maxRingSize", 100.0)))).getConfig());
     assertThat(cdsUpdate.lrsServerInfo()).isNull();
     assertThat(cdsUpdate.maxConcurrentRequests()).isNull();
     assertThat(cdsUpdate.upstreamTlsContext()).isNull();
@@ -2638,11 +2632,10 @@ public abstract class GrpcXdsClientImplTestBase {
     CdsUpdate cdsUpdate = statusOrUpdate.getValue();
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.AGGREGATE);
-    LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
-    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
-    List<LbConfig> childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
-        JsonUtil.getListOfObjects(lbConfig.getRawConfigValue(), "childPolicy"));
-    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
+    assertThat(cdsUpdate.lbPolicyConfig()).isEqualTo(
+        GracefulSwitchLoadBalancer.parseLoadBalancingPolicyConfig(ImmutableList.of(
+          ImmutableMap.of("wrr_locality_experimental", ImmutableMap.of("childPolicy",
+            ImmutableList.of(ImmutableMap.of("round_robin", ImmutableMap.of())))))).getConfig());
     assertThat(cdsUpdate.prioritizedClusterNames()).containsExactlyElementsIn(candidates).inOrder();
     verifyResourceMetadataAcked(CDS, CDS_RESOURCE, clusterAggregate, VERSION_1, TIME_INCREMENT);
     verifySubscribedResourcesMetadataSizes(0, 1, 0, 0);
@@ -2683,11 +2676,10 @@ public abstract class GrpcXdsClientImplTestBase {
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
     assertThat(cdsUpdate.edsServiceName()).isNull();
-    LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
-    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
-    List<LbConfig> childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
-        JsonUtil.getListOfObjects(lbConfig.getRawConfigValue(), "childPolicy"));
-    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
+    assertThat(cdsUpdate.lbPolicyConfig()).isEqualTo(
+        GracefulSwitchLoadBalancer.parseLoadBalancingPolicyConfig(ImmutableList.of(
+          ImmutableMap.of("wrr_locality_experimental", ImmutableMap.of("childPolicy",
+            ImmutableList.of(ImmutableMap.of("round_robin", ImmutableMap.of())))))).getConfig());
     assertThat(cdsUpdate.lrsServerInfo()).isNull();
     assertThat(cdsUpdate.maxConcurrentRequests()).isEqualTo(200L);
     assertThat(cdsUpdate.upstreamTlsContext()).isNull();
@@ -3085,11 +3077,10 @@ public abstract class GrpcXdsClientImplTestBase {
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.LOGICAL_DNS);
     assertThat(cdsUpdate.dnsHostName()).isEqualTo(dnsHostAddr + ":" + dnsHostPort);
-    LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
-    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
-    List<LbConfig> childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
-        JsonUtil.getListOfObjects(lbConfig.getRawConfigValue(), "childPolicy"));
-    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
+    assertThat(cdsUpdate.lbPolicyConfig()).isEqualTo(
+        GracefulSwitchLoadBalancer.parseLoadBalancingPolicyConfig(ImmutableList.of(
+          ImmutableMap.of("wrr_locality_experimental", ImmutableMap.of("childPolicy",
+            ImmutableList.of(ImmutableMap.of("round_robin", ImmutableMap.of())))))).getConfig());
     assertThat(cdsUpdate.lrsServerInfo()).isNull();
     assertThat(cdsUpdate.maxConcurrentRequests()).isNull();
     assertThat(cdsUpdate.upstreamTlsContext()).isNull();
@@ -3110,11 +3101,10 @@ public abstract class GrpcXdsClientImplTestBase {
     assertThat(cdsUpdate.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate.clusterType()).isEqualTo(ClusterType.EDS);
     assertThat(cdsUpdate.edsServiceName()).isEqualTo(edsService);
-    lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate.lbPolicyConfig());
-    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
-    childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
-        JsonUtil.getListOfObjects(lbConfig.getRawConfigValue(), "childPolicy"));
-    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
+    assertThat(cdsUpdate.lbPolicyConfig()).isEqualTo(
+        GracefulSwitchLoadBalancer.parseLoadBalancingPolicyConfig(ImmutableList.of(
+          ImmutableMap.of("wrr_locality_experimental", ImmutableMap.of("childPolicy",
+            ImmutableList.of(ImmutableMap.of("round_robin", ImmutableMap.of())))))).getConfig());
     assertThat(cdsUpdate.lrsServerInfo()).isEqualTo(xdsServerInfo);
     assertThat(cdsUpdate.maxConcurrentRequests()).isNull();
     assertThat(cdsUpdate.upstreamTlsContext()).isNull();
@@ -3511,11 +3501,10 @@ public abstract class GrpcXdsClientImplTestBase {
     assertThat(cdsUpdate1.clusterName()).isEqualTo(CDS_RESOURCE);
     assertThat(cdsUpdate1.clusterType()).isEqualTo(ClusterType.LOGICAL_DNS);
     assertThat(cdsUpdate1.dnsHostName()).isEqualTo(dnsHostAddr + ":" + dnsHostPort);
-    LbConfig lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate1.lbPolicyConfig());
-    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
-    List<LbConfig> childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
-        JsonUtil.getListOfObjects(lbConfig.getRawConfigValue(), "childPolicy"));
-    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
+    assertThat(cdsUpdate1.lbPolicyConfig()).isEqualTo(
+        GracefulSwitchLoadBalancer.parseLoadBalancingPolicyConfig(ImmutableList.of(
+          ImmutableMap.of("wrr_locality_experimental", ImmutableMap.of("childPolicy",
+            ImmutableList.of(ImmutableMap.of("round_robin", ImmutableMap.of())))))).getConfig());
     assertThat(cdsUpdate1.lrsServerInfo()).isNull();
     assertThat(cdsUpdate1.maxConcurrentRequests()).isNull();
     assertThat(cdsUpdate1.upstreamTlsContext()).isNull();
@@ -3527,11 +3516,10 @@ public abstract class GrpcXdsClientImplTestBase {
     assertThat(cdsUpdate2.clusterName()).isEqualTo(cdsResourceTwo);
     assertThat(cdsUpdate2.clusterType()).isEqualTo(ClusterType.EDS);
     assertThat(cdsUpdate2.edsServiceName()).isEqualTo(edsService);
-    lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate2.lbPolicyConfig());
-    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
-    childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
-        JsonUtil.getListOfObjects(lbConfig.getRawConfigValue(), "childPolicy"));
-    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
+    assertThat(cdsUpdate2.lbPolicyConfig()).isEqualTo(
+        GracefulSwitchLoadBalancer.parseLoadBalancingPolicyConfig(ImmutableList.of(
+          ImmutableMap.of("wrr_locality_experimental", ImmutableMap.of("childPolicy",
+            ImmutableList.of(ImmutableMap.of("round_robin", ImmutableMap.of())))))).getConfig());
     assertThat(cdsUpdate2.lrsServerInfo()).isEqualTo(xdsServerInfo);
     assertThat(cdsUpdate2.maxConcurrentRequests()).isNull();
     assertThat(cdsUpdate2.upstreamTlsContext()).isNull();
@@ -3543,11 +3531,10 @@ public abstract class GrpcXdsClientImplTestBase {
     assertThat(cdsUpdate3.clusterName()).isEqualTo(cdsResourceTwo);
     assertThat(cdsUpdate3.clusterType()).isEqualTo(ClusterType.EDS);
     assertThat(cdsUpdate3.edsServiceName()).isEqualTo(edsService);
-    lbConfig = ServiceConfigUtil.unwrapLoadBalancingConfig(cdsUpdate3.lbPolicyConfig());
-    assertThat(lbConfig.getPolicyName()).isEqualTo("wrr_locality_experimental");
-    childConfigs = ServiceConfigUtil.unwrapLoadBalancingConfigList(
-        JsonUtil.getListOfObjects(lbConfig.getRawConfigValue(), "childPolicy"));
-    assertThat(childConfigs.get(0).getPolicyName()).isEqualTo("round_robin");
+    assertThat(cdsUpdate3.lbPolicyConfig()).isEqualTo(
+        GracefulSwitchLoadBalancer.parseLoadBalancingPolicyConfig(ImmutableList.of(
+          ImmutableMap.of("wrr_locality_experimental", ImmutableMap.of("childPolicy",
+            ImmutableList.of(ImmutableMap.of("round_robin", ImmutableMap.of())))))).getConfig());
     assertThat(cdsUpdate3.lrsServerInfo()).isEqualTo(xdsServerInfo);
     assertThat(cdsUpdate3.maxConcurrentRequests()).isNull();
     assertThat(cdsUpdate3.upstreamTlsContext()).isNull();

--- a/xds/src/test/java/io/grpc/xds/LoadBalancerConfigFactoryTest.java
+++ b/xds/src/test/java/io/grpc/xds/LoadBalancerConfigFactoryTest.java
@@ -145,14 +145,14 @@ public class LoadBalancerConfigFactoryTest {
       ImmutableMap.of("childPolicy", ImmutableList.of(
       ImmutableMap.of("weighted_round_robin",
       ImmutableMap.of("blackoutPeriod","287s", "enableOobLoadReport", true,
-          "errorUtilizationPenalty", 1.75F )))));
+          "errorUtilizationPenalty", 1.75 )))));
 
   private static final LbConfig VALID_WRR_CONFIG_WITH_METRICS =
       new LbConfig("wrr_locality_experimental",
           ImmutableMap.of("childPolicy",
               ImmutableList.of(ImmutableMap.of("weighted_round_robin",
                   ImmutableMap.of("blackoutPeriod", "287s", "enableOobLoadReport", true,
-                      "errorUtilizationPenalty", 1.75F,
+                      "errorUtilizationPenalty", 1.75,
                       LoadBalancerConfigFactory.METRIC_NAMES_FOR_COMPUTING_UTILIZATION,
                       ImmutableList.of("foo", "bar"))))));
   private static final LbConfig VALID_RING_HASH_CONFIG = new LbConfig("ring_hash_experimental",

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -1264,7 +1264,7 @@ public class XdsNameResolverTest {
     for (String clusterName : clusterNames) {
       CdsUpdate.Builder forEds = CdsUpdate
           .forEds(clusterName, clusterName, null, null, null, null, false, null)
-              .roundRobinLbPolicy();
+              .lbPolicyConfigJsonForTesting(ImmutableMap.of("round_robin", ImmutableMap.of()));
       xdsClient.deliverCdsUpdate(clusterName, forEds.build());
       EdsUpdate edsUpdate = new EdsUpdate(clusterName,
           XdsTestUtils.createMinimalLbEndpointsMap("127.0.0.3"), Collections.emptyList());

--- a/xds/src/test/java/io/grpc/xds/XdsTestUtils.java
+++ b/xds/src/test/java/io/grpc/xds/XdsTestUtils.java
@@ -51,7 +51,6 @@ import io.grpc.InsecureChannelCredentials;
 import io.grpc.StatusOr;
 import io.grpc.internal.ExponentialBackoffPolicy;
 import io.grpc.internal.FakeClock;
-import io.grpc.internal.JsonParser;
 import io.grpc.stub.StreamObserver;
 import io.grpc.xds.Endpoints.LbEndpoint;
 import io.grpc.xds.Endpoints.LocalityLbEndpoints;
@@ -278,7 +277,7 @@ public class XdsTestUtils {
         EDS_NAME, lbEndpointsMap, Collections.emptyList());
     XdsClusterResource.CdsUpdate cdsUpdate = XdsClusterResource.CdsUpdate.forEds(
         CLUSTER_NAME, EDS_NAME, null, null, null, null, false, null)
-        .lbPolicyConfig(getWrrLbConfigAsMap()).build();
+        .lbPolicyConfigJsonForTesting(getWrrLbConfigAsMap()).build();
     XdsConfig.XdsClusterConfig clusterConfig = new XdsConfig.XdsClusterConfig(
         CLUSTER_NAME, cdsUpdate, new EndpointConfig(StatusOr.fromValue(edsUpdate)));
 
@@ -301,12 +300,9 @@ public class XdsTestUtils {
     return lbEndpointsMap;
   }
 
-  @SuppressWarnings("unchecked")
-  static ImmutableMap<String, ?> getWrrLbConfigAsMap() throws IOException {
-    String lbConfigStr = "{\"wrr_locality_experimental\" : "
-        + "{ \"childPolicy\" : [{\"round_robin\" : {}}]}}";
-
-    return ImmutableMap.copyOf((Map<String, ?>) JsonParser.parse(lbConfigStr));
+  static ImmutableMap<String, ?> getWrrLbConfigAsMap() {
+    return ImmutableMap.of("wrr_locality_experimental", ImmutableMap.of("childPolicy",
+          ImmutableList.of(ImmutableMap.of("round_robin", ImmutableMap.of()))));
   }
 
   static RouteConfiguration buildRouteConfiguration(String authority, String rdsName,


### PR DESCRIPTION
This avoids re-parsing the config within CdsLB, as the providers could have changed and the config may no longer be valid.

Many usages of ServiceConfigUtil.unwrapLoadBalancingConfig() were replaced with public API, which should be less brittle to internal changes. Similarly, config.equals() was added for LBs least_request, ring_hash, wrr to use more public APIs in testing. But I've gone out of my way to avoid using equals for XdsClient change detection, by preserving the original "JSON" config.

This fixes a bug in WRR config parsing which prevented it from parsing errorUtilizationPenalty as it assumed it would be a Float, not a Double like our parser actually generates and our API requires. JsonUtil.getNumberAsFloat() was added specifically for WRR and has never worked as JSON Numbers will always be Doubles.

In XdsClusterResource.CdsUpdate, the LB-specific fields like minRingSize were already not used at all, so this commit deletes them as it seems a relevant cleanup.

Fixes #12733

CC @lepistone