### PR TITLE
Fix ext_proc mock response handling in ext_proc client interceptor test

### DIFF
--- a/xds/src/test/java/io/grpc/xds/ExternalProcessorClientInterceptorTest.java
+++ b/xds/src/test/java/io/grpc/xds/ExternalProcessorClientInterceptorTest.java
@@ -14309,9 +14309,15 @@ public class ExternalProcessorClientInterceptorTest {
             return new StreamObserver<ProcessingRequest>() {
               @Override
               public void onNext(ProcessingRequest request) {
-                responseObserver.onNext(ProcessingResponse.newBuilder()
-                    .setRequestHeaders(HeadersResponse.newBuilder().build())
-                    .build());
+                if (request.hasRequestHeaders()) {
+                  responseObserver.onNext(ProcessingResponse.newBuilder()
+                      .setRequestHeaders(HeadersResponse.newBuilder().build())
+                      .build());
+                } else if (request.hasResponseHeaders()) {
+                  responseObserver.onNext(ProcessingResponse.newBuilder()
+                      .setResponseHeaders(HeadersResponse.newBuilder().build())
+                      .build());
+                }
               }
 
               @Override


### PR DESCRIPTION
In `ExternalProcessorClientInterceptorTest.clientInterceptor_contextPropagatedToStartCall()`, the mock ext_proc service blindly returned a `ProcessingResponse` with `setRequestHeaders` for every incoming `ProcessingRequest`. When the downstream RPC finished and sent back response headers, the interceptor sent a `ProcessingRequest` with `responseHeaders`. The mock's blind `requestHeaders` reply caused the interceptor to detect an out-of-order protocol error, triggering `internalOnError()` which called `delayedCall.cancel()` on the executor thread.

This async cancellation on the executor thread raced with the test code's cleanup `proxyCall.cancel()` on the test runner thread, causing TSAN to report a data race on the non-volatile field `ClientCallImpl.cancelCalled`.

This commit fixes the test mock to check the request type (`hasRequestHeaders()` vs. `hasResponseHeaders()`) before responding, matching the behavior in `clientInterceptor_contextPropagatedToListenerCallbacks()`.

Note: The unsynchronized cancellation between the application thread and an interceptor's cancellation on an executor thread, while technically a data race from TSAN's perspective due to `ClientCallImpl.cancelCalled` not being volatile, is not consequential in practice because the underlying `stream.cancel()` and `CancellationHandler.tearDown()` are thread-safe and idempotent. Therefore, modifying `cancelCalled` in `ClientCallImpl` is not necessary.

Internal TSAN test failure [link](http://shortn/_sh1PGgNkbQ)