### PR TITLE
fix: prevent NPE in RetriableStream when cancel() races start() (#12964) [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/core/src/main/java/io/grpc/internal/RetriableStream.java
+++ b/core/src/main/java/io/grpc/internal/RetriableStream.java
@@ -392,6 +392,26 @@ abstract class RetriableStream<ReqT> implements ClientStream {
   public final void start(ClientStreamListener listener) {
     masterListener = listener;
 
+    if (savedCloseMasterListenerReason != null) {
+      // cancel() was called before start() completed; close immediately with
+      // the already-saved reason.
+      listenerSerializeExecutor.execute(
+          new Runnable() {
+            @Override
+            public void run() {
+              if (masterListener == null || isClosed) {
+                return;
+              }
+              isClosed = true;
+              masterListener.closed(
+                  savedCloseMasterListenerReason.status,
+                  savedCloseMasterListenerReason.progress,
+                  savedCloseMasterListenerReason.metadata);
+            }
+          });
+      return;
+    }
+
     Status shutdownStatus = prestart();
 
     if (shutdownStatus != null) {
@@ -844,6 +864,9 @@ abstract class RetriableStream<ReqT> implements ClientStream {
           new Runnable() {
             @Override
             public void run() {
+              if (masterListener == null) {
+                return;
+              }
               isClosed = true;
               masterListener.closed(status, progress, metadata);
             }


### PR DESCRIPTION
### Fix: Prevent NPE in RetriableStream when cancel() races start()

**Bug:** When `cancel()` is called through `ClientCallStreamObserver` (from application code in `ClientResponseObserver.beforeStart()`) before `RetriableStream.start()` completes, `safeCloseMasterListener` tries to dereference `masterListener` which is still null, causing an NPE.

**Root cause:** `ClientCallImpl.startInternal` assigns the stream at line 250 and starts it at line 285. `RetriableStream.masterListener` is only assigned as the first statement of `start()` (line 388). A `cancel()` arriving in that window passes the `stream != null` guard in `cancelInternal` but finds `masterListener` null.

**Fix (two changes):**

1. **`safeCloseMasterListener`**: Null-check `masterListener` before dereferencing. If `masterListener` is null (cancel before start), the close reason is already saved in `savedCloseMasterListenerReason` and start() will pick it up.

2. **`start()`**: After assigning `masterListener`, check if `savedCloseMasterListenerReason` is already set (from a prior cancel). If so, close immediately with the saved reason instead of proceeding with the normal start flow.

Fixes #12964
