### PR TITLE
xds: Remove newlines from XdsConfig.toString()

### DIFF
--- a/xds/src/main/java/io/grpc/xds/XdsConfig.java
+++ b/xds/src/main/java/io/grpc/xds/XdsConfig.java
@@ -18,6 +18,7 @@ package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.grpc.StatusOr;
@@ -76,14 +77,12 @@ final class XdsConfig {
 
   @Override
   public String toString() {
-    StringBuilder builder = new StringBuilder();
-    builder.append("XdsConfig{")
-        .append("\n  listener=").append(listener)
-        .append(",\n  route=").append(route)
-        .append(",\n  virtualHost=").append(virtualHost)
-        .append(",\n  clusters=").append(clusters)
-        .append("\n}");
-    return builder.toString();
+    return MoreObjects.toStringHelper(this)
+        .add("listener", listener)
+        .add("route", route)
+        .add("virtualHost", virtualHost)
+        .add("clusters", clusters)
+        .toString();
   }
 
   public LdsUpdate getListener() {


### PR DESCRIPTION
The newlines can make logs really hard to read, as many log handling systems will split up each log statement by line. With the newlines, those singular log entries get split between multiple log entries which can make reading/processing it pretty ugly.

When logging XdsConfig by itself, it isn't necessarily _that_ bad when XdsConfig is what you're actually trying to look at, but when XdsConfig is in the attributes of ResolvedAddresses it gets very distracting.