### PR TITLE
buildscripts: add regional td config for psm-interop (v1.82.x backport)

### DIFF
--- a/buildscripts/kokoro/psm-regional_td.cfg
+++ b/buildscripts/kokoro/psm-regional_td.cfg
@@ -1,0 +1,17 @@
+# Config file for internal CI
+
+# Location of the continuous shell script in repository.
+build_file: "grpc-java/buildscripts/kokoro/psm-interop-test-java.sh"
+timeout_mins: 30
+
+action {
+  define_artifacts {
+    regex: "artifacts/**/*sponge_log.xml"
+    regex: "artifacts/**/*.log"
+    strip_prefix: "artifacts"
+  }
+}
+env_vars {
+  key: "PSM_TEST_SUITE"
+  value: "regional_td"
+}


### PR DESCRIPTION
Backport of #12833 to v1.82.x.
---
null