### PR TITLE
xds: fix TSAN data races in xDS security components and tests

### DIFF
--- a/xds/src/main/java/io/grpc/xds/internal/security/DynamicSslContextProvider.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/DynamicSslContextProvider.java
@@ -42,7 +42,7 @@ public abstract class DynamicSslContextProvider extends SslContextProvider {
 
   protected final List<Callback> pendingCallbacks = new ArrayList<>();
   @Nullable protected final CertificateValidationContext staticCertificateValidationContext;
-  @Nullable protected AbstractMap.SimpleImmutableEntry<SslContext, X509TrustManager>
+  @Nullable protected volatile AbstractMap.SimpleImmutableEntry<SslContext, X509TrustManager>
       sslContextAndTrustManager;
 
   protected DynamicSslContextProvider(

--- a/xds/src/main/java/io/grpc/xds/internal/security/certprovider/CertProviderSslContextProvider.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/certprovider/CertProviderSslContextProvider.java
@@ -39,10 +39,10 @@ abstract class CertProviderSslContextProvider extends DynamicSslContextProvider 
   @Nullable private final NoExceptionCloseable rootCertHandle;
   @Nullable private final CertificateProviderInstance certInstance;
   @Nullable protected final CertificateProviderInstance rootCertInstance;
-  @Nullable protected PrivateKey savedKey;
-  @Nullable protected List<X509Certificate> savedCertChain;
-  @Nullable protected List<X509Certificate> savedTrustedRoots;
-  @Nullable protected Map<String, List<X509Certificate>> savedSpiffeTrustMap;
+  @Nullable protected volatile PrivateKey savedKey;
+  @Nullable protected volatile List<X509Certificate> savedCertChain;
+  @Nullable protected volatile List<X509Certificate> savedTrustedRoots;
+  @Nullable protected volatile Map<String, List<X509Certificate>> savedSpiffeTrustMap;
   private final boolean isUsingSystemRootCerts;
 
   protected CertProviderSslContextProvider(

--- a/xds/src/main/java/io/grpc/xds/internal/security/certprovider/FileWatcherCertificateProviderProvider.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/certprovider/FileWatcherCertificateProviderProvider.java
@@ -38,8 +38,9 @@ public final class FileWatcherCertificateProviderProvider implements Certificate
 
   // TODO(lwge): Remove the old env var check once it's confirmed to be unused.
   @VisibleForTesting
-  public static boolean enableSpiffe = GrpcUtil.getFlag("GRPC_EXPERIMENTAL_SPIFFE_TRUST_BUNDLE_MAP",
-      false) || GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_MTLS_SPIFFE", false);
+  public static volatile boolean enableSpiffe =
+      GrpcUtil.getFlag("GRPC_EXPERIMENTAL_SPIFFE_TRUST_BUNDLE_MAP", false)
+          || GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_MTLS_SPIFFE", false);
   private static final String CERT_FILE_KEY = "certificate_file";
   private static final String KEY_FILE_KEY = "private_key_file";
   private static final String ROOT_FILE_KEY = "ca_certificate_file";

--- a/xds/src/main/java/io/grpc/xds/internal/security/trust/CertificateUtils.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/trust/CertificateUtils.java
@@ -30,7 +30,7 @@ import java.security.cert.X509Certificate;
  * Contains certificate utility method(s).
  */
 public final class CertificateUtils {
-  public static boolean useChannelAuthorityIfNoSniApplicable
+  public static volatile boolean useChannelAuthorityIfNoSniApplicable
       = GrpcUtil.getFlag("GRPC_USE_CHANNEL_AUTHORITY_IF_NO_SNI_APPLICABLE", false);
 
   /**


### PR DESCRIPTION
This change resolves several data races reported by ThreadSanitizer (TSAN) in XdsSecurityClientServerTest and associated xDS security components.

Key changes:
- Made certificate, key storage, and SSL context fields volatile in CertProviderSslContextProvider and DynamicSslContextProvider to ensure safe publication between Netty EventLoop threads and background FileWatcher threads.
- Made experimental static flags (enableSpiffe and useChannelAuthorityIfNoSniApplicable) volatile. These flags are toggled by tests while being read by background networking threads; making them volatile ensures these transitions are thread-safe and TSAN-compliant.

b/514777926