### PR TITLE
feat: normalize failed authorization future status

### DIFF
--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransportSecurity.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransportSecurity.java
@@ -108,7 +108,9 @@ public final class BinderTransportSecurity {
       Status authStatus;
       try {
         authStatus = Futures.getDone(authStatusFuture);
-      } catch (ExecutionException | CancellationException e) {
+      } catch (ExecutionException e) {
+        authStatus = statusFromFailedAuthorizationFuture(e.getCause());
+      } catch (CancellationException e) {
         authStatus = statusFromFailedAuthorizationFuture(e);
       }
 
@@ -149,10 +151,9 @@ public final class BinderTransportSecurity {
       return listener;
     }
 
-    private static Status statusFromFailedAuthorizationFuture(Throwable t) {
+    private static Status statusFromFailedAuthorizationFuture(Throwable cause) {
       // The actual failure is retained as the cause for debugging, but peers should see a
       // uniform transport-level failure instead of the underlying exception message.
-      Throwable cause = t instanceof ExecutionException && t.getCause() != null ? t.getCause() : t;
       return Status.INTERNAL.withCause(cause).withDescription("Authorization future failed");
     }
   }

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransportSecurity.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransportSecurity.java
@@ -109,12 +109,7 @@ public final class BinderTransportSecurity {
       try {
         authStatus = Futures.getDone(authStatusFuture);
       } catch (ExecutionException | CancellationException e) {
-        // Failed futures are treated as an internal error rather than a security rejection.
-        authStatus = Status.INTERNAL.withCause(e);
-        @Nullable String message = e.getMessage();
-        if (message != null) {
-          authStatus = authStatus.withDescription(message);
-        }
+        authStatus = statusFromFailedAuthorizationFuture(e);
       }
 
       if (authStatus.isOk()) {
@@ -147,13 +142,18 @@ public final class BinderTransportSecurity {
 
             @Override
             public void onFailure(Throwable t) {
-              call.close(
-                  Status.INTERNAL.withCause(t).withDescription("Authorization future failed"),
-                  new Metadata());
+              call.close(statusFromFailedAuthorizationFuture(t), new Metadata());
             }
           },
           executor);
       return listener;
+    }
+
+    private static Status statusFromFailedAuthorizationFuture(Throwable t) {
+      // The actual failure is retained as the cause for debugging, but peers should see a
+      // uniform transport-level failure instead of the underlying exception message.
+      Throwable cause = t instanceof ExecutionException && t.getCause() != null ? t.getCause() : t;
+      return Status.INTERNAL.withCause(cause).withDescription("Authorization future failed");
     }
   }
 

--- a/binder/src/test/java/io/grpc/binder/RobolectricBinderSecurityTest.java
+++ b/binder/src/test/java/io/grpc/binder/RobolectricBinderSecurityTest.java
@@ -164,7 +164,23 @@ public final class RobolectricBinderSecurityTest {
     ListenableFuture<Status> status = makeCall();
     statusesToSet.take().setException(new IllegalStateException("oops"));
 
-    assertThat(status.get().getCode()).isEqualTo(Status.Code.INTERNAL);
+    Status failureStatus = status.get();
+    assertThat(failureStatus.getCode()).isEqualTo(Status.Code.INTERNAL);
+    assertThat(failureStatus.getDescription()).isEqualTo("Authorization future failed");
+  }
+
+  @Test
+  public void testAsyncServerSecurityPolicy_failedFuture_cachedFailureIsOpaque() throws Exception {
+    ListenableFuture<Status> firstStatusFuture = makeCall();
+    statusesToSet.take().setException(new IOException("ouch"));
+
+    Status firstStatus = firstStatusFuture.get();
+    assertThat(firstStatus.getCode()).isEqualTo(Status.Code.INTERNAL);
+    assertThat(firstStatus.getDescription()).isEqualTo("Authorization future failed");
+
+    Status secondStatus = makeCall().get();
+    assertThat(secondStatus.getCode()).isEqualTo(Status.Code.INTERNAL);
+    assertThat(secondStatus.getDescription()).isEqualTo("Authorization future failed");
   }
 
   @Test

--- a/binder/src/test/java/io/grpc/binder/RobolectricBinderSecurityTest.java
+++ b/binder/src/test/java/io/grpc/binder/RobolectricBinderSecurityTest.java
@@ -170,7 +170,8 @@ public final class RobolectricBinderSecurityTest {
   }
 
   @Test
-  public void testAsyncServerSecurityPolicy_failedFuture_cachedFailureIsOpaque() throws Exception {
+  public void testAsyncServerSecurityPolicy_failedFuture_subsequentCallHasOpaqueFailure()
+      throws Exception {
     ListenableFuture<Status> firstStatusFuture = makeCall();
     statusesToSet.take().setException(new IOException("ouch"));
 
@@ -178,9 +179,25 @@ public final class RobolectricBinderSecurityTest {
     assertThat(firstStatus.getCode()).isEqualTo(Status.Code.INTERNAL);
     assertThat(firstStatus.getDescription()).isEqualTo("Authorization future failed");
 
-    Status secondStatus = makeCall().get();
+    // TransportAuthorizationState evicts failed futures so the second call triggers a fresh
+    // authorization check. Both calls must surface an opaque transport-level failure.
+    ListenableFuture<Status> secondStatusFuture = makeCall();
+    statusesToSet.take().setException(new IOException("ouch"));
+
+    Status secondStatus = secondStatusFuture.get();
     assertThat(secondStatus.getCode()).isEqualTo(Status.Code.INTERNAL);
     assertThat(secondStatus.getDescription()).isEqualTo("Authorization future failed");
+  }
+
+  @Test
+  public void testAsyncServerSecurityPolicy_failedFuture_cancelledFutureIsOpaque()
+      throws Exception {
+    ListenableFuture<Status> statusFuture = makeCall();
+    statusesToSet.take().cancel(false);
+
+    Status failureStatus = statusFuture.get();
+    assertThat(failureStatus.getCode()).isEqualTo(Status.Code.INTERNAL);
+    assertThat(failureStatus.getDescription()).isEqualTo("Authorization future failed");
   }
 
   @Test


### PR DESCRIPTION
## Background
fixed #12873

This PR makes binder server authorization failures report a uniform opaque status to peers.

Previously, `BinderTransportSecurity.ServerAuthInterceptor` handled failed authorization futures differently depending on whether the future was already completed. The pending path returned an opaque `INTERNAL` failure, but the `Futures.getDone()` path reused the underlying exception message as the status description. That allowed later calls to expose messages like `"ouch"`.

## Changes
- Centralized failed-authorization-future to `Status` mapping in `BinderTransportSecurity`
- Made both the pending callback path and the already-completed `Futures.getDone()` path return the same opaque `INTERNAL` status with description `"Authorization future failed"`
- Added regression assertions for failed future descriptions in `RobolectricBinderSecurityTest`
- Added coverage for the cached/already-completed failed future case to ensure later calls do not leak the underlying exception message

## Validation
-  `./gradlew :grpc-binder:testDebugUnitTest --tests io.grpc.binder.RobolectricBinderSecurityTest`