### PR TITLE
core: reject a JWK entry missing x5c when loading a SPIFFE trust bundle

### DIFF
--- a/core/src/main/java/io/grpc/internal/SpiffeUtil.java
+++ b/core/src/main/java/io/grpc/internal/SpiffeUtil.java
@@ -232,7 +232,8 @@ public final class SpiffeUtil {
       checkJwkEntry(keyNode, trustDomainName);
       List<String> rawCerts = JsonUtil.getListOfStrings(keyNode, "x5c");
       if (rawCerts == null) {
-        break;
+        throw new IllegalArgumentException(String.format("'x5c' parameter is required. Certificate "
+            + "loading for trust domain '%s' failed.", trustDomainName));
       }
       if (rawCerts.size() != 1) {
         throw new IllegalArgumentException(String.format("Exactly 1 certificate is expected, but "

--- a/core/src/test/java/io/grpc/internal/SpiffeUtilTest.java
+++ b/core/src/test/java/io/grpc/internal/SpiffeUtilTest.java
@@ -230,6 +230,7 @@ public class SpiffeUtilTest {
     private static final String SPIFFE_TRUST_BUNDLE_DUPLICATES = "spiffebundle_duplicates.json";
     private static final String SPIFFE_TRUST_BUNDLE_WRONG_ROOT = "spiffebundle_wrong_root.json";
     private static final String SPIFFE_TRUST_BUNDLE_WRONG_SEQ = "spiffebundle_wrong_seq_type.json";
+    private static final String SPIFFE_TRUST_BUNDLE_MISSING_X5C = "spiffebundle_missing_x5c.json";
     private static final String DOMAIN_ERROR_MESSAGE =
         " Certificate loading for trust domain 'google.com' failed.";
 
@@ -351,6 +352,10 @@ public class SpiffeUtilTest {
       iae = assertThrows(IllegalArgumentException.class, () -> SpiffeUtil
           .loadTrustBundleFromFile(copyFileToTmp(SPIFFE_TRUST_BUNDLE_CORRUPTED_CERT)));
       assertEquals("Certificate can't be parsed." + DOMAIN_ERROR_MESSAGE, iae.getMessage());
+      // Check the exception if a key entry is missing the 'x5c' parameter
+      iae = assertThrows(IllegalArgumentException.class, () -> SpiffeUtil
+          .loadTrustBundleFromFile(copyFileToTmp(SPIFFE_TRUST_BUNDLE_MISSING_X5C)));
+      assertEquals("'x5c' parameter is required." + DOMAIN_ERROR_MESSAGE, iae.getMessage());
       // Check the exception if 'kty' value differs from 'RSA'
       iae = assertThrows(IllegalArgumentException.class, () -> SpiffeUtil
           .loadTrustBundleFromFile(copyFileToTmp(SPIFFE_TRUST_BUNDLE_WRONG_KTY)));

--- a/core/src/test/resources/io/grpc/internal/spiffebundle_missing_x5c.json
+++ b/core/src/test/resources/io/grpc/internal/spiffebundle_missing_x5c.json
@@ -1,0 +1,12 @@
+{
+  "trust_domains": {
+    "google.com": {
+      "keys": [
+        {
+          "kty": "RSA",
+          "use": "x509-svid"
+        }
+      ]
+    }
+  }
+}

--- a/core/src/test/resources/io/grpc/internal/spiffebundle_missing_x5c.json
+++ b/core/src/test/resources/io/grpc/internal/spiffebundle_missing_x5c.json
@@ -4,6 +4,33 @@
       "keys": [
         {
           "kty": "RSA",
+          "use": "x509-svid",
+          "x5c": ["MIIELTCCAxWgAwIBAgIUVXGlXjNENtOZbI12epjgIhMaShEwDQYJKoZIhvcNAQEL
+          BQAwVjELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+          GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDEPMA0GA1UEAwwGdGVzdGNhMB4XDTI0
+          MDkxNzE2MTk0NFoXDTM0MDkxNTE2MTk0NFowTjELMAkGA1UEBhMCVVMxCzAJBgNV
+          BAgMAkNBMQwwCgYDVQQHDANTVkwxDTALBgNVBAoMBGdSUEMxFTATBgNVBAMMDHRl
+          c3QtY2xpZW50MTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAOcTjjcS
+          SfG/EGrr6G+f+3T2GXyHHfroQFi9mZUz80L7uKBdECOImID+YhoK8vcxLQjPmEEv
+          FIYgJT5amugDcYIgUhMjBx/8RPJaP/nGmBngAqsuuNCaZfyaHBRqN8XdS/AwmsI5
+          Wo+nru0+0/7aQFdqqtd2+e9dHjUWwgHxXvMgC4hkHpsdCGIZWVzWyBliwTYQYb1Y
+          yYe1LzqqQA5OMbZfKOY9MYDCEYOliRiunOn30iIOHj9V5qLzWGfSyxCRuvLRdEP8
+          iDeNweHbdaKuI80nQmxuBdRIspE9k5sD1WA4vLZpeg3zggxp4rfLL5zBJgb/33D3
+          d9Rkm14xfDPihhkCAwEAAaOB+jCB9zBZBgNVHREEUjBQhiZzcGlmZmU6Ly9mb28u
+          YmFyLmNvbS9jbGllbnQvd29ya2xvYWQvMYYmc3BpZmZlOi8vZm9vLmJhci5jb20v
+          Y2xpZW50L3dvcmtsb2FkLzIwHQYDVR0OBBYEFG9GkBgdBg/p0U9/lXv8zIJ+2c2N
+          MHsGA1UdIwR0MHKhWqRYMFYxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0
+          YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxDzANBgNVBAMM
+          BnRlc3RjYYIUWrP0VvHcy+LP6UuYNtiL9gBhD5owDQYJKoZIhvcNAQELBQADggEB
+          AJ4Cbxv+02SpUgkEu4hP/1+8DtSBXUxNxI0VG4e3Ap2+Rhjm3YiFeS/UeaZhNrrw
+          UEjkSTPFODyXR7wI7UO9OO1StyD6CMkp3SEvevU5JsZtGL6mTiTLTi3Qkywa91Bt
+          GlyZdVMghA1bBJLBMwiD5VT5noqoJBD7hDy6v9yNmt1Sw2iYBJPqI3Gnf5bMjR3s
+          UICaxmFyqaMCZsPkfJh0DmZpInGJys3m4QqGz6ZE2DWgcSr1r/ML7/5bSPjjr8j4
+          WFFSqFR3dMu8CbGnfZTCTXa4GTX/rARXbAO67Z/oJbJBK7VKayskL+PzKuohb9ox
+          jGL772hQMbwtFCOFXu5VP0s="]
+        },
+        {
+          "kty": "RSA",
           "use": "x509-svid"
         }
       ]


### PR DESCRIPTION
`SpiffeUtil.extractCert` silently truncates a SPIFFE trust bundle when a JWK `keys[]` entry is
missing `x5c`:

```java
for (Map<String, ?> keyNode : keysNode) {
  checkJwkEntry(keyNode, trustDomainName);
  List<String> rawCerts = JsonUtil.getListOfStrings(keyNode, "x5c");
  if (rawCerts == null) {
    break;          // abandons the loop, dropping every remaining cert
  }
  if (rawCerts.size() != 1) {
    throw new IllegalArgumentException(...);   // sibling paths throw
  }
  ...
}
```

`checkJwkEntry` has already guaranteed the entry is a declared `x509-svid` key (`use == "x509-svid"`,
`kty` in `{RSA, EC}`), so an entry with no `x5c` is malformed. But instead of failing, the `break`
abandons the loop and returns only the certificates collected **before** the bad entry — so a
trust domain whose `keys` array has a missing-`x5c` entry ahead of valid ones loads a **silently
truncated** trust store, and peers whose chain roots in a dropped CA fail verification (or a
partially loaded store is accepted with no error).

This also contradicts the method's own contract (`loadTrustBundleFromFile` javadoc: *"If any
element of the JSON content is invalid or unsupported, an `IllegalArgumentException` is thrown and
the entire Bundle is considered invalid"*). Every other malformed condition in `extractCert`
(`use`, `kty`, `kid`, `x5c.size() != 1`, unparseable cert) throws.

**Fix:** throw `IllegalArgumentException` for a missing `x5c`, consistent with the sibling error
paths and the documented contract, instead of silently dropping certificates.

**Tests:** added `spiffebundle_missing_x5c.json` and an assertion in
`SpiffeUtilTest.loadTrustBundleFromFileFailureTest`. It fails against the current code (the old
`break` returns a truncated bundle without throwing) and passes with the fix. `:grpc-core`
checkstyle/animalsniffer clean.
