### PR TITLE
Fix grpc tests issue with upcoming JDK versions

### DIFF
--- a/util/src/test/java/io/grpc/util/AdvancedTlsX509TrustManagerTest.java
+++ b/util/src/test/java/io/grpc/util/AdvancedTlsX509TrustManagerTest.java
@@ -44,6 +44,7 @@ import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocket;
 import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 import org.junit.Before;
@@ -161,6 +162,7 @@ public class AdvancedTlsX509TrustManagerTest {
     SSLSocket sslSocket = mock(SSLSocket.class);
     when(sslSocket.isConnected()).thenReturn(true);
     when(sslSocket.getHandshakeSession()).thenReturn(null);
+    when(sslSocket.getSSLParameters()).thenReturn(new SSLParameters());
     CertificateException ce = assertThrows(CertificateException.class, () -> trustManager
         .checkClientTrusted(serverCert0, "RSA", sslSocket));
     assertEquals("No handshake session", ce.getMessage());

--- a/xds/src/test/java/io/grpc/xds/internal/security/trust/XdsX509TrustManagerTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/trust/XdsX509TrustManagerTest.java
@@ -27,6 +27,7 @@ import static io.grpc.xds.internal.security.CommonTlsContextTestsUtil.SERVER_1_P
 import static io.grpc.xds.internal.security.CommonTlsContextTestsUtil.SERVER_1_SPIFFE_PEM_FILE;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -553,7 +554,7 @@ public class XdsX509TrustManagerTest {
     X509Certificate[] serverCerts =
         CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
     trustManager.checkServerTrusted(serverCerts, "ECDHE_ECDSA", sslEngine);
-    verify(sslEngine, times(1)).getHandshakeSession();
+    verify(sslEngine, atLeastOnce()).getHandshakeSession();
     assertThat(sslEngine.getSSLParameters().getEndpointIdentificationAlgorithm()).isEmpty();
   }
 


### PR DESCRIPTION
* Stub SSLParameters to avoid NullPointerException
* JDK 28's X509TrustManagerImpl retrieves handshake session multiple times