### PR TITLE
xds: ignore keep_empty_value and discard header keys on empty mutations

### DIFF
--- a/xds/src/main/java/io/grpc/xds/internal/headermutations/HeaderMutator.java
+++ b/xds/src/main/java/io/grpc/xds/internal/headermutations/HeaderMutator.java
@@ -67,24 +67,23 @@ public class HeaderMutator {
   private void updateHeader(final HeaderValueOption option, Metadata mutableHeaders) {
     HeaderValue header = option.header();
     HeaderAppendAction action = option.appendAction();
-    boolean keepEmptyValue = option.keepEmptyValue();
 
     if (header.key().endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
       if (header.rawValue().isPresent()) {
-        byte[] value = header.rawValue().get().toByteArray();
-        if (value.length > 0 || keepEmptyValue) {
-          updateHeader(action, Metadata.Key.of(header.key(), Metadata.BINARY_BYTE_MARSHALLER),
-                  value, mutableHeaders);
+        Metadata.Key<byte[]> key = Metadata.Key.of(header.key(), Metadata.BINARY_BYTE_MARSHALLER);
+        updateHeader(action, key, header.rawValue().get().toByteArray(), mutableHeaders);
+        if (containsEmpty(key, mutableHeaders)) {
+          mutableHeaders.discardAll(key);
         }
       } else {
         logger.fine("Missing binary rawValue for header: " + header.key());
       }
     } else {
       if (header.value().isPresent()) {
-        String value = header.value().get();
-        if (!value.isEmpty() || keepEmptyValue) {
-          updateHeader(action, Metadata.Key.of(header.key(), Metadata.ASCII_STRING_MARSHALLER),
-                  value, mutableHeaders);
+        Metadata.Key<String> key = Metadata.Key.of(header.key(), Metadata.ASCII_STRING_MARSHALLER);
+        updateHeader(action, key, header.value().get(), mutableHeaders);
+        if (containsEmpty(key, mutableHeaders)) {
+          mutableHeaders.discardAll(key);
         }
       } else {
         logger.fine("Missing value for header: " + header.key());
@@ -118,6 +117,25 @@ public class HeaderMutator {
         // Should be unreachable unless there's a proto schema mismatch.
         logger.fine("Unknown HeaderAppendAction: " + action);
     }
+  }
+
+  private <T> boolean containsEmpty(Metadata.Key<T> key, Metadata headers) {
+    Iterable<T> values = headers.getAll(key);
+    if (values == null) {
+      return false;
+    }
+    for (T val : values) {
+      if (val instanceof String) {
+        if (((String) val).isEmpty()) {
+          return true;
+        }
+      } else if (val instanceof byte[]) {
+        if (((byte[]) val).length == 0) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 }
 

--- a/xds/src/main/java/io/grpc/xds/internal/headermutations/HeaderMutator.java
+++ b/xds/src/main/java/io/grpc/xds/internal/headermutations/HeaderMutator.java
@@ -72,9 +72,6 @@ public class HeaderMutator {
       if (header.rawValue().isPresent()) {
         Metadata.Key<byte[]> key = Metadata.Key.of(header.key(), Metadata.BINARY_BYTE_MARSHALLER);
         updateHeader(action, key, header.rawValue().get().toByteArray(), mutableHeaders);
-        if (containsEmpty(key, mutableHeaders)) {
-          mutableHeaders.discardAll(key);
-        }
       } else {
         logger.fine("Missing binary rawValue for header: " + header.key());
       }
@@ -82,9 +79,6 @@ public class HeaderMutator {
       if (header.value().isPresent()) {
         Metadata.Key<String> key = Metadata.Key.of(header.key(), Metadata.ASCII_STRING_MARSHALLER);
         updateHeader(action, key, header.value().get(), mutableHeaders);
-        if (containsEmpty(key, mutableHeaders)) {
-          mutableHeaders.discardAll(key);
-        }
       } else {
         logger.fine("Missing value for header: " + header.key());
       }
@@ -117,25 +111,6 @@ public class HeaderMutator {
         // Should be unreachable unless there's a proto schema mismatch.
         logger.fine("Unknown HeaderAppendAction: " + action);
     }
-  }
-
-  private <T> boolean containsEmpty(Metadata.Key<T> key, Metadata headers) {
-    Iterable<T> values = headers.getAll(key);
-    if (values == null) {
-      return false;
-    }
-    for (T val : values) {
-      if (val instanceof String) {
-        if (((String) val).isEmpty()) {
-          return true;
-        }
-      } else if (val instanceof byte[]) {
-        if (((byte[]) val).length == 0) {
-          return true;
-        }
-      }
-    }
-    return false;
   }
 }
 

--- a/xds/src/main/java/io/grpc/xds/internal/headermutations/HeaderValueOption.java
+++ b/xds/src/main/java/io/grpc/xds/internal/headermutations/HeaderValueOption.java
@@ -27,15 +27,13 @@ import io.grpc.xds.internal.grpcservice.HeaderValue;
 public abstract class HeaderValueOption {
 
   public static HeaderValueOption create(
-      HeaderValue header, HeaderAppendAction appendAction, boolean keepEmptyValue) {
-    return new AutoValue_HeaderValueOption(header, appendAction, keepEmptyValue);
+      HeaderValue header, HeaderAppendAction appendAction) {
+    return new AutoValue_HeaderValueOption(header, appendAction);
   }
 
   public abstract HeaderValue header();
 
   public abstract HeaderAppendAction appendAction();
-
-  public abstract boolean keepEmptyValue();
 
   /**
    * Defines the action to take when appending headers.

--- a/xds/src/test/java/io/grpc/xds/internal/headermutations/HeaderMutationFilterTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/headermutations/HeaderMutationFilterTest.java
@@ -36,12 +36,12 @@ public class HeaderMutationFilterTest {
 
   private static HeaderValueOption header(String key, ByteString value) {
     return HeaderValueOption.create(io.grpc.xds.internal.grpcservice.HeaderValue.create(key, value),
-        HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD, false);
+        HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD);
   }
 
   private static HeaderValueOption header(String key, String value) {
     return HeaderValueOption.create(io.grpc.xds.internal.grpcservice.HeaderValue.create(key, value),
-        HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD, false);
+        HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD);
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/internal/headermutations/HeaderMutationsTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/headermutations/HeaderMutationsTest.java
@@ -31,7 +31,7 @@ public class HeaderMutationsTest {
   public void testCreate() {
     HeaderValueOption header = HeaderValueOption.create(
         HeaderValue.create("key", "value"),
-        HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD, false);
+        HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD);
     HeaderMutations mutations = HeaderMutations.create(
         ImmutableList.of(header), ImmutableList.of("remove-key"));
     assertThat(mutations.headers()).containsExactly(header);

--- a/xds/src/test/java/io/grpc/xds/internal/headermutations/HeaderMutatorTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/headermutations/HeaderMutatorTest.java
@@ -247,30 +247,27 @@ public class HeaderMutatorTest {
     headerMutator.applyMutations(mutations, headers);
 
     assertThat(headers.containsKey(NEW_ADD_KEY)).isFalse();
-    assertThat(headers.getAll(APPEND_KEY)).containsExactly("existing-value");
-    assertThat(headers.get(OVERWRITE_KEY)).isEqualTo("existing-value");
+    assertThat(headers.containsKey(APPEND_KEY)).isFalse();
+    assertThat(headers.containsKey(OVERWRITE_KEY)).isFalse();
     assertThat(headers.containsKey(ADD_KEY)).isFalse();
-    assertThat(headers.get(OVERWRITE_IF_EXISTS_KEY)).isEqualTo("existing-value");
+    assertThat(headers.containsKey(OVERWRITE_IF_EXISTS_KEY)).isFalse();
 
     Metadata.Key<String> keepEmptyKey =
         Metadata.Key.of("keep-empty-key", Metadata.ASCII_STRING_MARSHALLER);
     Metadata.Key<String> keepEmptyOverwriteKey =
         Metadata.Key.of("keep-empty-overwrite-key", Metadata.ASCII_STRING_MARSHALLER);
 
-    assertThat(headers.containsKey(keepEmptyKey)).isTrue();
-    assertThat(headers.get(keepEmptyKey)).isEqualTo("");
-    assertThat(headers.containsKey(keepEmptyOverwriteKey)).isTrue();
-    assertThat(headers.get(keepEmptyOverwriteKey)).isEqualTo("");
+    assertThat(headers.containsKey(keepEmptyKey)).isFalse();
+    assertThat(headers.containsKey(keepEmptyOverwriteKey)).isFalse();
 
     Metadata.Key<byte[]> keepEmptyBinKey =
         Metadata.Key.of("keep-empty-bin-key-bin", Metadata.BINARY_BYTE_MARSHALLER);
     Metadata.Key<byte[]> ignoreEmptyBinKey =
         Metadata.Key.of("ignore-empty-bin-key-bin", Metadata.BINARY_BYTE_MARSHALLER);
 
-    assertThat(headers.containsKey(keepEmptyBinKey)).isTrue();
-    assertThat(headers.get(keepEmptyBinKey)).isEqualTo(new byte[0]);
+    assertThat(headers.containsKey(keepEmptyBinKey)).isFalse();
     assertThat(headers.containsKey(ignoreEmptyBinKey)).isFalse();
-    assertThat(headers.get(overwriteEmptyBinKey)).isEqualTo(originalBinValue);
+    assertThat(headers.containsKey(overwriteEmptyBinKey)).isFalse();
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/internal/headermutations/HeaderMutatorTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/headermutations/HeaderMutatorTest.java
@@ -201,7 +201,7 @@ public class HeaderMutatorTest {
   }
 
   @Test
-  public void applyMutations_keepEmptyValue() {
+  public void applyMutations_emptyValuesAreKept() {
     Metadata headers = new Metadata();
     headers.put(APPEND_KEY, "existing-value");
     headers.put(OVERWRITE_KEY, "existing-value");
@@ -242,28 +242,28 @@ public class HeaderMutatorTest {
 
     headerMutator.applyMutations(mutations, headers);
 
-    assertThat(headers.containsKey(NEW_ADD_KEY)).isFalse();
-    assertThat(headers.containsKey(APPEND_KEY)).isFalse();
-    assertThat(headers.containsKey(OVERWRITE_KEY)).isFalse();
-    assertThat(headers.containsKey(ADD_KEY)).isFalse();
-    assertThat(headers.containsKey(OVERWRITE_IF_EXISTS_KEY)).isFalse();
+    assertThat(headers.get(NEW_ADD_KEY)).isEqualTo("");
+    assertThat(headers.getAll(APPEND_KEY)).containsExactly("existing-value", "");
+    assertThat(headers.get(OVERWRITE_KEY)).isEqualTo("");
+    assertThat(headers.get(ADD_KEY)).isEqualTo("");
+    assertThat(headers.get(OVERWRITE_IF_EXISTS_KEY)).isEqualTo("");
 
     Metadata.Key<String> keepEmptyKey =
         Metadata.Key.of("keep-empty-key", Metadata.ASCII_STRING_MARSHALLER);
     Metadata.Key<String> keepEmptyOverwriteKey =
         Metadata.Key.of("keep-empty-overwrite-key", Metadata.ASCII_STRING_MARSHALLER);
 
-    assertThat(headers.containsKey(keepEmptyKey)).isFalse();
-    assertThat(headers.containsKey(keepEmptyOverwriteKey)).isFalse();
+    assertThat(headers.get(keepEmptyKey)).isEqualTo("");
+    assertThat(headers.get(keepEmptyOverwriteKey)).isEqualTo("");
 
     Metadata.Key<byte[]> keepEmptyBinKey =
         Metadata.Key.of("keep-empty-bin-key-bin", Metadata.BINARY_BYTE_MARSHALLER);
     Metadata.Key<byte[]> ignoreEmptyBinKey =
         Metadata.Key.of("ignore-empty-bin-key-bin", Metadata.BINARY_BYTE_MARSHALLER);
 
-    assertThat(headers.containsKey(keepEmptyBinKey)).isFalse();
-    assertThat(headers.containsKey(ignoreEmptyBinKey)).isFalse();
-    assertThat(headers.containsKey(overwriteEmptyBinKey)).isFalse();
+    assertThat(headers.get(keepEmptyBinKey)).isEqualTo(new byte[0]);
+    assertThat(headers.get(ignoreEmptyBinKey)).isEqualTo(new byte[0]);
+    assertThat(headers.get(overwriteEmptyBinKey)).isEqualTo(new byte[0]);
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/internal/headermutations/HeaderMutatorTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/headermutations/HeaderMutatorTest.java
@@ -73,7 +73,7 @@ public class HeaderMutatorTest {
   }
 
   private static HeaderValueOption header(String key, String value, HeaderAppendAction action) {
-    return HeaderValueOption.create(HeaderValue.create(key, value), action, false);
+    return HeaderValueOption.create(HeaderValue.create(key, value), action);
   }
 
   @Test
@@ -147,8 +147,7 @@ public class HeaderMutatorTest {
     HeaderValueOption option =
         HeaderValueOption.create(
             HeaderValue.create(BINARY_KEY.name(), ByteString.copyFrom(value)),
-            HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD,
-            false);
+            HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD);
     headerMutator.applyMutations(
         HeaderMutations.create(ImmutableList.of(option), ImmutableList.of()), headers);
     assertThat(headers.get(BINARY_KEY)).isEqualTo(value);
@@ -195,8 +194,7 @@ public class HeaderMutatorTest {
     HeaderValueOption option =
         HeaderValueOption.create(
             HeaderValue.create(BINARY_KEY.name(), ByteString.copyFrom(value)),
-            HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD,
-            false);
+            HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD);
     headerMutator.applyMutations(
         HeaderMutations.create(ImmutableList.of(option), ImmutableList.of()), headers);
     assertThat(headers.get(BINARY_KEY)).isEqualTo(value);
@@ -219,21 +217,19 @@ public class HeaderMutatorTest {
                 header(OVERWRITE_IF_EXISTS_KEY.name(), "", HeaderAppendAction.OVERWRITE_IF_EXISTS),
                     HeaderValueOption.create(
                     HeaderValue.create("keep-empty-key", ""),
-                    HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD,
-                    true),
+                    HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD),
                 HeaderValueOption.create(
                     HeaderValue.create("keep-empty-overwrite-key", ""),
-                    HeaderAppendAction.OVERWRITE_IF_EXISTS_OR_ADD,
-                    true),
+                    HeaderAppendAction.OVERWRITE_IF_EXISTS_OR_ADD),
                     HeaderValueOption.create(
                     HeaderValue.create("keep-empty-bin-key-bin", ByteString.EMPTY),
-                    HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD, true),
+                    HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD),
                 HeaderValueOption.create(
                     HeaderValue.create("ignore-empty-bin-key-bin", ByteString.EMPTY),
-                    HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD, false),
+                    HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD),
                 HeaderValueOption.create(
                     HeaderValue.create("overwrite-empty-bin-key-bin", ByteString.EMPTY),
-                    HeaderAppendAction.OVERWRITE_IF_EXISTS_OR_ADD, false)),
+                    HeaderAppendAction.OVERWRITE_IF_EXISTS_OR_ADD)),
             ImmutableList.of());
 
     headers.put(
@@ -287,7 +283,7 @@ public class HeaderMutatorTest {
   public void applyMutations_stringValueWithBinaryKey_ignored() {
     Metadata headers = new Metadata();
     HeaderValueOption option = HeaderValueOption.create(HeaderValue.create("some-key-bin", "value"),
-        HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD, false);
+        HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD);
 
     headerMutator.applyMutations(
         HeaderMutations.create(ImmutableList.of(option), ImmutableList.of()), headers);
@@ -301,7 +297,7 @@ public class HeaderMutatorTest {
     Metadata headers = new Metadata();
     HeaderValueOption option = HeaderValueOption.create(
         HeaderValue.create("some-key", ByteString.copyFrom(new byte[] {1})),
-        HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD, false);
+        HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD);
 
     headerMutator.applyMutations(
         HeaderMutations.create(ImmutableList.of(option), ImmutableList.of()), headers);

--- a/xds/src/test/java/io/grpc/xds/internal/headermutations/HeaderValueOptionTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/headermutations/HeaderValueOptionTest.java
@@ -31,10 +31,9 @@ public class HeaderValueOptionTest {
   public void create_withAllFields_success() {
     HeaderValue header = HeaderValue.create("key1", "value1");
     HeaderValueOption option = HeaderValueOption.create(
-        header, HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD, true);
+        header, HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD);
 
     assertThat(option.header()).isEqualTo(header);
     assertThat(option.appendAction()).isEqualTo(HeaderAppendAction.APPEND_IF_EXISTS_OR_ADD);
-    assertThat(option.keepEmptyValue()).isTrue();
   }
 }


### PR DESCRIPTION
In GrpcService/ext_proc header mutations, we do not support the `keep_empty_value` field (https://github.com/grpc/proposal/pull/510/changes/f6d42d67dd7b80304eee1b29084d9b9af0b2feae). If any header mutation results in a header containing an empty value (either string or binary), we proceed with the empty value.