### PR TITLE
xds: Add Http11ProxyUpstreamTransport to MessagePrinter

### DIFF
--- a/xds/src/main/java/io/grpc/xds/MessagePrinter.java
+++ b/xds/src/main/java/io/grpc/xds/MessagePrinter.java
@@ -35,6 +35,7 @@ import io.envoyproxy.envoy.extensions.filters.http.router.v3.Router;
 import io.envoyproxy.envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager;
 import io.envoyproxy.envoy.extensions.load_balancing_policies.round_robin.v3.RoundRobin;
 import io.envoyproxy.envoy.extensions.load_balancing_policies.wrr_locality.v3.WrrLocality;
+import io.envoyproxy.envoy.extensions.transport_sockets.http_11_proxy.v3.Http11ProxyUpstreamTransport;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext;
 import io.envoyproxy.envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext;
 import io.envoyproxy.envoy.service.discovery.v3.Resource;
@@ -73,7 +74,8 @@ final class MessagePrinter implements MessagePrettyPrinter {
               .add(ClusterLoadAssignment.getDescriptor())
               .add(WrrLocality.getDescriptor())
               .add(TypedStruct.getDescriptor())
-              .add(RoundRobin.getDescriptor());
+              .add(RoundRobin.getDescriptor())
+              .add(Http11ProxyUpstreamTransport.getDescriptor());
       try {
         @SuppressWarnings("unchecked")
         Class<? extends Message> routeLookupClusterSpecifierClass =


### PR DESCRIPTION
Printer falls back to outputting the `@error` indicating that the type is not recognized. So because we are unpacking `Http11ProxyUpstreamTransport ` from `any`, we need to add it to the registry.
Here is the example cds resource:
```   
 "transportSocket": {
      "name": "envoy.transport_sockets.http_11_proxy",
      "typedConfig": {
        "@error": "envoy.extensions.transport_sockets.http_11_proxy.v3.Http11ProxyUpstreamTransport is not recognized; see @value for raw binary message data",
        "@type": "type.googleapis.com/envoy.extensions.transport_sockets.http_11_proxy.v3.Http11ProxyUpstreamTransport",
        "@value": ""
      }
    },
```

cc: @sergiitk 