### PR TITLE
build: Allow downloading pkgconfiglite with empty checksum

### DIFF
--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -1,4 +1,4 @@
-choco install -y pkgconfiglite
+choco install -y pkgconfiglite --allow-empty-checksums
 choco install -y openjdk --version=17.0
 set PATH=%PATH%;"c:\Program Files\OpenJDK\jdk-17\bin"
 set PROTOBUF_VER=35.1


### PR DESCRIPTION
Windows build fails (1) with an error "ERROR: Empty checksums are no longer allowed by default for non-secure sources" when trying to download pkgconfiglite 0.28.0 from an unsecure HTTP URL because Chocolatey v2.4.0 has safety features enabled by default, it rejects the package. This PR makes the change to specify the option `--allow-empty-checksums` for installing pkgconfiglite using Chocolatey.

1 - https://btx.cloud.google.com/invocations/db129a01-66e6-42b2-ab92-d849e24d09b2/targets/grpc%2Fjava%2Fv1.83.x%2Fpresubmit%2Fwindows;config=default/log