### PR TITLE
api: Bump Context to JDK 8

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -17,13 +17,13 @@ sourceSets {
 }
 
 tasks.named("compileContextJava").configure {
-    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_20)) {
-        println("!!! Javac does not support generating Java 7 bytecode. Do not use for release builds !!!")
+    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_27)) {
+        println("!!! Javac does not support generating Java 8 bytecode. Do not use for release builds !!!")
     } else if (JavaVersion.current().isJava9Compatible()) {
-        options.release = 7
+        options.release = 8
     } else {
-        sourceCompatibility = JavaVersion.VERSION_1_7
-        targetCompatibility = JavaVersion.VERSION_1_7
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 }
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -17,9 +17,7 @@ sourceSets {
 }
 
 tasks.named("compileContextJava").configure {
-    if (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_27)) {
-        println("!!! Javac does not support generating Java 8 bytecode. Do not use for release builds !!!")
-    } else if (JavaVersion.current().isJava9Compatible()) {
+    if (JavaVersion.current().isJava9Compatible()) {
         options.release = 8
     } else {
         sourceCompatibility = JavaVersion.VERSION_1_8


### PR DESCRIPTION
Java 26 complains about the obsolete version but does actually compile.  I can't test JDK 27 so it may just have to nag when it comes out.  

Updates https://github.com/grpc/grpc-java/pull/12935