### PR TITLE
binder: rework server SecurityPolicy future handling

### DIFF
--- a/binder/src/main/java/io/grpc/binder/internal/BinderServerTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderServerTransport.java
@@ -128,6 +128,11 @@ public final class BinderServerTransport extends BinderTransport implements Serv
   }
 
   @Override
+  void notifyTerminatedUnlocked() {
+    BinderTransportSecurity.notifyTerminatedUnlocked(getAttributes());
+  }
+
+  @Override
   @GuardedBy("this")
   void notifyTerminated() {
     listenerPromise.runWhenSet(ServerTransportListener::transportTerminated);

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransport.java
@@ -251,6 +251,8 @@ public abstract class BinderTransport implements IBinder.DeathRecipient {
   @GuardedBy("this")
   abstract void notifyTerminated();
 
+  void notifyTerminatedUnlocked() {}
+
   void releaseExecutors() {
     executorServicePool.returnObject(scheduledExecutorService);
   }
@@ -334,6 +336,8 @@ public abstract class BinderTransport implements IBinder.DeathRecipient {
               // Not holding any locks here just in case some listener runs on a direct Executor.
               future.cancel(false); // No effect if already isDone().
             }
+
+            notifyTerminatedUnlocked();
 
             synchronized (this) {
               notifyTerminated();

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransportSecurity.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransportSecurity.java
@@ -16,11 +16,14 @@
 
 package io.grpc.binder.internal;
 
+import static com.google.common.util.concurrent.Futures.nonCancellationPropagating;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.SettableFuture;
 import com.google.errorprone.annotations.CheckReturnValue;
 import io.grpc.Attributes;
 import io.grpc.Internal;
@@ -167,6 +170,7 @@ public final class BinderTransportSecurity {
   static final class TransportAuthorizationState {
     private final int uid;
     private final ServerPolicyChecker serverPolicyChecker;
+    // Holds *all* pending policy check futures and *certain* complete ones that we want to cache.
     private final ConcurrentHashMap<String, ListenableFuture<Status>> serviceAuthorization;
     private final Executor executor;
 
@@ -185,44 +189,53 @@ public final class BinderTransportSecurity {
     @CheckReturnValue
     ListenableFuture<Status> checkAuthorization(MethodDescriptor<?, ?> method) {
       String serviceName = method.getServiceName();
-      // Only cache decisions if the method can be sampled for tracing,
-      // which is true for all generated methods. Otherwise, programmatically
-      // created methods could cause this cache to grow unbounded.
-      boolean useCache = method.isSampledToLocalTracing();
-      if (useCache) {
-        @Nullable ListenableFuture<Status> authorization = serviceAuthorization.get(serviceName);
-        if (authorization != null) {
-          // Authorization check exists and is a pending or successful future (even if for a
-          // failed authorization).
-          return authorization;
-        }
+      @Nullable
+      ListenableFuture<Status> pendingOrCachedAuthResult = serviceAuthorization.get(serviceName);
+      if (pendingOrCachedAuthResult != null) {
+        return nonCancellationPropagating(pendingOrCachedAuthResult);
       }
-      // Under high load, this may trigger a large number of concurrent authorization checks that
-      // perform essentially the same work and have the potential of exhausting the resources they
-      // depend on. This was a non-issue in the past with synchronous policy checks due to the
-      // fixed-size nature of the thread pool this method runs under.
-      //
-      // TODO(10669): evaluate if there should be at most a single pending authorization check per
-      //  (uid, serviceName) pair at any given time.
-      ListenableFuture<Status> authorization =
-          serverPolicyChecker.checkAuthorizationForServiceAsync(uid, serviceName);
-      if (useCache) {
-        serviceAuthorization.putIfAbsent(serviceName, authorization);
-        Futures.addCallback(
-            authorization,
-            new FutureCallback<Status>() {
-              @Override
-              public void onSuccess(Status result) {}
 
-              @Override
-              public void onFailure(Throwable t) {
-                serviceAuthorization.remove(serviceName, authorization);
-              }
-            },
-            MoreExecutors.directExecutor());
+      SettableFuture<Status> newPendingAuthResult = SettableFuture.create();
+      ListenableFuture<Status> checkThenActRaceWinner =
+          serviceAuthorization.putIfAbsent(serviceName, newPendingAuthResult);
+      if (checkThenActRaceWinner != null) {
+        // Another thread running this method must have also just saw no entry for serviceName, then
+        // beat us to calling putIfAbsent(). We can only track one check at a time so share theirs.
+        return nonCancellationPropagating(checkThenActRaceWinner);
       }
-      return authorization;
+
+      try {
+        newPendingAuthResult.setFuture(
+            serverPolicyChecker.checkAuthorizationForServiceAsync(uid, serviceName));
+      } catch (Exception e) {  // Not just RuntimeException! Handle the "sneaky" checked case too.
+        newPendingAuthResult.setException(e);
+      }
+
+      Futures.addCallback(
+          newPendingAuthResult,
+          new FutureCallback<Status>() {
+            @Override
+            public void onSuccess(Status result) {
+              // Auth checks can be expensive so we want to cache the results. But programmatically
+              // created service names could cause the cache to grow without bound. Conservatively,
+              // we only cache results for codegen service names as there can't be too many of them.
+              if (!method.isSampledToLocalTracing()) {
+                serviceAuthorization.remove(serviceName, newPendingAuthResult);
+              }
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+              // Not simply a non-OK auth result but a failure to return any decision at all. Never
+              // cache these so that if the caller retries, we'll retry the auth check as well.
+              serviceAuthorization.remove(serviceName, newPendingAuthResult);
+            }
+          },
+          MoreExecutors.directExecutor());
+
+      return nonCancellationPropagating(newPendingAuthResult);
     }
+
   }
 
   /**

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransportSecurity.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransportSecurity.java
@@ -88,6 +88,24 @@ public final class BinderTransportSecurity {
   }
 
   /**
+   * Informs this module that the transport with the specified 'attributes' is terminating.
+   *
+   * <p>Any resources allocated by this module will be released and no further resources will be
+   * allocated. Any ongoing background work will be canceled and no further background work will be
+   * initiated.
+   *
+   * <p>This method completes futures and therefore may execute arbitrary listener code on a
+   * potentially direct Executor. To avoid deadlock, callers must not hold any locks.
+   */
+  @Internal
+  public static void notifyTerminatedUnlocked(Attributes attributes) {
+    TransportAuthorizationState state = attributes.get(TRANSPORT_AUTHORIZATION_STATE);
+    if (state != null) {
+      state.notifyTerminatedUnlocked();
+    }
+  }
+
+  /**
    * Intercepts server calls and ensures they're authorized before allowing them to proceed.
    * Authentication state is fetched from the call attributes, inherited from the transport.
    */
@@ -174,6 +192,8 @@ public final class BinderTransportSecurity {
     private final ConcurrentHashMap<String, ListenableFuture<Status>> serviceAuthorization;
     private final Executor executor;
 
+    private volatile boolean isTerminated;
+
     /**
      * @param executor used for calling into the application. Must outlive the transport.
      */
@@ -204,11 +224,20 @@ public final class BinderTransportSecurity {
         return nonCancellationPropagating(checkThenActRaceWinner);
       }
 
-      try {
-        newPendingAuthResult.setFuture(
-            serverPolicyChecker.checkAuthorizationForServiceAsync(uid, serviceName));
-      } catch (Exception e) {  // Not just RuntimeException! Handle the "sneaky" checked case too.
-        newPendingAuthResult.setException(e);
+      // We only check isTerminated *after* the new future is visible to other threads in
+      // serviceAuthorization. In case of a race with a simultaneous call to notifyTerminated(),
+      // better to harmlessly cancel the new future twice rather than not cancel it at all.
+      if (!isTerminated) {
+        // If notifyTerminated() already cancelled newPendingAuthResult, setFuture() will forward
+        // that cancellation to its argument so it's safe to ignore the return value here.
+        try {
+          newPendingAuthResult.setFuture(
+              serverPolicyChecker.checkAuthorizationForServiceAsync(uid, serviceName));
+        } catch (Exception e) {  // Not just RuntimeException! Handle the "sneaky" checked case too.
+          newPendingAuthResult.setException(e);
+        }
+      } else {
+        newPendingAuthResult.cancel(false);
       }
 
       Futures.addCallback(
@@ -236,6 +265,21 @@ public final class BinderTransportSecurity {
       return nonCancellationPropagating(newPendingAuthResult);
     }
 
+    /**
+     * After this method returns, every future ever returned by a prior or concurrent call to
+     * checkAuthorization() is guaranteed to be complete. Every future returned by subsequent call
+     * to checkAuthorization() is also guaranteed to be complete.
+     */
+    void notifyTerminatedUnlocked() {
+      // Any entries added to serviceAuthorization *after* this assignment will be immediately
+      // canceled by the adding thread in checkAuthorization().
+      isTerminated = true;
+
+      // Cancel any entries added to serviceAuthorization *before* the volatile assignment above.
+      for (ListenableFuture<Status> authResult : serviceAuthorization.values()) {
+        authResult.cancel(false); // No-op for cached results (already done).
+      }
+    }
   }
 
   /**

--- a/binder/src/main/java/io/grpc/binder/internal/BinderTransportSecurity.java
+++ b/binder/src/main/java/io/grpc/binder/internal/BinderTransportSecurity.java
@@ -16,6 +16,7 @@
 
 package io.grpc.binder.internal;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -162,7 +163,8 @@ public final class BinderTransportSecurity {
    * Maintains the authorization state for a single transport instance. This class lives for the
    * lifetime of a single transport.
    */
-  private static final class TransportAuthorizationState {
+  @VisibleForTesting
+  static final class TransportAuthorizationState {
     private final int uid;
     private final ServerPolicyChecker serverPolicyChecker;
     private final ConcurrentHashMap<String, ListenableFuture<Status>> serviceAuthorization;

--- a/binder/src/test/java/io/grpc/binder/RobolectricBinderSecurityTest.java
+++ b/binder/src/test/java/io/grpc/binder/RobolectricBinderSecurityTest.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertThrows;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.app.Application;
@@ -49,6 +50,10 @@ import io.grpc.stub.ClientCalls;
 import io.grpc.stub.ServerCalls;
 import java.io.IOException;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -207,6 +212,19 @@ public final class RobolectricBinderSecurityTest {
     awaitNext(statusesToSet).set(Status.OK);
 
     assertThat(awaitResult(status).getCode()).isEqualTo(Status.Code.OK);
+  }
+
+  @Test
+  public void testAsyncServerSecurityPolicy_shutdownNow_cancelsAuthFutures() throws Exception {
+    ListenableFuture<Status> callResult = makeCall();
+    SettableFuture<Status> authResultFuture = awaitNext(statusesToSet);
+
+    channel.shutdownNow();
+    boolean terminationResult = channel.awaitTermination(10, SECONDS);
+    assertThat(terminationResult).isTrue();
+
+    assertThrows(CancellationException.class, () -> awaitResult(authResultFuture));
+    assertThat(awaitResult(callResult).getCode()).isEqualTo(Status.Code.UNAVAILABLE);
   }
 
   private ListenableFuture<Status> makeCall() {

--- a/binder/src/test/java/io/grpc/binder/RobolectricBinderSecurityTest.java
+++ b/binder/src/test/java/io/grpc/binder/RobolectricBinderSecurityTest.java
@@ -19,6 +19,7 @@ package io.grpc.binder;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.app.Application;
@@ -154,17 +155,17 @@ public final class RobolectricBinderSecurityTest {
   @Test
   public void testAsyncServerSecurityPolicy_failed_returnsFailureStatus() throws Exception {
     ListenableFuture<Status> status = makeCall();
-    statusesToSet.take().set(Status.ALREADY_EXISTS);
+    awaitNext(statusesToSet).set(Status.ALREADY_EXISTS);
 
-    assertThat(status.get().getCode()).isEqualTo(Status.Code.ALREADY_EXISTS);
+    assertThat(awaitResult(status).getCode()).isEqualTo(Status.Code.ALREADY_EXISTS);
   }
 
   @Test
   public void testAsyncServerSecurityPolicy_failedFuture_failsWithCodeInternal() throws Exception {
     ListenableFuture<Status> status = makeCall();
-    statusesToSet.take().setException(new IllegalStateException("oops"));
+    awaitNext(statusesToSet).setException(new IllegalStateException("oops"));
 
-    Status failureStatus = status.get();
+    Status failureStatus = awaitResult(status);
     assertThat(failureStatus.getCode()).isEqualTo(Status.Code.INTERNAL);
     assertThat(failureStatus.getDescription()).isEqualTo("Authorization future failed");
   }
@@ -173,18 +174,18 @@ public final class RobolectricBinderSecurityTest {
   public void testAsyncServerSecurityPolicy_failedFuture_subsequentCallHasOpaqueFailure()
       throws Exception {
     ListenableFuture<Status> firstStatusFuture = makeCall();
-    statusesToSet.take().setException(new IOException("ouch"));
+    awaitNext(statusesToSet).setException(new IOException("ouch"));
 
-    Status firstStatus = firstStatusFuture.get();
+    Status firstStatus = awaitResult(firstStatusFuture);
     assertThat(firstStatus.getCode()).isEqualTo(Status.Code.INTERNAL);
     assertThat(firstStatus.getDescription()).isEqualTo("Authorization future failed");
 
     // TransportAuthorizationState evicts failed futures so the second call triggers a fresh
     // authorization check. Both calls must surface an opaque transport-level failure.
     ListenableFuture<Status> secondStatusFuture = makeCall();
-    statusesToSet.take().setException(new IOException("ouch"));
+    awaitNext(statusesToSet).setException(new IOException("ouch"));
 
-    Status secondStatus = secondStatusFuture.get();
+    Status secondStatus = awaitResult(secondStatusFuture);
     assertThat(secondStatus.getCode()).isEqualTo(Status.Code.INTERNAL);
     assertThat(secondStatus.getDescription()).isEqualTo("Authorization future failed");
   }
@@ -193,9 +194,9 @@ public final class RobolectricBinderSecurityTest {
   public void testAsyncServerSecurityPolicy_failedFuture_cancelledFutureIsOpaque()
       throws Exception {
     ListenableFuture<Status> statusFuture = makeCall();
-    statusesToSet.take().cancel(false);
+    awaitNext(statusesToSet).cancel(false);
 
-    Status failureStatus = statusFuture.get();
+    Status failureStatus = awaitResult(statusFuture);
     assertThat(failureStatus.getCode()).isEqualTo(Status.Code.INTERNAL);
     assertThat(failureStatus.getDescription()).isEqualTo("Authorization future failed");
   }
@@ -203,9 +204,9 @@ public final class RobolectricBinderSecurityTest {
   @Test
   public void testAsyncServerSecurityPolicy_allowed_returnsOkStatus() throws Exception {
     ListenableFuture<Status> status = makeCall();
-    statusesToSet.take().set(Status.OK);
+    awaitNext(statusesToSet).set(Status.OK);
 
-    assertThat(status.get().getCode()).isEqualTo(Status.Code.OK);
+    assertThat(awaitResult(status).getCode()).isEqualTo(Status.Code.OK);
   }
 
   private ListenableFuture<Status> makeCall() {
@@ -218,6 +219,18 @@ public final class RobolectricBinderSecurityTest {
         StatusRuntimeException.class,
         StatusRuntimeException::getStatus,
         directExecutor());
+  }
+
+  private static <T> T awaitNext(BlockingQueue<T> queue) throws Exception {
+    T item = queue.poll(10, SECONDS);
+    if (item == null) {
+      throw new TimeoutException("Queue timed out waiting for item");
+    }
+    return item;
+  }
+
+  private static <T> T awaitResult(Future<T> future) throws Exception {
+    return future.get(10, SECONDS);
   }
 
   private static MethodDescriptor<Empty, Empty> getMethodDescriptor() {

--- a/binder/src/test/java/io/grpc/binder/internal/TransportAuthorizationStateTest.java
+++ b/binder/src/test/java/io/grpc/binder/internal/TransportAuthorizationStateTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2024 The gRPC Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.grpc.binder.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.util.concurrent.TimeUnit.*;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+import com.google.protobuf.Empty;
+import io.grpc.MethodDescriptor;
+import io.grpc.Status;
+import io.grpc.binder.internal.BinderTransportSecurity.ServerPolicyChecker;
+import io.grpc.binder.internal.BinderTransportSecurity.TransportAuthorizationState;
+import io.grpc.protobuf.lite.ProtoLiteUtils;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public final class TransportAuthorizationStateTest {
+
+  private static final int UID = 12345;
+  private static final String NONCODEGEN_SERVICE_NAME = "test.noncodegen.service";
+  private static final MethodDescriptor<Empty, Empty> NONCODEGEN_METHOD =
+      MethodDescriptor.<Empty, Empty>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName(NONCODEGEN_SERVICE_NAME + "/NonCodegenMethod")
+          .setRequestMarshaller(ProtoLiteUtils.marshaller(Empty.getDefaultInstance()))
+          .setResponseMarshaller(ProtoLiteUtils.marshaller(Empty.getDefaultInstance()))
+          .setSampledToLocalTracing(false)
+          .build();
+
+  private static final String CODEGEN_SERVICE_NAME = "test.codegen.service";
+  private static final MethodDescriptor<Empty, Empty> CODEGEN_METHOD =
+      MethodDescriptor.<Empty, Empty>newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName(CODEGEN_SERVICE_NAME + "/CodegenMethod")
+          .setRequestMarshaller(ProtoLiteUtils.marshaller(Empty.getDefaultInstance()))
+          .setResponseMarshaller(ProtoLiteUtils.marshaller(Empty.getDefaultInstance()))
+          .setSampledToLocalTracing(true)
+          .build();
+
+  private ExecutorService executor;
+  private FakeServerPolicyChecker fakePolicyChecker;
+  private TransportAuthorizationState authState;
+
+  @Before
+  public void setUp() {
+    executor = Executors.newSingleThreadExecutor();
+    fakePolicyChecker = new FakeServerPolicyChecker();
+    authState = new TransportAuthorizationState(UID, fakePolicyChecker, executor);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    assertThat(executor.shutdownNow()).isEmpty();
+    assertThat(executor.awaitTermination(5, SECONDS)).isTrue();
+  }
+
+  @Test
+  public void checkAuthorization_doesNotCacheNonCodegenMethods() throws Exception {
+    ListenableFuture<Status> authResult1 = authState.checkAuthorization(NONCODEGEN_METHOD);
+    assertThat(authResult1.isDone()).isFalse();
+
+    fakePolicyChecker.takeNextAuthRequestOrDie().set(Status.OK);
+    assertThat(authResult1.get()).isEqualTo(Status.OK);
+    assertThat(fakePolicyChecker.statusesToSet).isEmpty();
+
+    // Because it's a non-codegen method, the auth result should not be cached.
+    ListenableFuture<Status> authResult2 = authState.checkAuthorization(NONCODEGEN_METHOD);
+    assertThat(authResult2.isDone()).isFalse();
+
+    fakePolicyChecker.takeNextAuthRequestOrDie().set(Status.PERMISSION_DENIED);
+    assertThat(authResult2.get()).isEqualTo(Status.PERMISSION_DENIED);
+  }
+
+  @Test
+  public void checkAuthorization_cachesCodegenMethods() throws Exception {
+    ListenableFuture<Status> authResult1 = authState.checkAuthorization(CODEGEN_METHOD);
+    assertThat(authResult1.isDone()).isFalse();
+
+    fakePolicyChecker.takeNextAuthRequestOrDie().set(Status.OK);
+    assertThat(authResult1.get()).isEqualTo(Status.OK);
+    assertThat(fakePolicyChecker.statusesToSet).isEmpty();
+
+    // Because it's a codegen method, the auth result should be cached for the life of the object.
+    ListenableFuture<Status> authResult2 = authState.checkAuthorization(CODEGEN_METHOD);
+    assertThat(authResult2.isDone()).isTrue();
+    assertThat(authResult2.get()).isEqualTo(Status.OK);
+    assertThat(fakePolicyChecker.statusesToSet).isEmpty();
+  }
+
+  @Test
+  public void checkAuthorization_failedFuture_notCached() throws Exception {
+    ListenableFuture<Status> authResult1 = authState.checkAuthorization(CODEGEN_METHOD);
+    assertThat(authResult1.isDone()).isFalse();
+
+    fakePolicyChecker.takeNextAuthRequestOrDie().setException(new IllegalStateException("oops"));
+    
+    ExecutionException exception = assertThrows(ExecutionException.class, authResult1::get);
+    assertThat(exception).hasCauseThat().isInstanceOf(IllegalStateException.class);
+    assertThat(fakePolicyChecker.statusesToSet).isEmpty();
+
+    // Failed futures must not be cached, even for codegen methods.
+    ListenableFuture<Status> authResult2 = authState.checkAuthorization(CODEGEN_METHOD);
+    assertThat(authResult2.isDone()).isFalse();
+    
+    fakePolicyChecker.takeNextAuthRequestOrDie().set(Status.OK);
+    assertThat(authResult2.get()).isEqualTo(Status.OK);
+  }
+
+  private static final class FakeServerPolicyChecker implements ServerPolicyChecker {
+    final LinkedBlockingQueue<SettableFuture<Status>> statusesToSet = new LinkedBlockingQueue<>();
+
+    @Override
+    public ListenableFuture<Status> checkAuthorizationForServiceAsync(int uid, String serviceName) {
+      SettableFuture<Status> pendingResult = SettableFuture.create();
+      statusesToSet.add(pendingResult);
+      return pendingResult;
+    }
+
+    SettableFuture<Status> takeNextAuthRequestOrDie() throws InterruptedException {
+      SettableFuture<Status> item = statusesToSet.poll(10, SECONDS);
+      if (item == null) {
+        throw new NoSuchElementException("Queue timed out waiting for item");
+      }
+      return item;
+    }
+  }
+}

--- a/binder/src/test/java/io/grpc/binder/internal/TransportAuthorizationStateTest.java
+++ b/binder/src/test/java/io/grpc/binder/internal/TransportAuthorizationStateTest.java
@@ -82,36 +82,86 @@ public final class TransportAuthorizationStateTest {
   }
 
   @Test
-  public void checkAuthorization_doesNotCacheNonCodegenMethods() throws Exception {
+  public void checkAuthorization_deduplicatesSimultaneousNonCodegenMethods() throws Exception {
     ListenableFuture<Status> authResult1 = authState.checkAuthorization(NONCODEGEN_METHOD);
     assertThat(authResult1.isDone()).isFalse();
 
-    fakePolicyChecker.takeNextAuthRequestOrDie().set(Status.OK);
-    assertThat(authResult1.get()).isEqualTo(Status.OK);
-    assertThat(fakePolicyChecker.statusesToSet).isEmpty();
-
-    // Because it's a non-codegen method, the auth result should not be cached.
     ListenableFuture<Status> authResult2 = authState.checkAuthorization(NONCODEGEN_METHOD);
     assertThat(authResult2.isDone()).isFalse();
 
+    // The fake policy checker was only invoked ONCE thanks to deduplication.
+    // Completing that single underlying auth check satisfies both futures.
+    fakePolicyChecker.takeNextAuthRequestOrDie().set(Status.OK);
+
+    assertThat(authResult1.get()).isEqualTo(Status.OK);
+    assertThat(authResult2.get()).isEqualTo(Status.OK);
+    assertThat(fakePolicyChecker.statusesToSet).isEmpty();
+
+    // Because it's a non-codegen method, the auth result should not be cached.
+    ListenableFuture<Status> authResult3 = authState.checkAuthorization(NONCODEGEN_METHOD);
+    assertThat(authResult3.isDone()).isFalse();
+
     fakePolicyChecker.takeNextAuthRequestOrDie().set(Status.PERMISSION_DENIED);
-    assertThat(authResult2.get()).isEqualTo(Status.PERMISSION_DENIED);
+    assertThat(authResult3.get()).isEqualTo(Status.PERMISSION_DENIED);
   }
 
   @Test
-  public void checkAuthorization_cachesCodegenMethods() throws Exception {
+  public void checkAuthorization_cachesSimultaneousCodegenMethods() throws Exception {
     ListenableFuture<Status> authResult1 = authState.checkAuthorization(CODEGEN_METHOD);
     assertThat(authResult1.isDone()).isFalse();
 
+    ListenableFuture<Status> authResult2 = authState.checkAuthorization(CODEGEN_METHOD);
+    assertThat(authResult2.isDone()).isFalse();
+
+    // The fake policy checker was only invoked ONCE thanks to deduplication.
+    // Completing that single underlying auth check satisfies both futures.
     fakePolicyChecker.takeNextAuthRequestOrDie().set(Status.OK);
+
     assertThat(authResult1.get()).isEqualTo(Status.OK);
+    assertThat(authResult2.get()).isEqualTo(Status.OK);
     assertThat(fakePolicyChecker.statusesToSet).isEmpty();
 
     // Because it's a codegen method, the auth result should be cached for the life of the object.
+    ListenableFuture<Status> authResult3 = authState.checkAuthorization(CODEGEN_METHOD);
+    assertThat(authResult3.isDone()).isTrue();
+    assertThat(authResult3.get()).isEqualTo(Status.OK);
+    assertThat(fakePolicyChecker.statusesToSet).isEmpty();
+  }
+
+  @Test
+  public void checkAuthorization_cachesPermissionDeniedForCodegenMethods() throws Exception {
+    ListenableFuture<Status> authResult1 = authState.checkAuthorization(CODEGEN_METHOD);
+    assertThat(authResult1.isDone()).isFalse();
+
+    fakePolicyChecker.takeNextAuthRequestOrDie().set(Status.PERMISSION_DENIED);
+
+    assertThat(authResult1.get()).isEqualTo(Status.PERMISSION_DENIED);
+    assertThat(fakePolicyChecker.statusesToSet).isEmpty();
+
+    // Because it's a codegen method, the non-OK status should be cached for the life of the object.
     ListenableFuture<Status> authResult2 = authState.checkAuthorization(CODEGEN_METHOD);
     assertThat(authResult2.isDone()).isTrue();
-    assertThat(authResult2.get()).isEqualTo(Status.OK);
+    assertThat(authResult2.get()).isEqualTo(Status.PERMISSION_DENIED);
     assertThat(fakePolicyChecker.statusesToSet).isEmpty();
+  }
+
+  @Test
+  public void checkAuthorization_cancellation_doesNotPropagateToUnderlyingCheck() throws Exception {
+    ListenableFuture<Status> authResult1 = authState.checkAuthorization(CODEGEN_METHOD);
+    ListenableFuture<Status> authResult2 = authState.checkAuthorization(CODEGEN_METHOD);
+
+    // Cancel the first future.
+    authResult1.cancel(true);
+
+    assertThat(authResult1.isCancelled()).isTrue();
+    // The second future should NOT be cancelled, because the cancellation shouldn't propagate
+    // to the underlying shared future.
+    assertThat(authResult2.isCancelled()).isFalse();
+
+    // Completing the underlying auth check satisfies the non-cancelled future.
+    fakePolicyChecker.takeNextAuthRequestOrDie().set(Status.OK);
+
+    assertThat(authResult2.get()).isEqualTo(Status.OK);
   }
 
   @Test
@@ -133,11 +183,37 @@ public final class TransportAuthorizationStateTest {
     assertThat(authResult2.get()).isEqualTo(Status.OK);
   }
 
+
+
+  @Test
+  public void checkAuthorization_synchronousException_doesNotLeaveStrandedFuture()
+      throws Exception {
+    IllegalStateException syncException = new IllegalStateException("ouch");
+    fakePolicyChecker.syncExceptionsToThrow.add(syncException);
+
+    // The synchronous exception is safely returned as a failed future.
+    ListenableFuture<Status> authResult1 = authState.checkAuthorization(CODEGEN_METHOD);
+    ExecutionException ee = assertThrows(ExecutionException.class, authResult1::get);
+    assertThat(ee).hasCauseThat().isSameInstanceAs(syncException);
+
+    // Ensure the failed check can be retried.
+    ListenableFuture<Status> authResult2 = authState.checkAuthorization(CODEGEN_METHOD);
+    assertThat(authResult2.isDone()).isFalse();
+
+    fakePolicyChecker.takeNextAuthRequestOrDie().set(Status.OK);
+    assertThat(authResult2.get()).isEqualTo(Status.OK);
+  }
+
   private static final class FakeServerPolicyChecker implements ServerPolicyChecker {
+    final LinkedBlockingQueue<RuntimeException> syncExceptionsToThrow = new LinkedBlockingQueue<>();
     final LinkedBlockingQueue<SettableFuture<Status>> statusesToSet = new LinkedBlockingQueue<>();
 
     @Override
     public ListenableFuture<Status> checkAuthorizationForServiceAsync(int uid, String serviceName) {
+      RuntimeException syncException = syncExceptionsToThrow.poll();
+      if (syncException != null) {
+        throw syncException;
+      }
       SettableFuture<Status> pendingResult = SettableFuture.create();
       statusesToSet.add(pendingResult);
       return pendingResult;

--- a/binder/src/test/java/io/grpc/binder/internal/TransportAuthorizationStateTest.java
+++ b/binder/src/test/java/io/grpc/binder/internal/TransportAuthorizationStateTest.java
@@ -183,7 +183,25 @@ public final class TransportAuthorizationStateTest {
     assertThat(authResult2.get()).isEqualTo(Status.OK);
   }
 
+  @Test
+  public void notifyTerminatedUnlocked_cancelsPendingAuthFutures() {
+    ListenableFuture<Status> authResult = authState.checkAuthorization(CODEGEN_METHOD);
+    assertThat(authResult.isDone()).isFalse();
 
+    authState.notifyTerminatedUnlocked();
+
+    assertThat(authResult.isCancelled()).isTrue();
+  }
+
+  @Test
+  public void checkAuthorization_afterTermination_returnsCancelledFuture() {
+    authState.notifyTerminatedUnlocked();
+
+    ListenableFuture<Status> authResult = authState.checkAuthorization(CODEGEN_METHOD);
+
+    assertThat(authResult.isCancelled()).isTrue();
+    assertThat(fakePolicyChecker.statusesToSet).isEmpty(); // fakePolicyChecker never called.
+  }
 
   @Test
   public void checkAuthorization_synchronousException_doesNotLeaveStrandedFuture()


### PR DESCRIPTION
- dedup auth checks for cached and uncached methods
- dedup even simultaneous auth checks, fixing #10669
- fixes #12929
- unit tests now cover preexisting code not reachable from the Channel/Server layer

Will not squash. Please consider each commit on its own.