### PR TITLE
kokoro: Avoid brew on Mac OS (v1.80.x backport)

### DIFF
--- a/buildscripts/kokoro/macos.sh
+++ b/buildscripts/kokoro/macos.sh
@@ -12,6 +12,9 @@ DOWNLOAD_DIR=/tmp/source
 mkdir -p ${DOWNLOAD_DIR}
 curl -Ls https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-macos-universal.tar.gz | tar xz -C ${DOWNLOAD_DIR}
 
+curl -Ls https://archive.apache.org/dist/maven/maven-3/3.8.8/binaries/apache-maven-3.8.8-bin.tar.gz |
+    tar xz -C "${DOWNLOAD_DIR}"
+
 # We had problems with random tests timing out because it took seconds to do
 # trivial (ns) operations. The Kokoro Mac machines have 2 cores with 4 logical
 # threads, so Gradle should be using 4 workers by default.
@@ -20,9 +23,7 @@ export GRADLE_FLAGS="${GRADLE_FLAGS:-} --max-workers=2"
 . "$GRPC_JAVA_DIR"/buildscripts/kokoro/kokoro.sh
 trap spongify_logs EXIT
 
-brew install --cask temurin@8
-export PATH="$(/usr/libexec/java_home -v"1.8.0")/bin:${DOWNLOAD_DIR}/cmake-${CMAKE_VERSION}-macos-universal/CMake.app/Contents/bin:${PATH}"
-export JAVA_HOME="$(/usr/libexec/java_home -v"1.8.0")"
-brew install maven
+export PATH="/Library/Java/JavaVirtualMachines/jdk-11-latest/Contents/Home/bin:${DOWNLOAD_DIR}/cmake-${CMAKE_VERSION}-macos-universal/CMake.app/Contents/bin:${DOWNLOAD_DIR}/apache-maven-3.8.8/bin:${PATH}"
+unset JAVA_HOME
 
-"$GRPC_JAVA_DIR"/buildscripts/kokoro/unix.sh
+ARCH=aarch_64 "$GRPC_JAVA_DIR"/buildscripts/kokoro/unix.sh

--- a/buildscripts/kokoro/upload_artifacts.sh
+++ b/buildscripts/kokoro/upload_artifacts.sh
@@ -41,9 +41,9 @@ LOCAL_OTHER_ARTIFACTS="$KOKORO_GFILE_DIR"/github/grpc-java/artifacts/
 [[ "$(find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'protoc-gen-grpc-java-*-linux-s390_64.exe' | wc -l)" != '0' ]]
 
 # from macos job:
-[[ "$(find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'protoc-gen-grpc-java-*-osx-x86_64.exe' | wc -l)" != '0' ]]
-# copy all x86 artifacts to aarch until native artifacts are built
-find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'protoc-gen-grpc-java-*-osx-x86_64.exe*' -exec bash -c 'cp "${0}" "${0/x86/aarch}"' {} \;
+[[ "$(find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'protoc-gen-grpc-java-*-osx-aarch_64.exe' | wc -l)" != '0' ]]
+# copy the universal binaries to x86, as they work on both architectures
+find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'protoc-gen-grpc-java-*-osx-aarch_64.exe*' -exec bash -c 'cp "${0}" "${0/aarch/x86/}"' {} \;
 
 # from windows job:
 [[ "$(find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'protoc-gen-grpc-java-*-windows-x86_64.exe' | wc -l)" != '0' ]]


### PR DESCRIPTION
Backport of #12846 to v1.80.x.
---
brew is failing with "Error: undefined method 'first' for nil" when trying to upgrade itself. We already use Java 11 on other platforms, and it is already available on the Kokoro machines. We swap to download Maven just like we do for Linux, so then we can avoid brew entirely.

However, the pre-installed Java is an arm build whereas the brew install was x86. So now the examples try to use
protoc-gen-grpc-java-1.82.0-SNAPSHOT-osx-aarch_64.exe which don't exist because we used the default ARCH of x86_64. So now we also need to swap the primary platform on OS X to aarch_64 and copy the x86_64 binaries from that.

CC @shivaspeaks, feel free to review, since you worked on the universal binaries