### PR TITLE
Fix docker tagging failure in upload_artifacts by using stable tag name

### DIFF
--- a/buildscripts/kokoro/upload_artifacts.sh
+++ b/buildscripts/kokoro/upload_artifacts.sh
@@ -90,9 +90,9 @@ LATEST_VERSION="$((echo "v$VERSION"; git ls-remote -t --refs https://github.com/
 STAGING_REPO=a93898609ef848
 "$GRPC_JAVA_DIR"/buildscripts/sonatype-upload.sh "$STAGING_REPO" "$LOCAL_MVN_ARTIFACTS"
 
-docker tag "$EXAMPLE_HOSTNAME_ID" "grpc/java-example-hostname:${VERSION}"
+docker tag "hostname:latest" "grpc/java-example-hostname:${VERSION}"
 docker push "grpc/java-example-hostname:${VERSION}"
 if [[ "v$VERSION" = "$LATEST_VERSION" ]]; then
-  docker tag "$EXAMPLE_HOSTNAME_ID" grpc/java-example-hostname:latest
+  docker tag "hostname:latest" grpc/java-example-hostname:latest
   docker push grpc/java-example-hostname:latest
 fi


### PR DESCRIPTION
The upload_artifacts.sh script previously read the build-phase image id from example-hostname.id to tag and push the example image. However, because the build and upload phases run on different VMs, differences in the Docker daemon versions and layer serialization can cause the image ID (hash of the config JSON) to be recalculated differently during docker load on the upload VM. This mismatch caused the docker tag command to fail with a "No such image" error. This change fixes the issue by directly tagging the stable, imported image tag hostname:latest (which is guaranteed to exist after docker load succeeds) instead of using the brittle sha256 hash.

[Failed upload job logs](https://btx.cloud.google.com/invocations/387baa72-224e-4885-bedc-9b9eb079a505/targets/grpc%2Fjava%2Fv1.83.x%2Fbranch%2Fupload_artifacts/log)