### PR TITLE
android: Drop support for Android API 23

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ gRPC-Java - An RPC library and framework
 Supported Platforms
 -------------------
 
-gRPC-Java supports Java 8 and later. Android minSdkVersion 23 (Marshmallow) and
+gRPC-Java supports Java 8 and later. Android minSdkVersion 24 (Nougat) and
 later are supported with [Java 8 language desugaring][android-java-8].
 
 TLS usage on Android typically requires Play Services Dynamic Security Provider.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,7 +14,7 @@ android {
     }
     compileSdkVersion 34
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 24
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
+++ b/android/src/main/java/io/grpc/android/AndroidChannelBuilder.java
@@ -16,14 +16,12 @@
 
 package io.grpc.android;
 
-import android.annotation.TargetApi;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.Network;
-import android.os.Build;
 import android.util.Log;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -212,7 +210,7 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
     private void configureNetworkMonitoring() {
       // Android N added the registerDefaultNetworkCallback API to listen to changes in the device's
       // default network. For earlier Android API levels, use the BroadcastReceiver API.
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && connectivityManager != null) {
+      if (connectivityManager != null) {
         final DefaultNetworkCallback defaultNetworkCallback = new DefaultNetworkCallback();
         connectivityManager.registerDefaultNetworkCallback(defaultNetworkCallback);
         unregisterRunnable =
@@ -306,7 +304,6 @@ public final class AndroidChannelBuilder extends ForwardingChannelBuilder<Androi
     }
 
     /** Respond to changes in the default network. Only used on API levels 24+. */
-    @TargetApi(Build.VERSION_CODES.N)
     private class DefaultNetworkCallback extends ConnectivityManager.NetworkCallback {
       @Override
       public void onAvailable(Network network) {

--- a/binder/build.gradle
+++ b/binder/build.gradle
@@ -13,7 +13,7 @@ android {
         targetCompatibility 1.8
     }
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 24
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/cronet/build.gradle
+++ b/cronet/build.gradle
@@ -14,7 +14,7 @@ android {
     namespace = 'io.grpc.cronet'
     compileSdkVersion 33
     defaultConfig {
-        minSdkVersion 23
+        minSdkVersion 24
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/examples/android/helloworld/app/build.gradle
+++ b/examples/android/helloworld/app/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId "io.grpc.helloworldexample"
-        minSdkVersion 23
+        minSdkVersion 24
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/examples/android/routeguide/app/build.gradle
+++ b/examples/android/routeguide/app/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId "io.grpc.routeguideexample"
-        minSdkVersion 23
+        minSdkVersion 24
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Google Play Services is requiring 24+ since June. We follow Google Play Services as it is relatively conservative and our users are generally using it to provide up-to-date security.

API 24 added the Java 8 library features.

Fixes #12928