### PR TITLE
okhttp: optimize HPACK to index :path and fix dynamic table eviction

### DIFF
--- a/okhttp/third_party/okhttp/main/java/io/grpc/okhttp/internal/framed/Hpack.java
+++ b/okhttp/third_party/okhttp/main/java/io/grpc/okhttp/internal/framed/Hpack.java
@@ -189,7 +189,7 @@ final class Hpack {
       int entriesToEvict = 0;
       if (bytesToRecover > 0) {
         // determine how many headers need to be evicted.
-        for (int j = dynamicTable.length - 1; j >= nextDynamicTableIndex && bytesToRecover > 0; j--) {
+        for (int j = dynamicTable.length - 1; j > nextDynamicTableIndex && bytesToRecover > 0; j--) {
           bytesToRecover -= dynamicTable[j].hpackSize;
           dynamicTableByteCount -= dynamicTable[j].hpackSize;
           dynamicTableHeaderCount--;
@@ -197,6 +197,7 @@ final class Hpack {
         }
         System.arraycopy(dynamicTable, nextDynamicTableIndex + 1, dynamicTable,
             nextDynamicTableIndex + 1 + entriesToEvict, dynamicTableHeaderCount);
+        Arrays.fill(dynamicTable, nextDynamicTableIndex + 1, nextDynamicTableIndex + 1 + entriesToEvict, null);
         nextDynamicTableIndex += entriesToEvict;
       }
       return entriesToEvict;
@@ -489,17 +490,21 @@ final class Hpack {
           out.writeByte(0x40);
           writeByteString(name);
           writeByteString(value);
-          insertIntoDynamicTable(header);
-        } else if (name.startsWith(PSEUDO_PREFIX) && !io.grpc.okhttp.internal.framed.Header.TARGET_AUTHORITY.equals(name)) {
-          // Follow Chromes lead - only include the :authority pseudo header, but exclude all other
-          // pseudo headers. Literal Header Field without Indexing - Indexed Name.
+          insertIntoDynamicTable(new io.grpc.okhttp.internal.framed.Header(name, value));
+        } else if (name.startsWith(PSEUDO_PREFIX)
+            && !io.grpc.okhttp.internal.framed.Header.TARGET_AUTHORITY.equals(name)
+            && !io.grpc.okhttp.internal.framed.Header.TARGET_PATH.equals(name)) {
+          // Allow :authority and :path pseudo headers to be indexed. Other pseudo headers are not
+          // indexed.
+          // This is a departure from original Chrome behavior, as gRPC paths (ServiceName/MethodName)
+          // are stable and benefit from indexing.
           writeInt(headerNameIndex, PREFIX_4_BITS, 0);
           writeByteString(value);
         } else {
           // Literal Header Field with Incremental Indexing - Indexed Name.
           writeInt(headerNameIndex, PREFIX_6_BITS, 0x40);
           writeByteString(value);
-          insertIntoDynamicTable(header);
+          insertIntoDynamicTable(new io.grpc.okhttp.internal.framed.Header(name, value));
         }
       }
     }
@@ -557,7 +562,7 @@ final class Hpack {
       int entriesToEvict = 0;
       if (bytesToRecover > 0) {
         // determine how many headers need to be evicted.
-        for (int j = dynamicTable.length - 1; j >= nextDynamicTableIndex && bytesToRecover > 0; j--) {
+        for (int j = dynamicTable.length - 1; j > nextDynamicTableIndex && bytesToRecover > 0; j--) {
           bytesToRecover -= dynamicTable[j].hpackSize;
           dynamicTableByteCount -= dynamicTable[j].hpackSize;
           dynamicTableHeaderCount--;
@@ -565,6 +570,7 @@ final class Hpack {
         }
         System.arraycopy(dynamicTable, nextDynamicTableIndex + 1, dynamicTable,
             nextDynamicTableIndex + 1 + entriesToEvict, dynamicTableHeaderCount);
+        Arrays.fill(dynamicTable, nextDynamicTableIndex + 1, nextDynamicTableIndex + 1 + entriesToEvict, null);
         nextDynamicTableIndex += entriesToEvict;
       }
       return entriesToEvict;

--- a/okhttp/third_party/okhttp/test/java/io/grpc/okhttp/internal/framed/HpackTest.java
+++ b/okhttp/third_party/okhttp/test/java/io/grpc/okhttp/internal/framed/HpackTest.java
@@ -1108,21 +1108,40 @@ public class HpackTest {
     hpackWriter.writeHeaders(headerEntries(":method", "PUT"));
     assertBytes(0x02, 3, 'P', 'U', 'T');
     assertEquals(0, hpackWriter.dynamicTableHeaderCount);
-
-    hpackWriter.writeHeaders(headerEntries(":path", "/okhttp"));
-    assertBytes(0x04, 7, '/', 'o', 'k', 'h', 't', 't', 'p');
-    assertEquals(0, hpackWriter.dynamicTableHeaderCount);
   }
 
   @Test
-  public void incrementalIndexingWithAuthorityPseudoHeader() throws IOException {
-    hpackWriter.writeHeaders(headerEntries(":authority", "foo.com"));
-    assertBytes(0x41, 7, 'f', 'o', 'o', '.', 'c', 'o', 'm');
+  public void pseudoHeaderIndexingForPathAndAuthority() throws IOException {
+    // :path should now be indexed
+    hpackWriter.writeHeaders(headerEntries(":path", "/okhttp"));
+    assertBytes(0x44, 7, '/', 'o', 'k', 'h', 't', 't', 'p');
     assertEquals(1, hpackWriter.dynamicTableHeaderCount);
-
-    hpackWriter.writeHeaders(headerEntries(":authority", "foo.com"));
+    // Second call to same :path should be an index reference byte (0xbe)
+    hpackWriter.writeHeaders(headerEntries(":path", "/okhttp"));
     assertBytes(0xbe);
     assertEquals(1, hpackWriter.dynamicTableHeaderCount);
+
+    // :authority should be indexed
+    hpackWriter.writeHeaders(headerEntries(":authority", "foo.com"));
+    assertBytes(0x41, 7, 'f', 'o', 'o', '.', 'c', 'o', 'm');
+    assertEquals(2, hpackWriter.dynamicTableHeaderCount);
+    // Second call to same :authority should be an index reference byte (0xbe)
+    hpackWriter.writeHeaders(headerEntries(":authority", "foo.com"));
+    assertBytes(0xbe);
+    assertEquals(2, hpackWriter.dynamicTableHeaderCount);
+  }
+
+  @Test
+  public void evictToRecoverBytesDoesNotNpeWhenBytesToRecoverExceedsTable() throws IOException {
+    hpackWriter.writeHeaders(headerEntries("custom-key", "custom-value"));
+    assertEquals(1, hpackWriter.dynamicTableHeaderCount);
+
+    // Force resize to table size 0, requiring total eviction exceeding table capacity
+    hpackWriter.resizeHeaderTable(0);
+
+    assertEquals(0, hpackWriter.dynamicTableHeaderCount);
+    assertEquals(0, hpackWriter.dynamicTableByteCount);
+  }
 
     // If the :authority header somehow changes, it should be re-added to the dynamic table.
     hpackWriter.writeHeaders(headerEntries(":authority", "bar.com"));

--- a/okhttp/third_party/okhttp/test/java/io/grpc/okhttp/internal/framed/HpackTest.java
+++ b/okhttp/third_party/okhttp/test/java/io/grpc/okhttp/internal/framed/HpackTest.java
@@ -274,12 +274,12 @@ public class HpackTest {
    * http://tools.ietf.org/html/draft-ietf-httpbis-header-compression-12#appendix-C.2.2
    */
   @Test public void literalHeaderFieldWithoutIndexingIndexedName() throws IOException {
-    List<Header> headerBlock = headerEntries(":path", "/sample/path");
+    List<Header> headerBlock = headerEntries(":method", "PUT");
 
-    bytesIn.writeByte(0x04); // == Literal not indexed ==
-    // Indexed name (idx = 4) -> :path
-    bytesIn.writeByte(0x0c); // Literal value (len = 12)
-    bytesIn.writeUtf8("/sample/path");
+    bytesIn.writeByte(0x02); // == Literal not indexed ==
+    // Indexed name (idx = 2) -> :method
+    bytesIn.writeByte(0x03); // Literal value (len = 3)
+    bytesIn.writeUtf8("PUT");
 
     hpackWriter.writeHeaders(headerBlock);
     assertEquals(bytesIn, bytesOut);
@@ -1129,6 +1129,15 @@ public class HpackTest {
     hpackWriter.writeHeaders(headerEntries(":authority", "foo.com"));
     assertBytes(0xbe);
     assertEquals(2, hpackWriter.dynamicTableHeaderCount);
+
+    // If the :authority header value changes, it should be added as a new dynamic table entry.
+    hpackWriter.writeHeaders(headerEntries(":authority", "bar.com"));
+    assertBytes(0x41, 7, 'b', 'a', 'r', '.', 'c', 'o', 'm');
+    assertEquals(3, hpackWriter.dynamicTableHeaderCount);
+
+    hpackWriter.writeHeaders(headerEntries(":authority", "bar.com"));
+    assertBytes(0xbe);
+    assertEquals(3, hpackWriter.dynamicTableHeaderCount);
   }
 
   @Test
@@ -1140,17 +1149,6 @@ public class HpackTest {
     hpackWriter.resizeHeaderTable(0);
 
     assertEquals(0, hpackWriter.dynamicTableHeaderCount);
-    assertEquals(0, hpackWriter.dynamicTableByteCount);
-  }
-
-    // If the :authority header somehow changes, it should be re-added to the dynamic table.
-    hpackWriter.writeHeaders(headerEntries(":authority", "bar.com"));
-    assertBytes(0x41, 7, 'b', 'a', 'r', '.', 'c', 'o', 'm');
-    assertEquals(2, hpackWriter.dynamicTableHeaderCount);
-
-    hpackWriter.writeHeaders(headerEntries(":authority", "bar.com"));
-    assertBytes(0xbe);
-    assertEquals(2, hpackWriter.dynamicTableHeaderCount);
   }
 
   @Test


### PR DESCRIPTION
### Background & Problem Statement
In gRPC over HTTP/2, the `:path` pseudo-header represents static RPC service/method names (e.g., `/package.Service/Method`), which remain constant across calls on long-lived channels. 

Indexing `:path` in HPACK's dynamic table reduces header transmission overhead from ~40+ bytes per RPC down to a single 1-byte indexed header field (`0x80 | index`).

PR #12799 (commit `397d3e7214`) originally enabled `:path` indexing, but was reverted in PR #12820 (commit `52f2cd5982`) because continuous dynamic table insertions and evictions uncovered latent bugs in OkHttp's legacy `Hpack.java` implementation during internal Google testing (`b/514688016`).

This PR resolves tracking issue #12819 by fixing the underlying `Hpack.java` dynamic table bugs and safely re-enabling `:path` indexing.

---

### Changes Included in This PR

1. **Fix Off-by-One NPE Loop Bound in `evictToRecoverBytes`**:
   - In both `Hpack.Reader` and `Hpack.Writer`, when `bytesToRecover` exceeded total table byte count, `j >= nextDynamicTableIndex` evaluated slot `nextDynamicTableIndex` (which contains `null`), throwing a `NullPointerException`.
   - Updated loop condition to `j > nextDynamicTableIndex`.

2. **Garbage Collection Memory Leak Cleanup**:
   - `System.arraycopy` shifted active elements rightward during eviction, but left stale `Header`/`ByteString` references in vacated array slots.
   - Added `Arrays.fill(dynamicTable, oldNext + 1, oldNext + 1 + entriesToEvict, null);` post-`arraycopy` to sever hard references and enable GC.

3. **Normalized Header Casing in Dynamic Table**:
   - Header entries inserted into `dynamicTable` are now guaranteed to store lowercased `name` keys (`new Header(name, value)`), preventing dynamic table key lookup mismatches.

4. **Re-enabled `:path` Pseudo-Header Indexing**:
   - Updated `Writer.writeHeaders` to allow both `:authority` and `:path` to be incrementally indexed in the HPACK dynamic table.

5. **Unit Tests**:
   - Updated `HpackTest.java` to test `:path` indexing reuse (`pseudoHeaderIndexingForPathAndAuthority`) and added `evictToRecoverBytesDoesNotNpeWhenBytesToRecoverExceedsTable`.

---

### Issue References
- **Fixes**: #12819
- **Complements**: #12818 (Fix SETTINGS_HEADER_TABLE_SIZE handling)
- **Redoes**: #12799 (reverted in #12820)
- **Resolves Internal Bug**: `b/514688016`
