### PR TITLE
api: Put attributes last in ResolvedAddresses.toString()

### DIFF
--- a/api/src/main/java/io/grpc/LoadBalancer.java
+++ b/api/src/main/java/io/grpc/LoadBalancer.java
@@ -337,8 +337,8 @@ public abstract class LoadBalancer {
     public String toString() {
       return MoreObjects.toStringHelper(this)
           .add("addresses", addresses)
-          .add("attributes", attributes)
           .add("loadBalancingPolicyConfig", loadBalancingPolicyConfig)
+          .add("attributes", attributes)
           .toString();
     }
 


### PR DESCRIPTION
Attributes is the least likely to be relevant in general, and has the most random assortment of information. Since xds puts XdsConfig in the Attributes, moving things before the attributes can make them much easier to read in logs.