### PR TITLE
xds: fix race condition in ext_proc client interceptor halfClose

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ExternalProcessorClientInterceptor.java
+++ b/xds/src/main/java/io/grpc/xds/ExternalProcessorClientInterceptor.java
@@ -851,6 +851,11 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
       pendingHalfClose.set(true);
 
       if (extProcStreamState.get().isCompleted()) {
+        if (passThroughMode.get()) {
+          if (requestSideClosed.compareAndSet(false, true)) {
+            proceedWithHalfClose();
+          }
+        }
         return;
       }
 


### PR DESCRIPTION
Fixes a race condition in `ExternalProcessorClientInterceptor$DataPlaneClientCall.halfClose()` that can cause the call to hang when the external processor stream completes concurrently.

If the external processor stream completes (marking state as COMPLETED and setting passThroughMode to true) after `halfClose()` has already checked `passThroughMode` (seeing false), halfClose() would subsequently see the state as COMPLETED and return early without invoking `proceedWithHalfClose()`.

This commit fixes the race by re-checking passThroughMode inside the `isCompleted()` block in `halfClose()`, ensuring we proceed with half-close if pass-through mode was enabled late.