### PR TITLE
kokoro: Remove extra / in architecture replacement (1.82.x backport)

### DIFF
--- a/buildscripts/kokoro/upload_artifacts.sh
+++ b/buildscripts/kokoro/upload_artifacts.sh
@@ -43,7 +43,7 @@ LOCAL_OTHER_ARTIFACTS="$KOKORO_GFILE_DIR"/github/grpc-java/artifacts/
 # from macos job:
 [[ "$(find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'protoc-gen-grpc-java-*-osx-aarch_64.exe' | wc -l)" != '0' ]]
 # copy the universal binaries to x86, as they work on both architectures
-find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'protoc-gen-grpc-java-*-osx-aarch_64.exe*' -exec bash -c 'cp "${0}" "${0/aarch/x86/}"' {} \;
+find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'protoc-gen-grpc-java-*-osx-aarch_64.exe*' -exec bash -c 'cp "${0}" "${0/aarch/x86}"' {} \;
 
 # from windows job:
 [[ "$(find "$LOCAL_MVN_ARTIFACTS" -type f -iname 'protoc-gen-grpc-java-*-windows-x86_64.exe' | wc -l)" != '0' ]]


### PR DESCRIPTION
The trailing slash was accidentally introduced in 10d901d64 when reversing the replacement order. The slash causes the new file name to have an extra directory in it, which doesn't exist, so the copy command then fails.

Fixes #12862

CC @zxuanhong

Backport of #12877