### PR TITLE
build: Allow downloading pkgconfiglite with empty checksum (v1.82.x backport)

### DIFF
--- a/buildscripts/make_dependencies.bat
+++ b/buildscripts/make_dependencies.bat
@@ -1,4 +1,4 @@
-choco install -y pkgconfiglite
+choco install -y pkgconfiglite --allow-empty-checksums
 choco install -y openjdk --version=17.0
 set PATH=%PATH%;"c:\Program Files\OpenJDK\jdk-17\bin"
 set PROTOBUF_VER=33.4


### PR DESCRIPTION
Backport of #12918 to v1.82.x.
---
Windows build fails (1) with an error "ERROR: Empty checksums are no longer allowed by default for non-secure sources" when trying to download pkgconfiglite 0.28.0 from an unsecure HTTP URL because Chocolatey v2.4.0 has safety features enabled by default, it rejects the package. This PR makes the change to specify the option `--allow-empty-checksums` for installing pkgconfiglite using Chocolatey.

1 - https://btx.cloud.google.com/invocations/b32524b5-094a-4afb-8e46-1b3aa35e413b/targets/grpc%2Fjava%2Fv1.82.x%2Fbranch%2Fwindows;config=default/log