### PR TITLE
docs: Add Javadoc to InternalMayRequireSpecificExecutor

### DIFF
--- a/api/src/main/java/io/grpc/InternalMayRequireSpecificExecutor.java
+++ b/api/src/main/java/io/grpc/InternalMayRequireSpecificExecutor.java
@@ -16,6 +16,10 @@
 
 package io.grpc;
 
+/**
+ * Indicates that a component may require a specific executor for certain operations.
+ * This is an internal interface.
+ */
 @Internal
 public interface InternalMayRequireSpecificExecutor {
   boolean isSpecificExecutorRequired();


### PR DESCRIPTION
### 问题背景
`InternalMayRequireSpecificExecutor` 是 gRPC Java 中的公共接口，尽管标有 `@Internal` 注解表示内部使用，但缺少 Javadoc 注释。这降低了代码的可读性和维护性，影响开发者理解和使用。

### 修改内容
- **添加了 Javadoc 注释**：为 `InternalMayRequireSpecificExecutor` 接口添加了清晰的文档字符串，说明其用途——指示组件可能需要特定执行器执行某些操作，并注明这是内部接口。
  - **为什么这样改**：遵循最佳实践，为公共 API 提供文档，提高代码自描述性，便于维护和协作。
  - **提升**：增强代码可读性和可维护性，无功能或性能影响。

### 验证方式
- 通过运行现有测试套件验证，确保无测试失败（修改仅涉及文档，不影响逻辑）。
- 手动检查 Javadoc 格式是否符合仓库风格和 Java 标准。

### 其他信息
- 无 breaking changes：API 和行为完全不变。
- 不需要更新其他文档：修改是局部的，仅涉及单个文件的文档字符串。
- 已知限制：无。