### PR TITLE
xds: Refactor to allow common code usage between the ext_proc client and server interceptors

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ExternalProcessorClientInterceptor.java
+++ b/xds/src/main/java/io/grpc/xds/ExternalProcessorClientInterceptor.java
@@ -17,22 +17,24 @@
 package io.grpc.xds;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.grpc.xds.internal.extproc.ExternalProcessorUtil.applyHeaderMutations;
+import static io.grpc.xds.internal.extproc.ExternalProcessorUtil.collectAttributes;
+import static io.grpc.xds.internal.extproc.ExternalProcessorUtil.markDataPlaneCallClosed;
+import static io.grpc.xds.internal.extproc.ExternalProcessorUtil.markExtProcStreamCompleted;
+import static io.grpc.xds.internal.extproc.ExternalProcessorUtil.markExtProcStreamFailed;
+import static io.grpc.xds.internal.extproc.ExternalProcessorUtil.outboundStreamToByteString;
+import static io.grpc.xds.internal.extproc.ExternalProcessorUtil.toHeaderMap;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.BaseEncoding;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Struct;
-import com.google.protobuf.Value;
-import io.envoyproxy.envoy.config.core.v3.HeaderMap;
 import io.envoyproxy.envoy.extensions.filters.http.ext_proc.v3.ProcessingMode;
 import io.envoyproxy.envoy.service.ext_proc.v3.BodyMutation;
 import io.envoyproxy.envoy.service.ext_proc.v3.BodyResponse;
 import io.envoyproxy.envoy.service.ext_proc.v3.CommonResponse;
 import io.envoyproxy.envoy.service.ext_proc.v3.ExternalProcessorGrpc;
-import io.envoyproxy.envoy.service.ext_proc.v3.HeaderMutation;
 import io.envoyproxy.envoy.service.ext_proc.v3.HttpBody;
 import io.envoyproxy.envoy.service.ext_proc.v3.HttpHeaders;
 import io.envoyproxy.envoy.service.ext_proc.v3.HttpTrailers;
@@ -48,10 +50,8 @@ import io.grpc.ClientInterceptor;
 import io.grpc.Context;
 import io.grpc.Deadline;
 import io.grpc.DoubleHistogramMetricInstrument;
-import io.grpc.Drainable;
 import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
 import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
-import io.grpc.KnownLength;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -60,27 +60,24 @@ import io.grpc.MetricRecorder;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.internal.DelayedClientCall;
-import io.grpc.internal.GrpcUtil;
 import io.grpc.internal.SerializingExecutor;
 import io.grpc.stub.ClientCallStreamObserver;
 import io.grpc.stub.ClientResponseObserver;
 import io.grpc.xds.ExternalProcessorFilter.ExternalProcessorFilterConfig;
-import io.grpc.xds.ExternalProcessorFilter.HeaderForwardingRulesConfig;
 import io.grpc.xds.Filter.FilterContext;
+import io.grpc.xds.internal.extproc.DataPlaneCallState;
+import io.grpc.xds.internal.extproc.EventType;
+import io.grpc.xds.internal.extproc.ExtProcStreamState;
+import io.grpc.xds.internal.extproc.KnownLengthInputStream;
 import io.grpc.xds.internal.grpcservice.CachedChannelManager;
 import io.grpc.xds.internal.grpcservice.HeaderValue;
-import io.grpc.xds.internal.grpcservice.HeaderValueValidationUtils;
 import io.grpc.xds.internal.headermutations.HeaderMutationDisallowedException;
 import io.grpc.xds.internal.headermutations.HeaderMutationFilter;
 import io.grpc.xds.internal.headermutations.HeaderMutationRulesConfig;
-import io.grpc.xds.internal.headermutations.HeaderMutations;
 import io.grpc.xds.internal.headermutations.HeaderMutator;
-import io.grpc.xds.internal.headermutations.HeaderValueOption;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -98,16 +95,14 @@ import javax.annotation.Nullable;
  */
 final class ExternalProcessorClientInterceptor implements ClientInterceptor {
 
-
-
   @VisibleForTesting
-  static final DoubleHistogramMetricInstrument clientHeadersDuration;
+  static DoubleHistogramMetricInstrument clientHeadersDuration;
   @VisibleForTesting
-  static final DoubleHistogramMetricInstrument clientHalfCloseDuration;
+  static DoubleHistogramMetricInstrument clientHalfCloseDuration;
   @VisibleForTesting
-  static final DoubleHistogramMetricInstrument serverHeadersDuration;
+  static DoubleHistogramMetricInstrument serverHeadersDuration;
   @VisibleForTesting
-  static final DoubleHistogramMetricInstrument serverTrailersDuration;
+  static DoubleHistogramMetricInstrument serverTrailersDuration;
 
   // Copied from io.grpc.opentelemetry.internal.OpenTelemetryConstants.LATENCY_BUCKETS
   private static final List<Double> LATENCY_BUCKETS = ImmutableList.of(
@@ -118,53 +113,54 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
       5d,     10d,      20d,      50d,     100d);
 
   static {
-    if (GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_CLIENT", false)) {
-      MetricInstrumentRegistry registry = MetricInstrumentRegistry.getDefaultRegistry();
+    initMetricInstruments();
+  }
 
-      clientHeadersDuration = registry.registerDoubleHistogram(
-          "grpc.client_ext_proc.client_headers_duration",
-          "Time between when the ext_proc filter sees the client's headers and when "
-              + "it allows those headers to continue on to the next filter",
-          "s",
-          LATENCY_BUCKETS,
-          ImmutableList.of("grpc.target"),
-          ImmutableList.of("grpc.lb.backend_service"),
-          true);
+  static synchronized void initMetricInstruments() {
+    if (io.grpc.internal.GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_CLIENT", false)) {
+      if (clientHeadersDuration == null) {
+        MetricInstrumentRegistry registry = MetricInstrumentRegistry.getDefaultRegistry();
 
-      clientHalfCloseDuration = registry.registerDoubleHistogram(
-          "grpc.client_ext_proc.client_half_close_duration",
-          "Time between when the ext_proc filter sees the client's half-close and when "
-              + "it allows that half-close to continue on to the next filter",
-          "s",
-          LATENCY_BUCKETS,
-          ImmutableList.of("grpc.target"),
-          ImmutableList.of("grpc.lb.backend_service"),
-          true);
+        clientHeadersDuration = registry.registerDoubleHistogram(
+            "grpc.client_ext_proc.client_headers_duration",
+            "Time between when the ext_proc filter sees the client's headers and when "
+                + "it allows those headers to continue on to the next filter",
+            "s",
+            LATENCY_BUCKETS,
+            ImmutableList.of("grpc.target"),
+            ImmutableList.of("grpc.lb.backend_service"),
+            true);
 
-      serverHeadersDuration = registry.registerDoubleHistogram(
-          "grpc.client_ext_proc.server_headers_duration",
-          "Time between when the ext_proc filter sees the server's headers and when "
-              + "it allows those headers to continue on to the next filter",
-          "s",
-          LATENCY_BUCKETS,
-          ImmutableList.of("grpc.target"),
-          ImmutableList.of("grpc.lb.backend_service"),
-          true);
+        clientHalfCloseDuration = registry.registerDoubleHistogram(
+            "grpc.client_ext_proc.client_half_close_duration",
+            "Time between when the ext_proc filter sees the client's half-close and when "
+                + "it allows that half-close to continue on to the next filter",
+            "s",
+            LATENCY_BUCKETS,
+            ImmutableList.of("grpc.target"),
+            ImmutableList.of("grpc.lb.backend_service"),
+            true);
 
-      serverTrailersDuration = registry.registerDoubleHistogram(
-          "grpc.client_ext_proc.server_trailers_duration",
-          "Time between when the ext_proc filter sees the server's trailers and when "
-              + "it allows those trailers to continue on to the next filter",
-          "s",
-          LATENCY_BUCKETS,
-          ImmutableList.of("grpc.target"),
-          ImmutableList.of("grpc.lb.backend_service"),
-          true);
-    } else {
-      clientHeadersDuration = null;
-      clientHalfCloseDuration = null;
-      serverHeadersDuration = null;
-      serverTrailersDuration = null;
+        serverHeadersDuration = registry.registerDoubleHistogram(
+            "grpc.client_ext_proc.server_headers_duration",
+            "Time between when the ext_proc filter sees the server's headers and when "
+                + "it allows those headers to continue on to the next filter",
+            "s",
+            LATENCY_BUCKETS,
+            ImmutableList.of("grpc.target"),
+            ImmutableList.of("grpc.lb.backend_service"),
+            true);
+
+        serverTrailersDuration = registry.registerDoubleHistogram(
+            "grpc.client_ext_proc.server_trailers_duration",
+            "Time between when the ext_proc filter sees the server's trailers and when "
+                + "it allows those trailers to continue on to the next filter",
+            "s",
+            LATENCY_BUCKETS,
+            ImmutableList.of("grpc.target"),
+            ImmutableList.of("grpc.lb.backend_service"),
+            true);
+      }
     }
   }
 
@@ -259,137 +255,6 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
   }
 
   // --- SHARED UTILITY METHODS ---
-  private static HeaderMap toHeaderMap(
-      Metadata metadata, Optional<HeaderForwardingRulesConfig> forwardRules) {
-    HeaderMap.Builder builder =
-        HeaderMap.newBuilder();
-
-    for (String key : metadata.keys()) {
-      if (forwardRules.isPresent() && !forwardRules.get().isAllowed(key)) {
-        continue;
-      }
-      // Map binary headers using raw_value
-      if (key.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
-        Metadata.Key<byte[]> binKey = Metadata.Key.of(key, Metadata.BINARY_BYTE_MARSHALLER);
-        Iterable<byte[]> values = metadata.getAll(binKey);
-        if (values != null) {
-          for (byte[] binValue : values) {
-            String base64Value = BaseEncoding.base64().encode(binValue);
-            io.envoyproxy.envoy.config.core.v3.HeaderValue headerValue =
-                io.envoyproxy.envoy.config.core.v3.HeaderValue.newBuilder()
-                    .setKey(key.toLowerCase(Locale.ROOT))
-                    .setRawValue(ByteString.copyFromUtf8(base64Value))
-                    .build();
-            builder.addHeaders(headerValue);
-          }
-        }
-      } else {
-        Metadata.Key<String> asciiKey = Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER);
-        Iterable<String> values = metadata.getAll(asciiKey);
-        if (values != null) {
-          for (String value : values) {
-            io.envoyproxy.envoy.config.core.v3.HeaderValue headerValue =
-                io.envoyproxy.envoy.config.core.v3.HeaderValue.newBuilder()
-                    .setKey(key.toLowerCase(Locale.ROOT))
-                    .setRawValue(ByteString.copyFromUtf8(value))
-                    .build();
-            builder.addHeaders(headerValue);
-          }
-        }
-      }
-    }
-    return builder.build();
-  }
-
-  private static ImmutableMap<String, Struct> collectAttributes(
-      ImmutableList<String> requestedAttributes,
-      MethodDescriptor<?, ?> method,
-      Channel channel,
-      Metadata headers) {
-    if (requestedAttributes.isEmpty()) {
-      return ImmutableMap.of();
-    }
-    ImmutableMap.Builder<String, Struct> attributes = ImmutableMap.builder();
-    for (String attr : requestedAttributes) {
-      switch (attr) {
-        case "request.path":
-        case "request.url_path":
-          attributes.put(attr, encodeAttribute("/" + method.getFullMethodName()));
-          break;
-        case "request.host":
-          attributes.put(attr, encodeAttribute(channel.authority()));
-          break;
-        case "request.method":
-          attributes.put(attr, encodeAttribute("POST"));
-          break;
-        case "request.headers":
-          attributes.put(attr, encodeHeaders(headers));
-          break;
-        case "request.referer":
-          String referer = getHeaderValue(headers, "referer");
-          if (referer != null) {
-            attributes.put(attr, encodeAttribute(referer));
-          }
-          break;
-        case "request.useragent":
-          String ua = getHeaderValue(headers, "user-agent");
-          if (ua != null) {
-            attributes.put(attr, encodeAttribute(ua));
-          }
-          break;
-        case "request.id":
-          String id = getHeaderValue(headers, "x-request-id");
-          if (id != null) {
-            attributes.put(attr, encodeAttribute(id));
-          }
-          break;
-        case "request.query":
-          attributes.put(attr, encodeAttribute(""));
-          break;
-        default:
-          // "Not set" attributes or unrecognized ones (already validated) are skipped.
-          break;
-      }
-    }
-    return attributes.buildOrThrow();
-  }
-
-  private static Struct encodeAttribute(String value) {
-    return Struct.newBuilder()
-        .putFields("", Value.newBuilder().setStringValue(value).build())
-        .build();
-  }
-
-  private static Struct encodeHeaders(Metadata headers) {
-    Struct.Builder builder = Struct.newBuilder();
-    for (String key : headers.keys()) {
-      String value = getHeaderValue(headers, key);
-      if (value != null) {
-        builder.putFields(key.toLowerCase(Locale.ROOT),
-            Value.newBuilder().setStringValue(value).build());
-      }
-    }
-    return builder.build();
-  }
-
-  @Nullable
-  private static String getHeaderValue(Metadata headers, String headerName) {
-    if (headerName.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
-      Metadata.Key<byte[]> key = Metadata.Key.of(headerName, Metadata.BINARY_BYTE_MARSHALLER);
-      Iterable<byte[]> values = headers.getAll(key);
-      if (values == null) {
-        return null;
-      }
-      List<String> encoded = new ArrayList<>();
-      for (byte[] v : values) {
-        encoded.add(BaseEncoding.base64().omitPadding().encode(v));
-      }
-      return Joiner.on(",").join(encoded);
-    }
-    Metadata.Key<String> key = Metadata.Key.of(headerName, Metadata.ASCII_STRING_MARSHALLER);
-    Iterable<String> values = headers.getAll(key);
-    return values == null ? null : Joiner.on(",").join(values);
-  }
 
   /**
    * A local subclass to expose the protected constructor of DelayedClientCall.
@@ -407,38 +272,6 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
    */
   private static class DataPlaneClientCall 
       extends SimpleForwardingClientCall<InputStream, InputStream> {
-    enum ExtProcStreamState {
-      ACTIVE,
-      DRAINING,
-      COMPLETED,
-      FAILED;
-
-      boolean isCompleted() {
-        return this == COMPLETED || this == FAILED;
-      }
-
-      boolean isFailed() {
-        return this == FAILED;
-      }
-
-      boolean isDraining() {
-        return this == DRAINING;
-      }
-    }
-
-    enum DataPlaneCallState {
-      IDLE,
-      ACTIVE,
-      CLOSED
-    }
-
-    private enum EventType {
-      REQUEST_HEADERS,
-      REQUEST_BODY,
-      RESPONSE_HEADERS,
-      RESPONSE_BODY,
-      RESPONSE_TRAILERS
-    }
 
     private final ExternalProcessorGrpc.ExternalProcessorStub stub;
     private final ExternalProcessorFilterConfig config;
@@ -511,41 +344,6 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
     }
 
 
-    boolean markExtProcStreamCompleted() {
-      while (true) {
-        ExtProcStreamState current = extProcStreamState.get();
-        if (current == ExtProcStreamState.COMPLETED || current == ExtProcStreamState.FAILED) {
-          return false;
-        }
-        if (extProcStreamState.compareAndSet(current, ExtProcStreamState.COMPLETED)) {
-          return true;
-        }
-      }
-    }
-
-    boolean markExtProcStreamFailed() {
-      while (true) {
-        ExtProcStreamState current = extProcStreamState.get();
-        if (current == ExtProcStreamState.COMPLETED || current == ExtProcStreamState.FAILED) {
-          return false;
-        }
-        if (extProcStreamState.compareAndSet(current, ExtProcStreamState.FAILED)) {
-          return true;
-        }
-      }
-    }
-
-    boolean markDataPlaneCallClosed() {
-      while (true) {
-        DataPlaneCallState current = dataPlaneCallState.get();
-        if (current == DataPlaneCallState.CLOSED) {
-          return false;
-        }
-        if (dataPlaneCallState.compareAndSet(current, DataPlaneCallState.CLOSED)) {
-          return true;
-        }
-      }
-    }
 
     private void activateCall() {
       if ((extProcStreamState.get() == ExtProcStreamState.FAILED
@@ -604,7 +402,7 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
             }
           }
           activateCall();
-          markExtProcStreamFailed();
+          markExtProcStreamFailed(extProcStreamState);
           delayedCall.cancel("gRPC message compression not supported in ext_proc", ex);
           closeExtProcStream();
           return false;
@@ -613,54 +411,7 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
       return true;
     }
 
-    private void applyHeaderMutations(Metadata metadata,
-        HeaderMutation mutation)
-        throws HeaderMutationDisallowedException {
-      if (metadata == null) {
-        return;
-      }
-      ImmutableList.Builder<HeaderValueOption> headersToModify = ImmutableList.builder();
-      for (io.envoyproxy.envoy.config.core.v3.HeaderValueOption protoOption
-          : mutation.getSetHeadersList()) {
-        io.envoyproxy.envoy.config.core.v3.HeaderValue protoHeader = protoOption.getHeader();
-        String key = protoHeader.getKey();
-        HeaderValueValidationUtils.validateHeaderKey(key);
 
-        ByteString rawBytes = protoHeader.getRawValue();
-        if (rawBytes.isEmpty()) {
-          rawBytes = ByteString.copyFromUtf8(protoHeader.getValue());
-        }
-
-        if (rawBytes.size() > HeaderValueValidationUtils.MAX_HEADER_LENGTH) {
-          throw new IllegalArgumentException(
-              "Header value length exceeds maximum allowed length: " + rawBytes.size());
-        }
-
-        HeaderValue headerValue;
-        if (key.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
-          byte[] decodedBytes = BaseEncoding.base64().decode(rawBytes.toStringUtf8());
-          headerValue = HeaderValue.create(key, ByteString.copyFrom(decodedBytes));
-        } else {
-          headerValue = HeaderValue.create(key, rawBytes.toStringUtf8());
-        }
-        headersToModify.add(HeaderValueOption.create(
-            headerValue,
-            HeaderValueOption.HeaderAppendAction.valueOf(protoOption.getAppendAction().name())));
-      }
-
-      ImmutableList.Builder<String> headersToRemove = ImmutableList.builder();
-      for (String headerToRemove : mutation.getRemoveHeadersList()) {
-        HeaderValueValidationUtils.validateHeaderKey(headerToRemove);
-        headersToRemove.add(headerToRemove);
-      }
-
-      HeaderMutations mutations = HeaderMutations.create(
-          headersToModify.build(),
-          headersToRemove.build());
-
-      HeaderMutations filteredMutations = mutationFilter.filter(mutations);
-      mutator.applyMutations(filteredMutations, metadata);
-    }
 
     @Override
     public void start(Listener<InputStream> responseListener, Metadata headers) {
@@ -768,7 +519,9 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
                 }
                 applyHeaderMutations(
                     requestHeaders,
-                    response.getRequestHeaders().getResponse().getHeaderMutation());
+                    response.getRequestHeaders().getResponse().getHeaderMutation(),
+                    mutationFilter,
+                    mutator);
               }
               activateCall();
             }
@@ -791,7 +544,10 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
                 Metadata target = wrappedListener.isTrailersOnly()
                     ? wrappedListener.getSavedTrailers() : wrappedListener.getSavedHeaders();
                 applyHeaderMutations(
-                    target, response.getResponseHeaders().getResponse().getHeaderMutation());
+                    target,
+                    response.getResponseHeaders().getResponse().getHeaderMutation(),
+                    mutationFilter,
+                    mutator);
               }
               if (wrappedListener.isTrailersOnly()) {
                 wrappedListener.proceedWithClose();
@@ -810,8 +566,9 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
               if (response.getResponseTrailers().hasHeaderMutation()) {
                 applyHeaderMutations(
                     wrappedListener.getSavedTrailers(),
-                    response.getResponseTrailers().getHeaderMutation()
-                );
+                    response.getResponseTrailers().getHeaderMutation(),
+                    mutationFilter,
+                    mutator);
               }
               wrappedListener.proceedWithClose();
             }
@@ -824,7 +581,7 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
 
         @Override
         public void onError(Throwable t) {
-          if (markExtProcStreamFailed()) {
+          if (markExtProcStreamFailed(extProcStreamState)) {
             synchronized (streamLock) {
               extProcClientCallRequestObserver = null;
             }
@@ -841,14 +598,14 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
 
         @Override
         public void onCompleted() {
-          if (markExtProcStreamCompleted()) {
+          if (markExtProcStreamCompleted(extProcStreamState)) {
             handleFailOpen(wrappedListener);
           }
         }
       });
 
       this.collectedAttributes = collectAttributes(
-          config.getRequestAttributes(), method, channel, headers);
+          config.getRequestAttributes(), method, channel.authority(), headers);
 
       boolean sendRequestHeaders =
           currentProcessingMode.getRequestHeaderMode() == ProcessingMode.HeaderSendMode.SEND
@@ -930,7 +687,7 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
 
     private void closeExtProcStream() {
       synchronized (streamLock) {
-        if (markExtProcStreamCompleted()) {
+        if (markExtProcStreamCompleted(extProcStreamState)) {
           if (extProcClientCallRequestObserver != null) {
             extProcClientCallRequestObserver.onCompleted();
           }
@@ -939,7 +696,7 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
     }
 
     private void internalOnError(Throwable t) {
-      if (markExtProcStreamFailed()) {
+      if (markExtProcStreamFailed(extProcStreamState)) {
         synchronized (streamLock) {
           if (extProcClientCallRequestObserver != null) {
             try {
@@ -1165,7 +922,7 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
 
       Metadata trailers = new Metadata();
       if (immediate.hasHeaders()) {
-        applyHeaderMutations(trailers, immediate.getHeaders());
+        applyHeaderMutations(trailers, immediate.getHeaders(), mutationFilter, mutator);
       }
 
       listener.setImmediateResponse(status, trailers);
@@ -1395,20 +1152,20 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
     @Override
     public void onClose(Status status, Metadata trailers) {
       dataPlaneClientCall.setServerTrailersStartNanos(System.nanoTime());
-      DataPlaneClientCall.ExtProcStreamState extProcStreamState =
+      ExtProcStreamState extProcStreamState =
           dataPlaneClientCall.getExtProcStreamState().get();
       if (extProcStreamState.isFailed()
           && !dataPlaneClientCall.getConfig().getObservabilityMode()
           && (!dataPlaneClientCall.getConfig().getFailureModeAllow()
               || dataPlaneClientCall.bodyMessageSentToExtProc.get())) {
-        if (dataPlaneClientCall.markDataPlaneCallClosed()) {
+        if (markDataPlaneCallClosed(dataPlaneClientCall.dataPlaneCallState)) {
           proceedWithClose(Status.INTERNAL.withDescription("External processor stream failed")
               .withCause(status.getCause()), new Metadata());
         }
         return;
       }
       if (dataPlaneClientCall.getPassThroughMode().get()) {
-        if (dataPlaneClientCall.markDataPlaneCallClosed()) {
+        if (markDataPlaneCallClosed(dataPlaneClientCall.dataPlaneCallState)) {
           proceedWithClose(status, trailers);
         }
         return;
@@ -1479,7 +1236,7 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
 
     void proceedWithClose() {
       if (savedStatus != null) {
-        if (dataPlaneClientCall.markDataPlaneCallClosed()) {
+        if (markDataPlaneCallClosed(dataPlaneClientCall.dataPlaneCallState)) {
           proceedWithClose(savedStatus, savedTrailers);
         }
         savedStatus = null;
@@ -1591,48 +1348,6 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
       dataPlaneClientCall.sendToExtProc(ProcessingRequest.newBuilder()
           .setResponseBody(bodyBuilder.build())
           .build());
-    }
-  }
-
-
-
-  private static ByteString outboundStreamToByteString(InputStream message) throws IOException {
-    if (message instanceof Drainable) {
-      int size = message.available();
-      ByteString.Output output =
-          size > 0 ? ByteString.newOutput(size) : ByteString.newOutput();
-      ((Drainable) message).drainTo(output);
-      return output.toByteString();
-    }
-    return ByteString.readFrom(message);
-  }
-
-  private static final class KnownLengthInputStream extends InputStream
-      implements KnownLength {
-    private final InputStream delegate;
-
-    KnownLengthInputStream(ByteString byteString) {
-      this.delegate = byteString.newInput();
-    }
-
-    @Override
-    public int read() throws IOException {
-      return delegate.read();
-    }
-
-    @Override
-    public int read(byte[] b, int off, int len) throws IOException {
-      return delegate.read(b, off, len);
-    }
-
-    @Override
-    public int available() throws IOException {
-      return delegate.available();
-    }
-
-    @Override
-    public void close() throws IOException {
-      delegate.close();
     }
   }
 }

--- a/xds/src/main/java/io/grpc/xds/ExternalProcessorFilter.java
+++ b/xds/src/main/java/io/grpc/xds/ExternalProcessorFilter.java
@@ -29,14 +29,10 @@ import io.envoyproxy.envoy.config.core.v3.GrpcService;
 import io.envoyproxy.envoy.extensions.filters.http.ext_proc.v3.ExtProcOverrides;
 import io.envoyproxy.envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute;
 import io.envoyproxy.envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor;
-import io.envoyproxy.envoy.extensions.filters.http.ext_proc.v3.HeaderForwardingRules;
 import io.envoyproxy.envoy.extensions.filters.http.ext_proc.v3.ProcessingMode;
 import io.grpc.ClientInterceptor;
 import io.grpc.internal.GrpcUtil;
-import io.grpc.xds.Filter.FilterConfigParseContext;
-import io.grpc.xds.Filter.FilterContext;
-import io.grpc.xds.internal.MatcherParser;
-import io.grpc.xds.internal.Matchers;
+import io.grpc.xds.internal.HeaderForwardingRulesConfig;
 import io.grpc.xds.internal.grpcservice.CachedChannelManager;
 import io.grpc.xds.internal.grpcservice.GrpcServiceConfig;
 import io.grpc.xds.internal.grpcservice.GrpcServiceParseException;
@@ -44,7 +40,6 @@ import io.grpc.xds.internal.headermutations.HeaderMutationRulesConfig;
 import io.grpc.xds.internal.headermutations.HeaderMutationRulesParseException;
 import io.grpc.xds.internal.headermutations.HeaderMutationRulesParser;
 import java.util.List;
-import java.util.Locale;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -397,51 +392,5 @@ public class ExternalProcessorFilter implements Filter {
     }
   }
 
-  static final class HeaderForwardingRulesConfig {
-    private final ImmutableList<Matchers.StringMatcher> allowedHeaders;
-    private final ImmutableList<Matchers.StringMatcher> disallowedHeaders;
 
-    HeaderForwardingRulesConfig(
-        ImmutableList<Matchers.StringMatcher> allowedHeaders,
-        ImmutableList<Matchers.StringMatcher> disallowedHeaders) {
-      this.allowedHeaders = checkNotNull(allowedHeaders, "allowedHeaders");
-      this.disallowedHeaders = checkNotNull(disallowedHeaders, "disallowedHeaders");
-    }
-
-    static HeaderForwardingRulesConfig create(HeaderForwardingRules proto) {
-      ImmutableList<Matchers.StringMatcher> allowedHeaders = ImmutableList.of();
-      if (proto.hasAllowedHeaders()) {
-        allowedHeaders = MatcherParser.parseListStringMatcher(proto.getAllowedHeaders());
-      }
-      ImmutableList<Matchers.StringMatcher> disallowedHeaders = ImmutableList.of();
-      if (proto.hasDisallowedHeaders()) {
-        disallowedHeaders = MatcherParser.parseListStringMatcher(proto.getDisallowedHeaders());
-      }
-      return new HeaderForwardingRulesConfig(allowedHeaders, disallowedHeaders);
-    }
-
-    boolean isAllowed(String headerName) {
-      String lowerHeaderName = headerName.toLowerCase(Locale.ROOT);
-      if (!allowedHeaders.isEmpty()) {
-        boolean matched = false;
-        for (Matchers.StringMatcher matcher : allowedHeaders) {
-          if (matcher.matches(lowerHeaderName)) {
-            matched = true;
-            break;
-          }
-        }
-        if (!matched) {
-          return false;
-        }
-      }
-      if (!disallowedHeaders.isEmpty()) {
-        for (Matchers.StringMatcher matcher : disallowedHeaders) {
-          if (matcher.matches(lowerHeaderName)) {
-            return false;
-          }
-        }
-      }
-      return true;
-    }
-  }
 }

--- a/xds/src/main/java/io/grpc/xds/internal/HeaderForwardingRulesConfig.java
+++ b/xds/src/main/java/io/grpc/xds/internal/HeaderForwardingRulesConfig.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableList;
+import io.envoyproxy.envoy.extensions.filters.http.ext_proc.v3.HeaderForwardingRules;
+import java.util.Locale;
+
+/**
+ * Configuration for header forwarding rules in external processing.
+ */
+public final class HeaderForwardingRulesConfig {
+  private final ImmutableList<Matchers.StringMatcher> allowedHeaders;
+  private final ImmutableList<Matchers.StringMatcher> disallowedHeaders;
+
+  public HeaderForwardingRulesConfig(
+      ImmutableList<Matchers.StringMatcher> allowedHeaders,
+      ImmutableList<Matchers.StringMatcher> disallowedHeaders) {
+    this.allowedHeaders = checkNotNull(allowedHeaders, "allowedHeaders");
+    this.disallowedHeaders = checkNotNull(disallowedHeaders, "disallowedHeaders");
+  }
+
+  public static HeaderForwardingRulesConfig create(HeaderForwardingRules proto) {
+    ImmutableList<Matchers.StringMatcher> allowedHeaders = ImmutableList.of();
+    if (proto.hasAllowedHeaders()) {
+      allowedHeaders = MatcherParser.parseListStringMatcher(proto.getAllowedHeaders());
+    }
+    ImmutableList<Matchers.StringMatcher> disallowedHeaders = ImmutableList.of();
+    if (proto.hasDisallowedHeaders()) {
+      disallowedHeaders = MatcherParser.parseListStringMatcher(proto.getDisallowedHeaders());
+    }
+    return new HeaderForwardingRulesConfig(allowedHeaders, disallowedHeaders);
+  }
+
+  public boolean isAllowed(String headerName) {
+    String lowerHeaderName = headerName.toLowerCase(Locale.ROOT);
+    if (!allowedHeaders.isEmpty()) {
+      boolean matched = false;
+      for (Matchers.StringMatcher matcher : allowedHeaders) {
+        if (matcher.matches(lowerHeaderName)) {
+          matched = true;
+          break;
+        }
+      }
+      if (!matched) {
+        return false;
+      }
+    }
+    if (!disallowedHeaders.isEmpty()) {
+      for (Matchers.StringMatcher matcher : disallowedHeaders) {
+        if (matcher.matches(lowerHeaderName)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/internal/extproc/DataPlaneCallState.java
+++ b/xds/src/main/java/io/grpc/xds/internal/extproc/DataPlaneCallState.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds.internal.extproc;
+
+/**
+ * States of the call inside the data plane.
+ */
+public enum DataPlaneCallState {
+  IDLE,
+  ACTIVE,
+  CLOSED
+}

--- a/xds/src/main/java/io/grpc/xds/internal/extproc/EventType.java
+++ b/xds/src/main/java/io/grpc/xds/internal/extproc/EventType.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds.internal.extproc;
+
+/**
+ * The event type representing the phase of external processing.
+ */
+public enum EventType {
+  REQUEST_HEADERS,
+  REQUEST_BODY,
+  RESPONSE_HEADERS,
+  RESPONSE_BODY,
+  RESPONSE_TRAILERS
+}

--- a/xds/src/main/java/io/grpc/xds/internal/extproc/ExtProcStreamState.java
+++ b/xds/src/main/java/io/grpc/xds/internal/extproc/ExtProcStreamState.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds.internal.extproc;
+
+/**
+ * States of the stream with the external processor.
+ */
+public enum ExtProcStreamState {
+  ACTIVE,
+  DRAINING,
+  COMPLETED,
+  FAILED;
+
+  public boolean isCompleted() {
+    return this == COMPLETED || this == FAILED;
+  }
+
+  public boolean isFailed() {
+    return this == FAILED;
+  }
+
+  public boolean isDraining() {
+    return this == DRAINING;
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/internal/extproc/ExternalProcessorServerInterceptorMetricInstruments.java
+++ b/xds/src/main/java/io/grpc/xds/internal/extproc/ExternalProcessorServerInterceptorMetricInstruments.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2026 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds.internal.extproc;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import io.grpc.DoubleHistogramMetricInstrument;
+import io.grpc.MetricInstrumentRegistry;
+import io.grpc.internal.GrpcUtil;
+import java.util.List;
+
+/**
+ * Holds metric instrument definitions for server-side external processing.
+ */
+public final class ExternalProcessorServerInterceptorMetricInstruments {
+  @VisibleForTesting
+  public static DoubleHistogramMetricInstrument clientHeadersDuration;
+  @VisibleForTesting
+  public static DoubleHistogramMetricInstrument clientHalfCloseDuration;
+  @VisibleForTesting
+  public static DoubleHistogramMetricInstrument serverHeadersDuration;
+  @VisibleForTesting
+  public static DoubleHistogramMetricInstrument serverTrailersDuration;
+
+  // Copied from io.grpc.opentelemetry.internal.OpenTelemetryConstants.LATENCY_BUCKETS
+  private static final List<Double> LATENCY_BUCKETS = ImmutableList.of(
+      0d,     0.00001d, 0.00005d, 0.0001d, 0.0003d, 0.0006d, 0.0008d, 0.001d, 0.002d,
+      0.003d, 0.004d,   0.005d,   0.006d,  0.008d,  0.01d,   0.013d,  0.016d, 0.02d,
+      0.025d, 0.03d,    0.04d,    0.05d,   0.065d,  0.08d,   0.1d,    0.13d,  0.16d,
+      0.2d,   0.25d,    0.3d,     0.4d,    0.5d,    0.65d,   0.8d,    1d,     2d,
+      5d,     10d,      20d,      50d,     100d);
+
+  static {
+    initMetricInstruments();
+  }
+
+  public static synchronized void initMetricInstruments() {
+    if (GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_SERVER", false)) {
+      if (clientHeadersDuration == null) {
+        MetricInstrumentRegistry registry = MetricInstrumentRegistry.getDefaultRegistry();
+
+        clientHeadersDuration = registry.registerDoubleHistogram(
+            "grpc.server_ext_proc.client_headers_duration",
+            "Time between when the ext_proc filter sees the client's headers and when "
+                + "it allows those headers to continue on to the next filter",
+            "s",
+            LATENCY_BUCKETS,
+            ImmutableList.of(),
+            ImmutableList.of(),
+            true);
+
+        clientHalfCloseDuration = registry.registerDoubleHistogram(
+            "grpc.server_ext_proc.client_half_close_duration",
+            "Time between when the ext_proc filter sees the client's half-close and when "
+                + "it allows that half-close to continue on to the next filter",
+            "s",
+            LATENCY_BUCKETS,
+            ImmutableList.of(),
+            ImmutableList.of(),
+            true);
+
+        serverHeadersDuration = registry.registerDoubleHistogram(
+            "grpc.server_ext_proc.server_headers_duration",
+            "Time between when the ext_proc filter sees the server's headers and when "
+                + "it allows those headers to continue on to the next filter",
+            "s",
+            LATENCY_BUCKETS,
+            ImmutableList.of(),
+            ImmutableList.of(),
+            true);
+
+        serverTrailersDuration = registry.registerDoubleHistogram(
+            "grpc.server_ext_proc.server_trailers_duration",
+            "Time between when the ext_proc filter sees the server's trailers and when "
+                + "it allows those trailers to continue on to the next filter",
+            "s",
+            LATENCY_BUCKETS,
+            ImmutableList.of(),
+            ImmutableList.of(),
+            true);
+      }
+    }
+  }
+
+  private ExternalProcessorServerInterceptorMetricInstruments() {}
+}

--- a/xds/src/main/java/io/grpc/xds/internal/extproc/ExternalProcessorUtil.java
+++ b/xds/src/main/java/io/grpc/xds/internal/extproc/ExternalProcessorUtil.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright 2026 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds.internal.extproc;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.BaseEncoding;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Struct;
+import com.google.protobuf.Value;
+import io.envoyproxy.envoy.config.core.v3.HeaderMap;
+import io.envoyproxy.envoy.service.ext_proc.v3.HeaderMutation;
+import io.grpc.Drainable;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.xds.internal.HeaderForwardingRulesConfig;
+import io.grpc.xds.internal.grpcservice.HeaderValue;
+import io.grpc.xds.internal.grpcservice.HeaderValueValidationUtils;
+import io.grpc.xds.internal.headermutations.HeaderMutationDisallowedException;
+import io.grpc.xds.internal.headermutations.HeaderMutationFilter;
+import io.grpc.xds.internal.headermutations.HeaderMutations;
+import io.grpc.xds.internal.headermutations.HeaderMutator;
+import io.grpc.xds.internal.headermutations.HeaderValueOption;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+
+/**
+ * Utility methods for external processing.
+ */
+public final class ExternalProcessorUtil {
+  private ExternalProcessorUtil() {}
+
+  /**
+   * Reads an InputStream into a ByteString.
+   */
+  public static ByteString outboundStreamToByteString(InputStream message) throws IOException {
+    if (message instanceof Drainable) {
+      int size = message.available();
+      ByteString.Output output =
+          size > 0 ? ByteString.newOutput(size) : ByteString.newOutput();
+      ((Drainable) message).drainTo(output);
+      return output.toByteString();
+    }
+    return ByteString.readFrom(message);
+  }
+
+  /**
+   * Collects request attributes and structures them as Struct map.
+   */
+  public static ImmutableMap<String, Struct> collectAttributes(
+      ImmutableList<String> requestedAttributes,
+      MethodDescriptor<?, ?> method,
+      String authority,
+      Metadata headers) {
+    if (requestedAttributes.isEmpty()) {
+      return ImmutableMap.of();
+    }
+    ImmutableMap.Builder<String, Struct> attributes = ImmutableMap.builder();
+    for (String attr : requestedAttributes) {
+      switch (attr) {
+        case "request.path":
+        case "request.url_path":
+          attributes.put(attr, encodeAttribute("/" + method.getFullMethodName()));
+          break;
+        case "request.host":
+          attributes.put(attr, encodeAttribute(authority));
+          break;
+        case "request.method":
+          attributes.put(attr, encodeAttribute("POST"));
+          break;
+        case "request.headers":
+          attributes.put(attr, encodeHeaders(headers));
+          break;
+        case "request.referer":
+          String referer = getHeaderValue(headers, "referer");
+          if (referer != null) {
+            attributes.put(attr, encodeAttribute(referer));
+          }
+          break;
+        case "request.useragent":
+          String ua = getHeaderValue(headers, "user-agent");
+          if (ua != null) {
+            attributes.put(attr, encodeAttribute(ua));
+          }
+          break;
+        case "request.id":
+          String id = getHeaderValue(headers, "x-request-id");
+          if (id != null) {
+            attributes.put(attr, encodeAttribute(id));
+          }
+          break;
+        case "request.query":
+          attributes.put(attr, encodeAttribute(""));
+          break;
+        default:
+          // "Not set" attributes or unrecognized ones (already validated) are skipped.
+          break;
+      }
+    }
+    return attributes.buildOrThrow();
+  }
+
+  /**
+   * Encodes a single string attribute as Struct.
+   */
+  public static Struct encodeAttribute(String value) {
+    return Struct.newBuilder()
+        .putFields("", Value.newBuilder().setStringValue(value).build())
+        .build();
+  }
+
+  /**
+   * Encodes metadata headers as Struct.
+   */
+  public static Struct encodeHeaders(Metadata headers) {
+    Struct.Builder builder = Struct.newBuilder();
+    for (String key : headers.keys()) {
+      String value = getHeaderValue(headers, key);
+      if (value != null) {
+        builder.putFields(key.toLowerCase(Locale.ROOT),
+            Value.newBuilder().setStringValue(value).build());
+      }
+    }
+    return builder.build();
+  }
+
+  /**
+   * Gets a header value from metadata.
+   */
+  @Nullable
+  public static String getHeaderValue(Metadata headers, String headerName) {
+    if (headerName.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
+      Metadata.Key<byte[]> key = Metadata.Key.of(headerName, Metadata.BINARY_BYTE_MARSHALLER);
+      Iterable<byte[]> values = headers.getAll(key);
+      if (values == null) {
+        return null;
+      }
+      List<String> encoded = new ArrayList<>();
+      for (byte[] v : values) {
+        encoded.add(BaseEncoding.base64().omitPadding().encode(v));
+      }
+      return Joiner.on(",").join(encoded);
+    }
+    Metadata.Key<String> key = Metadata.Key.of(headerName, Metadata.ASCII_STRING_MARSHALLER);
+    Iterable<String> values = headers.getAll(key);
+    return values == null ? null : Joiner.on(",").join(values);
+  }
+
+  /**
+   * Transitions ExtProcStreamState to COMPLETED.
+   */
+  public static boolean markExtProcStreamCompleted(
+      AtomicReference<ExtProcStreamState> extProcStreamState) {
+    while (true) {
+      ExtProcStreamState current = extProcStreamState.get();
+      if (current == ExtProcStreamState.COMPLETED || current == ExtProcStreamState.FAILED) {
+        return false;
+      }
+      if (extProcStreamState.compareAndSet(current, ExtProcStreamState.COMPLETED)) {
+        return true;
+      }
+    }
+  }
+
+  /**
+   * Transitions ExtProcStreamState to FAILED.
+   */
+  public static boolean markExtProcStreamFailed(
+      AtomicReference<ExtProcStreamState> extProcStreamState) {
+    while (true) {
+      ExtProcStreamState current = extProcStreamState.get();
+      if (current == ExtProcStreamState.COMPLETED || current == ExtProcStreamState.FAILED) {
+        return false;
+      }
+      if (extProcStreamState.compareAndSet(current, ExtProcStreamState.FAILED)) {
+        return true;
+      }
+    }
+  }
+
+  /**
+   * Transitions DataPlaneCallState to CLOSED.
+   */
+  public static boolean markDataPlaneCallClosed(
+      AtomicReference<DataPlaneCallState> dataPlaneCallState) {
+    while (true) {
+      DataPlaneCallState current = dataPlaneCallState.get();
+      if (current == DataPlaneCallState.CLOSED) {
+        return false;
+      }
+      if (dataPlaneCallState.compareAndSet(current, DataPlaneCallState.CLOSED)) {
+        return true;
+      }
+    }
+  }
+
+  /**
+   * Converts Metadata to Envoy HeaderMap based on forwarding rules.
+   */
+  public static HeaderMap toHeaderMap(
+      Metadata metadata, Optional<HeaderForwardingRulesConfig> forwardRules) {
+    HeaderMap.Builder builder = HeaderMap.newBuilder();
+
+    for (String key : metadata.keys()) {
+      if (forwardRules.isPresent() && !forwardRules.get().isAllowed(key)) {
+        continue;
+      }
+      // Map binary headers using raw_value
+      if (key.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
+        Metadata.Key<byte[]> binKey = Metadata.Key.of(key, Metadata.BINARY_BYTE_MARSHALLER);
+        Iterable<byte[]> values = metadata.getAll(binKey);
+        if (values != null) {
+          for (byte[] binValue : values) {
+            String base64Value = BaseEncoding.base64().encode(binValue);
+            io.envoyproxy.envoy.config.core.v3.HeaderValue headerValue =
+                io.envoyproxy.envoy.config.core.v3.HeaderValue.newBuilder()
+                    .setKey(key.toLowerCase(Locale.ROOT))
+                    .setRawValue(ByteString.copyFromUtf8(base64Value))
+                    .build();
+            builder.addHeaders(headerValue);
+          }
+        }
+      } else {
+        Metadata.Key<String> asciiKey = Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER);
+        Iterable<String> values = metadata.getAll(asciiKey);
+        if (values != null) {
+          for (String value : values) {
+            io.envoyproxy.envoy.config.core.v3.HeaderValue headerValue =
+                io.envoyproxy.envoy.config.core.v3.HeaderValue.newBuilder()
+                    .setKey(key.toLowerCase(Locale.ROOT))
+                    .setRawValue(ByteString.copyFromUtf8(value))
+                    .build();
+            builder.addHeaders(headerValue);
+          }
+        }
+      }
+    }
+    return builder.build();
+  }
+
+  /**
+   * Applies header mutations to metadata under the validation of mutationFilter and mutator.
+   */
+  public static void applyHeaderMutations(
+      Metadata metadata,
+      HeaderMutation mutation,
+      HeaderMutationFilter mutationFilter,
+      HeaderMutator mutator)
+      throws HeaderMutationDisallowedException {
+    if (metadata == null) {
+      return;
+    }
+    ImmutableList.Builder<HeaderValueOption> headersToModify = ImmutableList.builder();
+    for (io.envoyproxy.envoy.config.core.v3.HeaderValueOption protoOption
+        : mutation.getSetHeadersList()) {
+      io.envoyproxy.envoy.config.core.v3.HeaderValue protoHeader = protoOption.getHeader();
+      String key = protoHeader.getKey();
+      HeaderValueValidationUtils.validateHeaderKey(key);
+
+      ByteString rawBytes = protoHeader.getRawValue();
+      if (rawBytes.isEmpty()) {
+        rawBytes = ByteString.copyFromUtf8(protoHeader.getValue());
+      }
+
+      if (rawBytes.size() > HeaderValueValidationUtils.MAX_HEADER_LENGTH) {
+        throw new IllegalArgumentException(
+            "Header value length exceeds maximum allowed length: " + rawBytes.size());
+      }
+
+      HeaderValue headerValue;
+      if (key.endsWith(Metadata.BINARY_HEADER_SUFFIX)) {
+        byte[] decodedBytes = BaseEncoding.base64().decode(rawBytes.toStringUtf8());
+        headerValue = HeaderValue.create(key, ByteString.copyFrom(decodedBytes));
+      } else {
+        headerValue = HeaderValue.create(key, rawBytes.toStringUtf8());
+      }
+      headersToModify.add(HeaderValueOption.create(
+          headerValue,
+          HeaderValueOption.HeaderAppendAction.valueOf(protoOption.getAppendAction().name())));
+    }
+
+    ImmutableList.Builder<String> headersToRemove = ImmutableList.builder();
+    for (String headerToRemove : mutation.getRemoveHeadersList()) {
+      HeaderValueValidationUtils.validateHeaderKey(headerToRemove);
+      headersToRemove.add(headerToRemove);
+    }
+
+    HeaderMutations mutations = HeaderMutations.create(
+        headersToModify.build(),
+        headersToRemove.build());
+
+    HeaderMutations filteredMutations = mutationFilter.filter(mutations);
+    mutator.applyMutations(filteredMutations, metadata);
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/internal/extproc/KnownLengthInputStream.java
+++ b/xds/src/main/java/io/grpc/xds/internal/extproc/KnownLengthInputStream.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.xds.internal.extproc;
+
+import com.google.protobuf.ByteString;
+import io.grpc.KnownLength;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * An {@link InputStream} backed by a {@link ByteString} that implements {@link KnownLength}.
+ */
+public final class KnownLengthInputStream extends InputStream implements KnownLength {
+  private final InputStream delegate;
+
+  public KnownLengthInputStream(ByteString byteString) {
+    this.delegate = byteString.newInput();
+  }
+
+  @Override
+  public int read() throws IOException {
+    return delegate.read();
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    return delegate.read(b, off, len);
+  }
+
+  @Override
+  public int available() throws IOException {
+    return delegate.available();
+  }
+
+  @Override
+  public void close() throws IOException {
+    delegate.close();
+  }
+}

--- a/xds/src/main/java/io/grpc/xds/internal/grpcservice/HeaderValue.java
+++ b/xds/src/main/java/io/grpc/xds/internal/grpcservice/HeaderValue.java
@@ -29,16 +29,12 @@ public abstract class HeaderValue {
 
   public static HeaderValue create(String key, String value) {
     HeaderValueValidationUtils.validateHeaderValue(key, value);
-    return new AutoValue_HeaderValue(key, Optional.of(value), Optional.empty(), true);
+    return new AutoValue_HeaderValue(key, Optional.of(value), Optional.empty());
   }
 
   public static HeaderValue create(String key, ByteString rawValue) {
     HeaderValueValidationUtils.validateHeaderValue(key, rawValue);
-    return new AutoValue_HeaderValue(key, Optional.empty(), Optional.of(rawValue), true);
-  }
-
-  public static HeaderValue createInvalid(String key) {
-    return new AutoValue_HeaderValue(key, Optional.empty(), Optional.empty(), false);
+    return new AutoValue_HeaderValue(key, Optional.empty(), Optional.of(rawValue));
   }
 
   public abstract String key();
@@ -46,6 +42,4 @@ public abstract class HeaderValue {
   public abstract Optional<String> value();
 
   public abstract Optional<ByteString> rawValue();
-
-  public abstract boolean isValid();
 }

--- a/xds/src/test/java/io/grpc/xds/ExternalProcessorClientInterceptorTest.java
+++ b/xds/src/test/java/io/grpc/xds/ExternalProcessorClientInterceptorTest.java
@@ -71,9 +71,11 @@ import io.grpc.stub.ServerCalls;
 import io.grpc.stub.StreamObserver;
 import io.grpc.testing.GrpcCleanupRule;
 import io.grpc.util.MutableHandlerRegistry;
-import io.grpc.xds.ExternalProcessorClientInterceptor;
+import io.grpc.xds.ConfigOrError;
 import io.grpc.xds.ExternalProcessorFilter.ExternalProcessorFilterConfig;
 import io.grpc.xds.ExternalProcessorFilter.ExternalProcessorFilterOverrideConfig;
+import io.grpc.xds.Filter;
+import io.grpc.xds.XdsNameResolver;
 import io.grpc.xds.client.Bootstrapper;
 import io.grpc.xds.client.EnvoyProtoData.Node;
 import io.grpc.xds.internal.grpcservice.CachedChannelManager;
@@ -7323,6 +7325,7 @@ public class ExternalProcessorClientInterceptorTest {
     final AtomicReference<Metadata> appReceivedTrailers = new AtomicReference<>();
     final CountDownLatch appCloseLatch = new CountDownLatch(1);
     final CountDownLatch mutatedMsg1ReceivedLatch = new CountDownLatch(1);
+    final CountDownLatch mutatedMsg2ReceivedLatch = new CountDownLatch(1);
     
     ClientCall.Listener<String> appListener = new ClientCall.Listener<String>() {
       @Override
@@ -7335,6 +7338,8 @@ public class ExternalProcessorClientInterceptorTest {
         appReceivedMessages.add(message);
         if ("Mutated Message 1".equals(message)) {
           mutatedMsg1ReceivedLatch.countDown();
+        } else if ("Mutated Message 2".equals(message)) {
+          mutatedMsg2ReceivedLatch.countDown();
         }
       }
 
@@ -7387,8 +7392,9 @@ public class ExternalProcessorClientInterceptorTest {
     // 4. Signal sidecar to send Mutated Message 2
     m3SentLatch.countDown();
     
-    // Wait for sidecar to finish sending M2
+    // Wait for sidecar to finish sending M2 and app to receive it
     assertThat(respBody2Latch.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(mutatedMsg2ReceivedLatch.await(5, TimeUnit.SECONDS)).isTrue();
 
     // Verify that Mutated Message 2 is delivered immediately to app upon arrival (even before
     // M3 is released)


### PR DESCRIPTION
Moved some of the util classes for ext_proc to a new sub package io.grpc.xds.internal.extproc.