### PR TITLE
xds: remove ORCA LRS propagation flag

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
+++ b/xds/src/main/java/io/grpc/xds/ClusterImplLoadBalancer.java
@@ -17,7 +17,6 @@
 package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.grpc.xds.client.LoadStatsManager2.isEnabledOrcaLrsPropagation;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
@@ -535,12 +534,10 @@ final class ClusterImplLoadBalancer extends LoadBalancer {
      */
     @Override
     public void onLoadReport(MetricReport report) {
-      if (isEnabledOrcaLrsPropagation) {
-        stats.recordTopLevelMetrics(
-            report.getCpuUtilization(),
-            report.getMemoryUtilization(),
-            report.getApplicationUtilization());
-      }
+      stats.recordTopLevelMetrics(
+          report.getCpuUtilization(),
+          report.getMemoryUtilization(),
+          report.getApplicationUtilization());
       stats.recordBackendLoadMetricStats(report.getNamedMetrics());
     }
   }

--- a/xds/src/main/java/io/grpc/xds/XdsClusterResource.java
+++ b/xds/src/main/java/io/grpc/xds/XdsClusterResource.java
@@ -18,7 +18,6 @@ package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.grpc.xds.client.Bootstrapper.ServerInfo;
-import static io.grpc.xds.client.LoadStatsManager2.isEnabledOrcaLrsPropagation;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
@@ -225,7 +224,7 @@ class XdsClusterResource extends XdsResourceType<CdsUpdate> {
     boolean isHttp11ProxyAvailable = false;
     BackendMetricPropagation backendMetricPropagation = null;
 
-    if (isEnabledOrcaLrsPropagation && !cluster.getLrsReportEndpointMetricsList().isEmpty()) {
+    if (!cluster.getLrsReportEndpointMetricsList().isEmpty()) {
       backendMetricPropagation = BackendMetricPropagation.fromMetricSpecs(
           cluster.getLrsReportEndpointMetricsList());
     }

--- a/xds/src/main/java/io/grpc/xds/client/LoadStatsManager2.java
+++ b/xds/src/main/java/io/grpc/xds/client/LoadStatsManager2.java
@@ -25,7 +25,6 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.Sets;
 import io.grpc.Internal;
 import io.grpc.Status;
-import io.grpc.internal.GrpcUtil;
 import io.grpc.xds.client.Stats.BackendLoadMetricStats;
 import io.grpc.xds.client.Stats.ClusterStats;
 import io.grpc.xds.client.Stats.DroppedRequests;
@@ -58,8 +57,6 @@ public final class LoadStatsManager2 {
   private final Map<String, Map<String,
       Map<Locality, ReferenceCounted<ClusterLocalityStats>>>> allLoadStats = new HashMap<>();
   private final Supplier<Stopwatch> stopwatchSupplier;
-  public static boolean isEnabledOrcaLrsPropagation =
-      GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_ORCA_LRS_PROPAGATION", true);
 
   @VisibleForTesting
   public LoadStatsManager2(Supplier<Stopwatch> stopwatchSupplier) {
@@ -385,11 +382,6 @@ public final class LoadStatsManager2 {
      * Metrics are filtered based on the backend metric propagation configuration if configured.
      */
     public synchronized void recordBackendLoadMetricStats(Map<String, Double> namedMetrics) {
-      if (!isEnabledOrcaLrsPropagation) {
-        namedMetrics.forEach((name, value) -> updateLoadMetricStats(name, value));
-        return;
-      }
-
       namedMetrics.forEach((name, value) -> {
         if (backendMetricPropagation.shouldPropagateNamedMetric(name)) {
           updateLoadMetricStats("named_metrics." + name, value);

--- a/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterImplLoadBalancerTest.java
@@ -317,7 +317,7 @@ public class ClusterImplLoadBalancerTest {
   }
 
   @Test
-  public void recordLoadStats() {
+  public void recordLoadStats_orcaMetricsPropagation() {
     LoadBalancerProvider weightedTargetProvider = new WeightedTargetLoadBalancerProvider();
     WeightedTargetConfig weightedTargetConfig =
         buildWeightedTargetConfig(ImmutableMap.of(locality, 10));
@@ -406,9 +406,7 @@ public class ClusterImplLoadBalancerTest {
   }
 
   @Test
-  public void recordLoadStats_orcaLrsPropagationEnabled() {
-    boolean originalVal = LoadStatsManager2.isEnabledOrcaLrsPropagation;
-    LoadStatsManager2.isEnabledOrcaLrsPropagation = true;
+  public void recordLoadStats() {
     BackendMetricPropagation backendMetricPropagation = BackendMetricPropagation.fromMetricSpecs(
         Arrays.asList("application_utilization", "cpu_utilization", "named_metrics.named1"));
     LoadBalancerProvider weightedTargetProvider = new WeightedTargetLoadBalancerProvider();
@@ -459,60 +457,6 @@ public class ClusterImplLoadBalancerTest {
         .isWithin(TOLERANCE).of(3.14159);
     assertThat(localityStats.loadMetricStatsMap()).doesNotContainKey("named_metrics.named2");
     subchannel.shutdown();
-    LoadStatsManager2.isEnabledOrcaLrsPropagation = originalVal;
-  }
-
-  @Test
-  public void recordLoadStats_orcaLrsPropagationDisabled() {
-    boolean originalVal = LoadStatsManager2.isEnabledOrcaLrsPropagation;
-    LoadStatsManager2.isEnabledOrcaLrsPropagation = false;
-    BackendMetricPropagation backendMetricPropagation = BackendMetricPropagation.fromMetricSpecs(
-        Arrays.asList("application_utilization", "cpu_utilization", "named_metrics.named1"));
-    LoadBalancerProvider weightedTargetProvider = new WeightedTargetLoadBalancerProvider();
-    WeightedTargetConfig weightedTargetConfig =
-        buildWeightedTargetConfig(ImmutableMap.of(locality, 10));
-    ClusterImplConfig config = new ClusterImplConfig(CLUSTER, EDS_SERVICE_NAME, LRS_SERVER_INFO,
-        null, Collections.<DropOverload>emptyList(),
-        GracefulSwitchLoadBalancer.createLoadBalancingPolicyConfig(
-            weightedTargetProvider, weightedTargetConfig),
-        null, Collections.emptyMap(), backendMetricPropagation);
-    EquivalentAddressGroup endpoint = makeAddress("endpoint-addr", locality);
-    deliverAddressesAndConfig(Collections.singletonList(endpoint), config);
-    FakeLoadBalancer leafBalancer = Iterables.getOnlyElement(downstreamBalancers);
-    Subchannel subchannel = leafBalancer.createSubChannel();
-    FakeSubchannel fakeSubchannel = helper.subchannels.poll();
-    fakeSubchannel.updateState(ConnectivityStateInfo.forNonError(ConnectivityState.CONNECTING));
-    fakeSubchannel.setConnectedEagIndex(0);
-    fakeSubchannel.updateState(ConnectivityStateInfo.forNonError(ConnectivityState.READY));
-    assertThat(currentState).isEqualTo(ConnectivityState.READY);
-    PickResult result = currentPicker.pickSubchannel(pickSubchannelArgs);
-    assertThat(result.getStatus().isOk()).isTrue();
-    ClientStreamTracer streamTracer = result.getStreamTracerFactory().newClientStreamTracer(
-        ClientStreamTracer.StreamInfo.newBuilder().build(), new Metadata());
-    Metadata trailersWithOrcaLoadReport = new Metadata();
-    trailersWithOrcaLoadReport.put(ORCA_ENDPOINT_LOAD_METRICS_KEY,
-        OrcaLoadReport.newBuilder()
-            .setApplicationUtilization(1.414)
-            .setCpuUtilization(0.5)
-            .setMemUtilization(0.034)
-            .putNamedMetrics("named1", 3.14159)
-            .putNamedMetrics("named2", -1.618).build());
-    streamTracer.inboundTrailers(trailersWithOrcaLoadReport);
-    streamTracer.streamClosed(Status.OK);
-    ClusterStats clusterStats =
-        Iterables.getOnlyElement(loadStatsManager.getClusterStatsReports(CLUSTER));
-    UpstreamLocalityStats localityStats =
-        Iterables.getOnlyElement(clusterStats.upstreamLocalityStatsList());
-
-    assertThat(localityStats.loadMetricStatsMap()).doesNotContainKey("application_utilization");
-    assertThat(localityStats.loadMetricStatsMap()).doesNotContainKey("cpu_utilization");
-    assertThat(localityStats.loadMetricStatsMap()).doesNotContainKey("mem_utilization");
-    assertThat(localityStats.loadMetricStatsMap()).doesNotContainKey("named_metrics.named1");
-    assertThat(localityStats.loadMetricStatsMap()).doesNotContainKey("named_metrics.named2");
-    assertThat(localityStats.loadMetricStatsMap().containsKey("named1")).isTrue();
-    assertThat(localityStats.loadMetricStatsMap().containsKey("named2")).isTrue();
-    subchannel.shutdown();
-    LoadStatsManager2.isEnabledOrcaLrsPropagation = originalVal;
   }
 
   // Verifies https://github.com/grpc/grpc-java/issues/11434.

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -95,7 +95,6 @@ import io.grpc.xds.RingHashLoadBalancer.RingHashConfig;
 import io.grpc.xds.WrrLocalityLoadBalancer.WrrLocalityConfig;
 import io.grpc.xds.client.BackendMetricPropagation;
 import io.grpc.xds.client.Bootstrapper.ServerInfo;
-import io.grpc.xds.client.LoadStatsManager2;
 import io.grpc.xds.client.XdsClient;
 import io.grpc.xds.internal.XdsInternalAttributes;
 import java.net.InetSocketAddress;

--- a/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
+++ b/xds/src/test/java/io/grpc/xds/ClusterResolverLoadBalancerTest.java
@@ -275,8 +275,6 @@ public class ClusterResolverLoadBalancerTest {
 
   @Test
   public void edsClustersWithRingHashEndpointLbPolicy() throws Exception {
-    boolean originalVal = LoadStatsManager2.isEnabledOrcaLrsPropagation;
-    LoadStatsManager2.isEnabledOrcaLrsPropagation = true;
     List<String> metricSpecs = Arrays.asList("cpu_utilization");
     BackendMetricPropagation backendMetricPropagation =
         BackendMetricPropagation.fromMetricSpecs(metricSpecs);
@@ -348,7 +346,6 @@ public class ClusterResolverLoadBalancerTest {
     assertClusterImplConfig(clusterImplConfig, CLUSTER, EDS_SERVICE_NAME, null, null,
         null, Collections.emptyList(), "ring_hash_experimental");
     assertThat(clusterImplConfig.backendMetricPropagation).isEqualTo(backendMetricPropagation);
-    LoadStatsManager2.isEnabledOrcaLrsPropagation = originalVal;
     RingHashConfig ringHashConfig = (RingHashConfig)
         GracefulSwitchLoadBalancerAccessor.getChildConfig(clusterImplConfig.childConfig);
     assertThat(ringHashConfig.minRingSize).isEqualTo(10L);
@@ -889,8 +886,6 @@ public class ClusterResolverLoadBalancerTest {
 
   @Test
   public void onlyLogicalDnsCluster_endpointsResolved() {
-    boolean originalVal = LoadStatsManager2.isEnabledOrcaLrsPropagation;
-    LoadStatsManager2.isEnabledOrcaLrsPropagation = true;
     List<String> metricSpecs = Arrays.asList("cpu_utilization");
     BackendMetricPropagation backendMetricPropagation =
         BackendMetricPropagation.fromMetricSpecs(metricSpecs);
@@ -922,7 +917,6 @@ public class ClusterResolverLoadBalancerTest {
     assertClusterImplConfig(clusterImplConfig, CLUSTER, null, null, null, null,
         Collections.<DropOverload>emptyList(), "wrr_locality_experimental");
     assertThat(clusterImplConfig.backendMetricPropagation).isEqualTo(backendMetricPropagation);
-    LoadStatsManager2.isEnabledOrcaLrsPropagation = originalVal;
     assertAddressesEqual(
         Arrays.asList(new EquivalentAddressGroup(Arrays.asList(
             newInetSocketAddress("127.0.2.1", 9000), newInetSocketAddress("127.0.2.2", 9000)))),

--- a/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplDataTest.java
@@ -2652,9 +2652,6 @@ public class GrpcXdsClientImplDataTest {
 
   @Test
   public void processCluster_parsesOrcaLrsPropagationMetrics() throws ResourceInvalidException {
-    boolean originalVal = LoadStatsManager2.isEnabledOrcaLrsPropagation;
-    LoadStatsManager2.isEnabledOrcaLrsPropagation = true;
-
     ImmutableList<String> metricSpecs = ImmutableList.of(
         "cpu_utilization",
         "named_metrics.foo",
@@ -2683,8 +2680,6 @@ public class GrpcXdsClientImplDataTest {
     assertThat(propagationConfig.shouldPropagateNamedMetric("bar")).isFalse();
     assertThat(propagationConfig.shouldPropagateNamedMetric("unknown_metric_spec"))
         .isFalse();
-
-    LoadStatsManager2.isEnabledOrcaLrsPropagation = originalVal;
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplDataTest.java
+++ b/xds/src/test/java/io/grpc/xds/GrpcXdsClientImplDataTest.java
@@ -139,7 +139,6 @@ import io.grpc.xds.VirtualHost.Route.RouteMatch.PathMatcher;
 import io.grpc.xds.XdsClusterResource.CdsUpdate;
 import io.grpc.xds.client.BackendMetricPropagation;
 import io.grpc.xds.client.Bootstrapper.ServerInfo;
-import io.grpc.xds.client.LoadStatsManager2;
 import io.grpc.xds.client.XdsClient;
 import io.grpc.xds.client.XdsResourceType;
 import io.grpc.xds.client.XdsResourceType.ResourceInvalidException;

--- a/xds/src/test/java/io/grpc/xds/client/LoadStatsManager2Test.java
+++ b/xds/src/test/java/io/grpc/xds/client/LoadStatsManager2Test.java
@@ -259,9 +259,7 @@ public class LoadStatsManager2Test {
   }
 
   @Test
-  public void recordMetrics_orcaLrsPropagationEnabled_specificMetrics() {
-    boolean originalVal = LoadStatsManager2.isEnabledOrcaLrsPropagation;
-    LoadStatsManager2.isEnabledOrcaLrsPropagation = true;
+  public void recordMetrics_specificMetrics() {
     BackendMetricPropagation backendMetricPropagation = BackendMetricPropagation.fromMetricSpecs(
         Arrays.asList("cpu_utilization", "named_metrics.named1"));
     ClusterLocalityStats stats = loadStatsManager.getClusterLocalityStats(
@@ -283,13 +281,10 @@ public class LoadStatsManager2Test {
     assertThat(localityStats.loadMetricStatsMap().get("named_metrics.named1").totalMetricValue())
         .isWithin(TOLERANCE).of(123.4);
     assertThat(localityStats.loadMetricStatsMap()).doesNotContainKey("named_metrics.named2");
-    LoadStatsManager2.isEnabledOrcaLrsPropagation = originalVal;
   }
 
   @Test
-  public void recordMetrics_orcaLrsPropagationEnabled_wildcardNamedMetrics() {
-    boolean originalVal = LoadStatsManager2.isEnabledOrcaLrsPropagation;
-    LoadStatsManager2.isEnabledOrcaLrsPropagation = true;
+  public void recordMetrics_wildcardNamedMetrics() {
     BackendMetricPropagation backendMetricPropagation = BackendMetricPropagation.fromMetricSpecs(
         Arrays.asList("named_metrics.*"));
     ClusterLocalityStats stats = loadStatsManager.getClusterLocalityStats(
@@ -308,7 +303,6 @@ public class LoadStatsManager2Test {
     assertThat(localityStats.loadMetricStatsMap()).containsKey("named_metrics.named2");
     assertThat(localityStats.loadMetricStatsMap().get("named_metrics.named2").totalMetricValue())
         .isWithin(TOLERANCE).of(567.8);
-    LoadStatsManager2.isEnabledOrcaLrsPropagation = originalVal;
   }
 
   @Test


### PR DESCRIPTION
## Summary
Remove `GRPC_EXPERIMENTAL_XDS_ORCA_LRS_PROPAGATION`, which became redundant after ORCA-to-LRS propagation was enabled by default.

## Changes
- Delete the static flag and its conditional branch in `LoadStatsManager2`.
- Always parse `lrs_report_endpoint_metrics` into `BackendMetricPropagation` in CDS parsing.
- Always record ORCA top-level metrics in the LRS listener.
- Update tests to reflect the always-on behavior and remove flag-toggling test code.

## Testing
- `./gradlew -PskipAndroid=true -PskipCodegen=true :grpc-xds:test --tests io.grpc.xds.client.LoadStatsManager2Test --tests io.grpc.xds.ClusterImplLoadBalancerTest --tests io.grpc.xds.GrpcXdsClientImplDataTest --tests io.grpc.xds.ClusterResolverLoadBalancerTest`

Closes #12837