### PR TITLE
api: Remove io.grpc.Uri#isAbsolute()

### DIFF
--- a/api/src/main/java/io/grpc/Uri.java
+++ b/api/src/main/java/io/grpc/Uri.java
@@ -530,10 +530,6 @@ public final class Uri {
    * slashes are not segment delimiters but rather part of the first and only path segment.
    *
    * <p>Contrast absolute paths with rootless ones (see {@link #isPathRootless()}.
-   *
-   * <p>NB: The term "absolute" has two different meanings in RFC 3986 which are easily confused.
-   * This method tests for a property of this URI's path component. Contrast with {@link
-   * #isAbsolute()} which tests the URI itself for a different property.
    */
   public boolean isPathAbsolute() {
     return path.startsWith("/");
@@ -629,16 +625,6 @@ public final class Uri {
     return sb.toString();
   }
 
-  /**
-   * Returns true iff this URI has a scheme and an authority/path hierarchy, but no fragment.
-   *
-   * <p>All instances of {@link Uri} are RFC 3986 URIs, not "relative references", so this method is
-   * equivalent to {@code getFragment() == null}. It mostly exists for compatibility with {@link
-   * java.net.URI}.
-   */
-  public boolean isAbsolute() {
-    return scheme != null && fragment == null;
-  }
 
   /**
    * {@inheritDoc}

--- a/api/src/test/java/io/grpc/UriTest.java
+++ b/api/src/test/java/io/grpc/UriTest.java
@@ -45,7 +45,6 @@ public final class UriTest {
     assertThat(uri.getRawQuery()).isEqualTo("query");
     assertThat(uri.getFragment()).isEqualTo("fragment");
     assertThat(uri.toString()).isEqualTo("scheme://user@host:0443/path?query#fragment");
-    assertThat(uri.isAbsolute()).isFalse(); // Has a fragment.
     assertThat(uri.isPathAbsolute()).isTrue();
     assertThat(uri.isPathRootless()).isFalse();
   }
@@ -59,7 +58,6 @@ public final class UriTest {
     assertThat(uri.getRawQuery()).isEqualTo("query");
     assertThat(uri.getFragment()).isEqualTo("fragment");
     assertThat(uri.toString()).isEqualTo("scheme:/path?query#fragment");
-    assertThat(uri.isAbsolute()).isFalse(); // Has a fragment.
   }
 
   @Test
@@ -116,7 +114,6 @@ public final class UriTest {
     assertThat(uri.getRawQuery()).isEqualTo("query");
     assertThat(uri.getFragment()).isNull();
     assertThat(uri.toString()).isEqualTo("scheme://authority/path?query");
-    assertThat(uri.isAbsolute()).isTrue();
   }
 
   @Test
@@ -128,7 +125,6 @@ public final class UriTest {
     assertThat(uri.getRawQuery()).isNull();
     assertThat(uri.getFragment()).isNull();
     assertThat(uri.toString()).isEqualTo("scheme://authority");
-    assertThat(uri.isAbsolute()).isTrue();
     assertThat(uri.isPathAbsolute()).isFalse();
     assertThat(uri.isPathRootless()).isFalse();
   }
@@ -142,7 +138,6 @@ public final class UriTest {
     assertThat(uri.getRawQuery()).isEqualTo("subject=raise");
     assertThat(uri.getFragment()).isNull();
     assertThat(uri.toString()).isEqualTo("mailto:ceo@company.com?subject=raise");
-    assertThat(uri.isAbsolute()).isTrue();
     assertThat(uri.isPathAbsolute()).isFalse();
     assertThat(uri.isPathRootless()).isTrue();
   }
@@ -156,7 +151,6 @@ public final class UriTest {
     assertThat(uri.getRawQuery()).isNull();
     assertThat(uri.getFragment()).isNull();
     assertThat(uri.toString()).isEqualTo("scheme:");
-    assertThat(uri.isAbsolute()).isTrue();
     assertThat(uri.isPathAbsolute()).isFalse();
     assertThat(uri.isPathRootless()).isFalse();
   }
@@ -772,13 +766,6 @@ public final class UriTest {
         .testEquals();
   }
 
-  @Test
-  public void isAbsolute() {
-    assertThat(Uri.create("scheme://authority/path").isAbsolute()).isTrue();
-    assertThat(Uri.create("scheme://authority/path?query").isAbsolute()).isTrue();
-    assertThat(Uri.create("scheme://authority/path#fragment").isAbsolute()).isFalse();
-    assertThat(Uri.create("scheme://authority/path?query#fragment").isAbsolute()).isFalse();
-  }
 
   @Test
   public void serializedCharacterClasses_matchComputed() {


### PR DESCRIPTION
Javadoc says this method only exists for compatibility with java.net.URI but the meaning of "absolute" actually changed from RFC 2396 to 3986 so isAbsolute() is more of a trap than a convenience.

io.grpc.Uri intentionally only models URIs, not URI references. So under  the RFC 2396 definition of absolute, every instance is absolute because it has a scheme.

Removing isAbsolute() also avoids confusion with absolute paths, an entirely different concept.