### PR TITLE
fix: configure Undertow test entity size

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -146,12 +146,7 @@ tomcat-embed-core = "org.apache.tomcat.embed:tomcat-embed-core:10.1.55"
 # checkForUpdates: tomcat-embed-core9:9.+
 tomcat-embed-core9 = "org.apache.tomcat.embed:tomcat-embed-core:9.0.118"
 truth = "com.google.truth:truth:1.4.5"
-# 2.2.39 fails UndertowInteropTest.veryLargeRequest()
-# https://github.com/grpc/grpc-java/issues/12859
-# (disabled) checkForUpdates: undertow-servlet22:2.2.+
-# checkForUpdates: undertow-servlet22:2.2.38.Final
-undertow-servlet22 = "io.undertow:undertow-servlet:2.2.38.Final"
-# 2.3.21 fails UndertowInteropTest.veryLargeRequest()
-# https://github.com/grpc/grpc-java/issues/12859
-# checkForUpdates: undertow-servlet:2.3.20.Final
-undertow-servlet = "io.undertow:undertow-servlet:2.3.20.Final"
+# checkForUpdates: undertow-servlet22:2.2.+
+undertow-servlet22 = "io.undertow:undertow-servlet:2.2.39.Final"
+# checkForUpdates: undertow-servlet:2.3.+
+undertow-servlet = "io.undertow:undertow-servlet:2.3.21.Final"

--- a/servlet/src/undertowTest/java/io/grpc/servlet/UndertowInteropTest.java
+++ b/servlet/src/undertowTest/java/io/grpc/servlet/UndertowInteropTest.java
@@ -47,6 +47,7 @@ import org.junit.Test;
 public class UndertowInteropTest extends AbstractInteropTest {
   private static final String HOST = "localhost";
   private static final String MYAPP = "/grpc.testing.TestService";
+  private static final long MAX_ENTITY_SIZE = AbstractInteropTest.MAX_MESSAGE_SIZE;
   private int port;
   private Undertow server;
   private DeploymentManager manager;
@@ -101,6 +102,7 @@ public class UndertowInteropTest extends AbstractInteropTest {
         .addPrefixPath("/", servletHandler); // for unimplementedService test
     server = Undertow.builder()
         .setServerOption(UndertowOptions.ENABLE_HTTP2, true)
+        .setServerOption(UndertowOptions.MAX_ENTITY_SIZE, MAX_ENTITY_SIZE)
         .setServerOption(UndertowOptions.SHUTDOWN_TIMEOUT, 5000 /* 5 sec */)
         .addHttpListener(0, HOST)
         .setHandler(path)

--- a/servlet/src/undertowTest/java/io/grpc/servlet/UndertowTransportTest.java
+++ b/servlet/src/undertowTest/java/io/grpc/servlet/UndertowTransportTest.java
@@ -63,6 +63,7 @@ public class UndertowTransportTest extends AbstractTransportTest {
 
   private static final String HOST = "localhost";
   private static final String MYAPP = "/service";
+  private static final long MAX_ENTITY_SIZE = Integer.MAX_VALUE;
 
   private final FakeClock fakeClock = new FakeClock();
 
@@ -131,6 +132,7 @@ public class UndertowTransportTest extends AbstractTransportTest {
         undertowServer =
             Undertow.builder()
                 .setServerOption(UndertowOptions.ENABLE_HTTP2, true)
+                .setServerOption(UndertowOptions.MAX_ENTITY_SIZE, MAX_ENTITY_SIZE)
                 .setServerOption(UndertowOptions.SHUTDOWN_TIMEOUT, 5000 /* 5 sec */)
                 .addHttpListener(0, HOST)
                 .setHandler(path)


### PR DESCRIPTION
fixes #12859 

## Background
This PR updates the grpc-servlet Undertow tests to work with Undertow `2.2.39.Final` and `2.3.21.Final`.

Those releases changed Undertow's default `MAX_ENTITY_SIZE` to 2 MiB, which caused `UndertowInteropTest.veryLargeRequest()` to fail before the request reached the gRPC servlet.

## Cause
`UndertowInteropTest.veryLargeRequest()` sends a 10 MiB unary request. The test server already configured gRPC's `maxInboundMessageSize`, but it did not configure Undertow's container-level entity size limit.

After the Undertow default changed, the container started rejecting the request and the client saw `RST_STREAM ... CANCEL`.

## Changes
- Set `UndertowOptions.MAX_ENTITY_SIZE` explicitly in `UndertowInteropTest`
- Set `UndertowOptions.MAX_ENTITY_SIZE` explicitly in `UndertowTransportTest` to keep the transport test environment effectively unbounded
- Upgrade Undertow test dependencies to `2.2.39.Final` and `2.3.21.Final`

## Verification
- `./gradlew -PskipAndroid=true -PskipCodegen=true :grpc-servlet:undertowTest --tests io.grpc.servlet.UndertowInteropTest`
- `./gradlew -PskipAndroid=true -PskipCodegen=true :grpc-servlet:undertowTest --tests io.grpc.servlet.UndertowTransportTest`

