### PR TITLE
Add getExtensionRegistry() getter to ProtoLiteUtils and ProtoUtils (#3836) [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/protobuf-lite/src/main/java/io/grpc/protobuf/lite/ProtoLiteUtils.java
+++ b/protobuf-lite/src/main/java/io/grpc/protobuf/lite/ProtoLiteUtils.java
@@ -78,6 +78,15 @@ public final class ProtoLiteUtils {
   }
 
   /**
+   * Returns the global extension registry.
+   *
+   * @since 1.62.0
+   */
+  public static ExtensionRegistryLite getExtensionRegistry() {
+    return globalRegistry;
+  }
+
+  /**
    * Creates a {@link Marshaller} for protos of the same type as {@code defaultInstance}.
    *
    * @since 1.0.0

--- a/protobuf/src/main/java/io/grpc/protobuf/ProtoUtils.java
+++ b/protobuf/src/main/java/io/grpc/protobuf/ProtoUtils.java
@@ -47,6 +47,15 @@ public final class ProtoUtils {
   }
 
   /**
+   * Returns the global extension registry.
+   *
+   * @since 1.62.0
+   */
+  public static ExtensionRegistry getExtensionRegistry() {
+    return (ExtensionRegistry) ProtoLiteUtils.getExtensionRegistry();
+  }
+
+  /**
    * Create a {@link Marshaller} for protos of the same type as {@code defaultInstance}.
    *
    * @since 1.0.0


### PR DESCRIPTION
### Description

The `ProtoLiteUtils.setExtensionRegistry()` setter was added in gRPC 1.0.0, but there was no corresponding getter. This made it impossible for the reflection service or other components to discover the extensions that were registered via the global `ExtensionRegistry`.

### Changes

1. **ProtoLiteUtils.java**: Added `getExtensionRegistry()` returning `ExtensionRegistryLite` - the global registry stored in the package-private `globalRegistry` field.

2. **ProtoUtils.java**: Added `getExtensionRegistry()` returning `ExtensionRegistry` - delegating to `ProtoLiteUtils.getExtensionRegistry()` with a cast, since `ExtensionRegistry` extends `ExtensionRegistryLite`.

### Related Issue

Fixes #3836 - Reflection service does not consult ExtensionRegistry

### Note

This is the first step (the getter). The reflection service can now use `ProtoUtils.getExtensionRegistry()` to discover programmatically registered extensions that are not in the `FileDescriptor` graph. A follow-up can update `ProtoReflectionServiceV1.FileDescriptorIndex` to also consult the global registry.