### PR TITLE
fix: close frameReader before socket in stopIfNecessary to prevent TSAN data race

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpClientTransport.java
@@ -1207,8 +1207,15 @@ class OkHttpClientTransport implements ConnectionClientTransport, TransportExcep
       frameWriter.goAway(0, ErrorCode.NO_ERROR, new byte[0]);
     }
 
-    // We will close the underlying socket in the writing thread to break out the reader
-    // thread, which will close the frameReader and notify the listener.
+    // Close the frameReader first to stop the ClientFrameHandler thread, then
+    // close the frameWriter (which closes the underlying socket through the
+    // writing thread). This prevents a TSAN data race between the socket close
+    // and the ClientFrameHandler's read from the same socket.
+    try {
+      clientFrameHandler.frameReader.close();
+    } catch (IOException e) {
+      log.log(java.util.logging.Level.FINE, "Exception closing frame reader", e);
+    }
     frameWriter.close();
   }
 


### PR DESCRIPTION
Fixes #10294

## Description

The  thread reads from the socket while  closes the same socket on the  thread. This causes a TSAN-detected data race in the JVM's SSL Cipher state:

- Thread T56 (SerializingExecutor):  →  →  →  (READ)
- Thread T57 (thread pool):  →  →  →  (WRITE)

## Fix

In , close the 's  before closing the  (which triggers the socket close). This ensures the reader thread is stopped before the socket is closed, preventing the data race.

The  causes the  loop to exit, and its  block handles the  idempotently.