### PR TITLE
compiler: Update maximum supported edition to EDITION_2026

### DIFF
--- a/compiler/src/java_plugin/cpp/java_plugin.cpp
+++ b/compiler/src/java_plugin/cpp/java_plugin.cpp
@@ -58,7 +58,9 @@ class JavaGrpcGenerator : public protobuf::compiler::CodeGenerator {
     return protobuf::Edition::EDITION_PROTO2;
   }
   protobuf::Edition GetMaximumEdition() const override {
-#if GOOGLE_PROTOBUF_VERSION >= 6032000
+#if GOOGLE_PROTOBUF_VERSION >= 7035000
+    return protobuf::Edition::EDITION_2026;
+#elif GOOGLE_PROTOBUF_VERSION >= 6032000
     return protobuf::Edition::EDITION_2024;
 #else
     return protobuf::Edition::EDITION_2023;


### PR DESCRIPTION
Update the maximum supported edition in the Java gRPC compiler plugin
to EDITION_2026 when compiling against Protobuf version 7.35.0 (v35.0)
or later.

cc @JasonLunn 