### PR TITLE
feat(api): (poc) add java.security.Provider setting

### DIFF
--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder2.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder2.java
@@ -131,10 +131,11 @@ public abstract class ForwardingChannelBuilder2<T extends ManagedChannelBuilder<
   }
 
   @Override
-  public T preferJdkSslProvider(javax.net.ssl.SSLContext sslContext) {
-    delegate().preferJdkSslProvider(sslContext);
+  public T preferJdkSslWithSecurityProvider(java.security.Provider provider) {
+    delegate().preferJdkSslWithSecurityProvider(provider);
     return thisT();
   }
+
 
 
   @Deprecated

--- a/api/src/main/java/io/grpc/ForwardingChannelBuilder2.java
+++ b/api/src/main/java/io/grpc/ForwardingChannelBuilder2.java
@@ -130,6 +130,13 @@ public abstract class ForwardingChannelBuilder2<T extends ManagedChannelBuilder<
     return thisT();
   }
 
+  @Override
+  public T preferJdkSslProvider(javax.net.ssl.SSLContext sslContext) {
+    delegate().preferJdkSslProvider(sslContext);
+    return thisT();
+  }
+
+
   @Deprecated
   @Override
   public T nameResolverFactory(NameResolver.Factory resolverFactory) {

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -247,6 +247,20 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   }
 
   /**
+   * Sets a custom JDK {@link javax.net.ssl.SSLContext} to use for secure connections,
+   * preferring the JDK's built-in SSL/TLS implementation (JSSE).
+   *
+   * @param sslContext the custom SSLContext to use, or {@code null} to use defaults.
+   * @throws UnsupportedOperationException if the transport implementation does not support
+   *         configuring SSL provider preferences or custom JDK {@code SSLContext}.
+   * @since 1.69.0
+   */
+  public T preferJdkSslProvider(javax.net.ssl.SSLContext sslContext) {
+    throw new UnsupportedOperationException();
+  }
+
+
+  /**
    * Provides a custom {@link NameResolver.Factory} for the channel. If this method is not called,
    * the builder will try the providers registered in the default {@link NameResolverRegistry} for
    * the given target.

--- a/api/src/main/java/io/grpc/ManagedChannelBuilder.java
+++ b/api/src/main/java/io/grpc/ManagedChannelBuilder.java
@@ -247,17 +247,18 @@ public abstract class ManagedChannelBuilder<T extends ManagedChannelBuilder<T>> 
   }
 
   /**
-   * Sets a custom JDK {@link javax.net.ssl.SSLContext} to use for secure connections,
-   * preferring the JDK's built-in SSL/TLS implementation (JSSE).
+   * Sets a custom {@link java.security.Provider} to use for secure connections,
+   * preferring the JDK's built-in SSL/TLS implementation with that provider.
    *
-   * @param sslContext the custom SSLContext to use, or {@code null} to use defaults.
+   * @param provider the Provider to use, or {@code null} to use defaults.
    * @throws UnsupportedOperationException if the transport implementation does not support
-   *         configuring SSL provider preferences or custom JDK {@code SSLContext}.
+   *         configuring SSL provider preferences or custom JDK {@code Provider}.
    * @since 1.69.0
    */
-  public T preferJdkSslProvider(javax.net.ssl.SSLContext sslContext) {
+  public T preferJdkSslWithSecurityProvider(java.security.Provider provider) {
     throw new UnsupportedOperationException();
   }
+
 
 
   /**

--- a/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
@@ -27,6 +27,7 @@ import io.netty.handler.ssl.ApplicationProtocolConfig.Protocol;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectedListenerFailureBehavior;
 import io.netty.handler.ssl.ApplicationProtocolConfig.SelectorFailureBehavior;
 import io.netty.handler.ssl.OpenSsl;
+import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import io.netty.handler.ssl.SupportedCipherSuiteFilter;
@@ -221,6 +222,23 @@ public class GrpcSslContexts {
         .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
         .applicationProtocolConfig(apc)
         .sslContextProvider(jdkProvider);
+  }
+
+  /**
+   * Returns a Netty {@link SslContext} that wraps the given JDK {@link javax.net.ssl.SSLContext} and is
+   * configured with ciphers and ALPN appropriate for gRPC.
+   */
+  static SslContext configure(javax.net.ssl.SSLContext sslContext) {
+    return new io.netty.handler.ssl.JdkSslContext(
+        sslContext,
+        true, /* isClient */
+        Http2SecurityUtil.CIPHERS,
+        SupportedCipherSuiteFilter.INSTANCE,
+        ALPN,
+        io.netty.handler.ssl.ClientAuth.NONE,
+        null, /* protocols */
+        false /* startTls */
+    );
   }
 
   /**

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -397,14 +397,20 @@ public final class NettyChannelBuilder extends ForwardingChannelBuilder2<NettyCh
 
   @CanIgnoreReturnValue
   @Override
-  public NettyChannelBuilder preferJdkSslProvider(javax.net.ssl.SSLContext sslContext) {
+  public NettyChannelBuilder preferJdkSslWithSecurityProvider(java.security.Provider provider) {
     checkState(!freezeProtocolNegotiatorFactory,
                "Cannot change security when using ChannelCredentials");
-    if (sslContext == null) {
+    if (provider == null) {
       return this;
     }
-    return sslContext(GrpcSslContexts.configure(sslContext));
+    try {
+      SslContext nettySslContext = GrpcSslContexts.configure(SslContextBuilder.forClient(), provider).build();
+      return sslContext(nettySslContext);
+    } catch (SSLException e) {
+      throw new RuntimeException("Failed to configure Netty SslContext with provider", e);
+    }
   }
+
 
 
   /**

--- a/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
+++ b/netty/src/main/java/io/grpc/netty/NettyChannelBuilder.java
@@ -58,6 +58,7 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ReflectiveChannelFactory;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Collection;
@@ -393,6 +394,18 @@ public final class NettyChannelBuilder extends ForwardingChannelBuilder2<NettyCh
     ((DefaultProtocolNegotiator) protocolNegotiatorFactory).sslContext = sslContext;
     return this;
   }
+
+  @CanIgnoreReturnValue
+  @Override
+  public NettyChannelBuilder preferJdkSslProvider(javax.net.ssl.SSLContext sslContext) {
+    checkState(!freezeProtocolNegotiatorFactory,
+               "Cannot change security when using ChannelCredentials");
+    if (sslContext == null) {
+      return this;
+    }
+    return sslContext(GrpcSslContexts.configure(sslContext));
+  }
+
 
   /**
    * Sets the initial flow control window in bytes. Setting initial flow control window enables auto

--- a/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
@@ -329,10 +329,10 @@ public class NettyChannelBuilderTest {
   }
 
   @Test
-  public void preferJdkSslProviderJavax_configuresJdkSslContext() throws Exception {
+  public void preferJdkSslWithSecurityProvider_configuresJdkSslContext() throws Exception {
     NettyChannelBuilder builder = NettyChannelBuilder.forTarget("fakeTarget");
-    javax.net.ssl.SSLContext javaxContext = javax.net.ssl.SSLContext.getDefault();
-    builder.preferJdkSslProvider(javaxContext);
+    java.security.Provider provider = javax.net.ssl.SSLContext.getDefault().getProvider();
+    builder.preferJdkSslWithSecurityProvider(provider);
 
     java.lang.reflect.Field factoryField = NettyChannelBuilder.class.getDeclaredField("protocolNegotiatorFactory");
     factoryField.setAccessible(true);
@@ -346,7 +346,7 @@ public class NettyChannelBuilderTest {
   }
 
   @Test
-  public void preferJdkSslProviderJavax_null_isNoop() throws Exception {
+  public void preferJdkSslWithSecurityProvider_null_isNoop() throws Exception {
     NettyChannelBuilder builder = NettyChannelBuilder.forTarget("fakeTarget");
     SslContext customContext = mock(SslContext.class);
     org.mockito.Mockito.when(customContext.isClient()).thenReturn(true);
@@ -355,7 +355,7 @@ public class NettyChannelBuilderTest {
     org.mockito.Mockito.when(customContext.applicationProtocolNegotiator()).thenReturn(apn);
     builder.sslContext(customContext);
 
-    builder.preferJdkSslProvider(null);
+    builder.preferJdkSslWithSecurityProvider(null);
 
     java.lang.reflect.Field factoryField = NettyChannelBuilder.class.getDeclaredField("protocolNegotiatorFactory");
     factoryField.setAccessible(true);

--- a/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyChannelBuilderTest.java
@@ -141,7 +141,7 @@ public class NettyChannelBuilderTest {
   @Test
   public void sslContextCanBeNull() {
     NettyChannelBuilder builder = new NettyChannelBuilder(getTestSocketAddress());
-    builder.sslContext(null);
+    builder.sslContext(noSslContext);
   }
 
   @Test
@@ -327,4 +327,43 @@ public class NettyChannelBuilderTest {
         NettyChannelCredentials.create(new PlaintextProtocolNegotiatorClientFactory()));
     assertThat(result).isNotNull();
   }
+
+  @Test
+  public void preferJdkSslProviderJavax_configuresJdkSslContext() throws Exception {
+    NettyChannelBuilder builder = NettyChannelBuilder.forTarget("fakeTarget");
+    javax.net.ssl.SSLContext javaxContext = javax.net.ssl.SSLContext.getDefault();
+    builder.preferJdkSslProvider(javaxContext);
+
+    java.lang.reflect.Field factoryField = NettyChannelBuilder.class.getDeclaredField("protocolNegotiatorFactory");
+    factoryField.setAccessible(true);
+    Object factory = factoryField.get(builder);
+
+    java.lang.reflect.Field sslContextField = factory.getClass().getDeclaredField("sslContext");
+    sslContextField.setAccessible(true);
+    SslContext nettySslContext = (SslContext) sslContextField.get(factory);
+
+    assertThat(nettySslContext).isInstanceOf(io.netty.handler.ssl.JdkSslContext.class);
+  }
+
+  @Test
+  public void preferJdkSslProviderJavax_null_isNoop() throws Exception {
+    NettyChannelBuilder builder = NettyChannelBuilder.forTarget("fakeTarget");
+    SslContext customContext = mock(SslContext.class);
+    org.mockito.Mockito.when(customContext.isClient()).thenReturn(true);
+    io.netty.handler.ssl.ApplicationProtocolNegotiator apn = mock(io.netty.handler.ssl.ApplicationProtocolNegotiator.class);
+    org.mockito.Mockito.when(apn.protocols()).thenReturn(java.util.Arrays.asList("h2"));
+    org.mockito.Mockito.when(customContext.applicationProtocolNegotiator()).thenReturn(apn);
+    builder.sslContext(customContext);
+
+    builder.preferJdkSslProvider(null);
+
+    java.lang.reflect.Field factoryField = NettyChannelBuilder.class.getDeclaredField("protocolNegotiatorFactory");
+    factoryField.setAccessible(true);
+    Object factory = factoryField.get(builder);
+
+    java.lang.reflect.Field sslContextField = factory.getClass().getDeclaredField("sslContext");
+    sslContextField.setAccessible(true);
+    assertThat(sslContextField.get(factory)).isSameInstanceAs(customContext);
+  }
 }
+

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -488,14 +488,22 @@ public final class OkHttpChannelBuilder extends ForwardingChannelBuilder2<OkHttp
   }
 
   @Override
-  public OkHttpChannelBuilder preferJdkSslProvider(javax.net.ssl.SSLContext sslContext) {
+  public OkHttpChannelBuilder preferJdkSslWithSecurityProvider(java.security.Provider provider) {
     Preconditions.checkState(!freezeSecurityConfiguration,
         "Cannot change security when using ChannelCredentials");
-    if (sslContext != null) {
-      sslSocketFactory(sslContext.getSocketFactory());
+    if (provider == null) {
+      return this;
     }
-    return this;
+    try {
+      javax.net.ssl.SSLContext sslContext = javax.net.ssl.SSLContext.getInstance("TLS", provider);
+      sslContext.init(null, null, null);
+      sslSocketFactory(sslContext.getSocketFactory());
+      return this;
+    } catch (java.security.GeneralSecurityException e) {
+      throw new RuntimeException("Failed to initialize SSLContext with provider", e);
+    }
   }
+
 
 
   /**

--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpChannelBuilder.java
@@ -487,6 +487,17 @@ public final class OkHttpChannelBuilder extends ForwardingChannelBuilder2<OkHttp
     return this;
   }
 
+  @Override
+  public OkHttpChannelBuilder preferJdkSslProvider(javax.net.ssl.SSLContext sslContext) {
+    Preconditions.checkState(!freezeSecurityConfiguration,
+        "Cannot change security when using ChannelCredentials");
+    if (sslContext != null) {
+      sslSocketFactory(sslContext.getSocketFactory());
+    }
+    return this;
+  }
+
+
   /**
    * Provides a custom scheduled executor service.
    *


### PR DESCRIPTION
This PR works as a POC for exposing a setting in `ManagedChannelBuilder`
that allows for _implicitly preferring_ the JDK implementation + the specified provider in transports that 
support it (e.g. netty), or throw an unsupported op exception for those that don't.

This would allow gax-grpc to easily insert a custom ssl context that
contains the providers we need as follows:

```java
      // Conscrypt can be an option too
private void configurePqc(ManagedChannelBuilder<?> builder) {
      java.security.Provider bcProvider = new org.bouncycastle.jce.provider.BouncyCastleProvider();
      java.security.Provider bcJsseProvider =
          new org.bouncycastle.jsse.provider.BouncyCastleJsseProvider(bcProvider);

      builder.preferJdkSslWithSecurityProvider(bcJsseProvider);
```

This was tested locally in https://github.com/googleapis/google-cloud-java/pull/13388
