### PR TITLE
api: Implement custom events framework in gRPC-Java server

### DIFF
--- a/api/src/main/java/io/grpc/Contexts.java
+++ b/api/src/main/java/io/grpc/Contexts.java
@@ -118,6 +118,16 @@ public final class Contexts {
         context.detach(previous);
       }
     }
+
+    @Override
+    public void onEvent(Object event) {
+      Context previous = context.attach();
+      try {
+        super.onEvent(event);
+      } finally {
+        context.detach(previous);
+      }
+    }
   }
 
   /**

--- a/api/src/main/java/io/grpc/PartialForwardingServerCall.java
+++ b/api/src/main/java/io/grpc/PartialForwardingServerCall.java
@@ -88,6 +88,11 @@ abstract class PartialForwardingServerCall<ReqT, RespT> extends ServerCall<ReqT,
   }
 
   @Override
+  public void triggerEvent(Object event) {
+    delegate().triggerEvent(event);
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper(this).add("delegate", delegate()).toString();
   }

--- a/api/src/main/java/io/grpc/PartialForwardingServerCallListener.java
+++ b/api/src/main/java/io/grpc/PartialForwardingServerCallListener.java
@@ -51,6 +51,11 @@ abstract class PartialForwardingServerCallListener<ReqT>
   }
 
   @Override
+  public void onEvent(Object event) {
+    delegate().onEvent(event);
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper(this).add("delegate", delegate()).toString();
   }

--- a/api/src/main/java/io/grpc/ServerCall.java
+++ b/api/src/main/java/io/grpc/ServerCall.java
@@ -279,7 +279,8 @@ public abstract class ServerCall<ReqT, RespT> {
    * Triggers a custom event to be processed by the listener.
    * The event will be delivered to {@link Listener#onEvent(Object)} on the call's executor.
    *
-   * <p>This method is thread-safe and can be called from any thread.
+   * <p>This method is thread-safe and can be called from any thread. No events will be delivered
+   * after the RPC is cancelled or completed.
    *
    * @param event the event to trigger.
    */

--- a/api/src/main/java/io/grpc/ServerCall.java
+++ b/api/src/main/java/io/grpc/ServerCall.java
@@ -110,6 +110,7 @@ public abstract class ServerCall<ReqT, RespT> {
      *
      * @param event the triggered event.
      */
+    @ExperimentalApi("https://github.com/grpc/grpc-java/issues/12979")
     public void onEvent(Object event) {
       // Default no-op
     }
@@ -284,6 +285,7 @@ public abstract class ServerCall<ReqT, RespT> {
    *
    * @param event the event to trigger.
    */
+  @ExperimentalApi("https://github.com/grpc/grpc-java/issues/12979")
   public void triggerEvent(Object event) {
     // Default no-op
   }

--- a/api/src/main/java/io/grpc/ServerCall.java
+++ b/api/src/main/java/io/grpc/ServerCall.java
@@ -100,6 +100,19 @@ public abstract class ServerCall<ReqT, RespT> {
      * <em>another</em> {@code onReady()} callback.
      */
     public void onReady() {}
+
+    /**
+     * A custom event has been triggered by the call.
+     *
+     * <p>This callback is guaranteed to run on the call's executor, serialized with other
+     * callbacks (like {@link #onMessage}, {@link #onHalfClose}). This means the implementation
+     * does not need internal synchronization to access call-specific state.
+     *
+     * @param event the triggered event.
+     */
+    public void onEvent(Object event) {
+      // Default no-op
+    }
   }
 
   /**
@@ -260,6 +273,18 @@ public abstract class ServerCall<ReqT, RespT> {
   @Nullable
   public String getAuthority() {
     return null;
+  }
+
+  /**
+   * Triggers a custom event to be processed by the listener.
+   * The event will be delivered to {@link Listener#onEvent(Object)} on the call's executor.
+   *
+   * <p>This method is thread-safe and can be called from any thread.
+   *
+   * @param event the event to trigger.
+   */
+  public void triggerEvent(Object event) {
+    // Default no-op
   }
 
   /**

--- a/api/src/main/java/io/grpc/ServerCall.java
+++ b/api/src/main/java/io/grpc/ServerCall.java
@@ -108,6 +108,14 @@ public abstract class ServerCall<ReqT, RespT> {
      * callbacks (like {@link #onMessage}, {@link #onHalfClose}). This means the implementation
      * does not need internal synchronization to access call-specific state.
      *
+     * <p><strong>Deadlock avoidance:</strong> In some transports (such as Binder transport)
+     * or when using a direct executor, this callback may be invoked while transport-level
+     * locks are held. Implementations should avoid acquiring locks that are held by callers of
+     * {@link ServerCall} methods (such as {@link ServerCall#triggerEvent},
+     * {@link ServerCall#close}, or {@link ServerCall#request}), and should avoid calling
+     * {@link ServerCall} methods while holding application-level locks, as this can lead to
+     * deadlocks from lock-order inversion.
+     *
      * @param event the triggered event.
      */
     @ExperimentalApi("https://github.com/grpc/grpc-java/issues/12979")
@@ -280,8 +288,19 @@ public abstract class ServerCall<ReqT, RespT> {
    * Triggers a custom event to be processed by the listener.
    * The event will be delivered to {@link Listener#onEvent(Object)} on the call's executor.
    *
-   * <p>This method is thread-safe and can be called from any thread. No events will be delivered
-   * after the RPC is cancelled or completed.
+   * <p>This method is safe to call from multiple threads without external synchronization. No
+   * events will be delivered after the RPC is cancelled or completed.
+   *
+   * <p><strong>Deadlock avoidance:</strong> Callers should avoid holding application-level or
+   * interceptor locks when calling this method. Depending on the transport and executor
+   * configuration (such as {@code directExecutor()} or transports like Binder),
+   * {@code triggerEvent} may acquire transport-level locks and may dispatch
+   * {@link Listener#onEvent(Object)} synchronously on the calling thread.
+   * If the caller holds an application lock while calling {@code triggerEvent}, and
+   * {@code onEvent} or a concurrent transport operation (such as {@link #close} or
+   * {@link #request}) attempts to acquire that same lock, a deadlock can occur from
+   * lock-order inversion. Applications should mutate internal state under lock, release
+   * the lock, and only then invoke {@code triggerEvent}.
    *
    * @param event the event to trigger.
    */

--- a/api/src/test/java/io/grpc/ContextsTest.java
+++ b/api/src/test/java/io/grpc/ContextsTest.java
@@ -82,6 +82,11 @@ public class ContextsTest {
         assertSame(uniqueContext, Context.current());
         methodCalls.add(5);
       }
+
+      @Override public void onEvent(Object event) {
+        assertSame(uniqueContext, Context.current());
+        methodCalls.add(6);
+      }
     };
     ServerCall.Listener<Object> wrapped = interceptCall(uniqueContext, call, headers,
         new ServerCallHandler<Object, Object>() {
@@ -101,7 +106,8 @@ public class ContextsTest {
     wrapped.onCancel();
     wrapped.onComplete();
     wrapped.onReady();
-    assertEquals(Arrays.asList(1, 2, 3, 4, 5), methodCalls);
+    wrapped.onEvent(new Object());
+    assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6), methodCalls);
     assertSame(origContext, Context.current());
   }
 
@@ -145,6 +151,10 @@ public class ContextsTest {
       @Override public void onReady() {
         throw new RuntimeException();
       }
+
+      @Override public void onEvent(Object event) {
+        throw new RuntimeException();
+      }
     };
     ServerCall.Listener<Object> wrapped = interceptCall(uniqueContext, call, headers,
         new ServerCallHandler<Object, Object>() {
@@ -177,6 +187,11 @@ public class ContextsTest {
     }
     try {
       wrapped.onReady();
+      fail("Exception expected");
+    } catch (RuntimeException expected) {
+    }
+    try {
+      wrapped.onEvent(new Object());
       fail("Exception expected");
     } catch (RuntimeException expected) {
     }

--- a/binder/src/main/java/io/grpc/binder/internal/Inbound.java
+++ b/binder/src/main/java/io/grpc/binder/internal/Inbound.java
@@ -669,15 +669,13 @@ abstract class Inbound<L extends StreamListener, T extends BinderTransport>
     }
 
     void triggerEvent(Object event) {
-      ServerStreamListener localListener;
       synchronized (this) {
         if (isClosed()) {
           return;
         }
-        localListener = listener;
-      }
-      if (localListener != null) {
-        localListener.triggerEvent(event);
+        if (listener != null) {
+          listener.triggerEvent(event);
+        }
       }
     }
 

--- a/binder/src/main/java/io/grpc/binder/internal/Inbound.java
+++ b/binder/src/main/java/io/grpc/binder/internal/Inbound.java
@@ -671,6 +671,9 @@ abstract class Inbound<L extends StreamListener, T extends BinderTransport>
     void triggerEvent(Object event) {
       ServerStreamListener localListener;
       synchronized (this) {
+        if (isClosed()) {
+          return;
+        }
         localListener = listener;
       }
       if (localListener != null) {

--- a/binder/src/main/java/io/grpc/binder/internal/Inbound.java
+++ b/binder/src/main/java/io/grpc/binder/internal/Inbound.java
@@ -668,6 +668,16 @@ abstract class Inbound<L extends StreamListener, T extends BinderTransport>
       listener.closed(status);
     }
 
+    void triggerEvent(Object event) {
+      ServerStreamListener localListener;
+      synchronized (this) {
+        localListener = listener;
+      }
+      if (localListener != null) {
+        localListener.triggerEvent(event);
+      }
+    }
+
     @GuardedBy("this")
     void onCloseSent(Status status) {
       if (!isClosed()) {

--- a/binder/src/main/java/io/grpc/binder/internal/MultiMessageServerStream.java
+++ b/binder/src/main/java/io/grpc/binder/internal/MultiMessageServerStream.java
@@ -176,6 +176,11 @@ final class MultiMessageServerStream implements ServerStream {
   }
 
   @Override
+  public void triggerEvent(Object event) {
+    // Ignore.
+  }
+
+  @Override
   public void optimizeForDirectExecutor() {
     // Ignore.
   }

--- a/binder/src/main/java/io/grpc/binder/internal/MultiMessageServerStream.java
+++ b/binder/src/main/java/io/grpc/binder/internal/MultiMessageServerStream.java
@@ -177,7 +177,7 @@ final class MultiMessageServerStream implements ServerStream {
 
   @Override
   public void triggerEvent(Object event) {
-    // Ignore.
+    inbound.triggerEvent(event);
   }
 
   @Override

--- a/binder/src/main/java/io/grpc/binder/internal/PendingAuthListener.java
+++ b/binder/src/main/java/io/grpc/binder/internal/PendingAuthListener.java
@@ -88,6 +88,12 @@ final class PendingAuthListener<ReqT, RespT> extends ServerCall.Listener<ReqT> {
     maybeRunPendingSteps();
   }
 
+  @Override
+  public void onEvent(Object event) {
+    pendingSteps.offer(delegate -> delegate.onEvent(event));
+    maybeRunPendingSteps();
+  }
+
   /**
    * Similar to Java8's {@link java.util.function.Consumer}, but redeclared in order to support
    * Android SDK 21.

--- a/binder/src/main/java/io/grpc/binder/internal/SingleMessageServerStream.java
+++ b/binder/src/main/java/io/grpc/binder/internal/SingleMessageServerStream.java
@@ -169,7 +169,7 @@ final class SingleMessageServerStream implements ServerStream {
 
   @Override
   public void triggerEvent(Object event) {
-    // Ignore.
+    inbound.triggerEvent(event);
   }
 
   @Override

--- a/binder/src/main/java/io/grpc/binder/internal/SingleMessageServerStream.java
+++ b/binder/src/main/java/io/grpc/binder/internal/SingleMessageServerStream.java
@@ -168,6 +168,11 @@ final class SingleMessageServerStream implements ServerStream {
   }
 
   @Override
+  public void triggerEvent(Object event) {
+    // Ignore.
+  }
+
+  @Override
   public void optimizeForDirectExecutor() {
     // Ignore.
   }

--- a/binder/src/test/java/io/grpc/binder/AsyncSecurityPoliciesTest.java
+++ b/binder/src/test/java/io/grpc/binder/AsyncSecurityPoliciesTest.java
@@ -289,6 +289,7 @@ public final class AsyncSecurityPoliciesTest {
     ListenableFuture<Status> authFuture = asyncPolicy.checkAuthorizationAsync(SOME_UID);
     assertThat(awaitResult(settableUid)).isEqualTo(SOME_UID);
     authFuture.cancel(false);
+    executor.submit(() -> {}).get(10, TimeUnit.SECONDS);
 
     assertThat(delegateAuthFuture.isCancelled()).isTrue();
   }

--- a/binder/src/test/java/io/grpc/binder/internal/PendingAuthListenerTest.java
+++ b/binder/src/test/java/io/grpc/binder/internal/PendingAuthListenerTest.java
@@ -45,6 +45,7 @@ public final class PendingAuthListenerTest {
   public void onCallbacks_noOpBeforeStartCall() {
     listener.onReady();
     listener.onMessage("foo");
+    listener.onEvent("bar");
     listener.onHalfClose();
     listener.onComplete();
 
@@ -54,16 +55,19 @@ public final class PendingAuthListenerTest {
   @Test
   public void onCallbacks_runsPendingCallbacksAfterStartCall() {
     String message = "foo";
+    String event = "bar";
 
     // Act 1
     listener.onReady();
     listener.onMessage(message);
+    listener.onEvent(event);
     listener.startCall(call, headers, next);
 
     // Assert 1
     InOrder order = Mockito.inOrder(delegate);
     order.verify(delegate).onReady();
     order.verify(delegate).onMessage(message);
+    order.verify(delegate).onEvent(event);
 
     // Act 2
     listener.onHalfClose();

--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -178,9 +178,7 @@ public abstract class AbstractServerStream extends AbstractStream
     transportState().runOnTransportThread(new Runnable() {
       @Override
       public void run() {
-        if (transportState().listener != null) {
-          transportState().listener.triggerEvent(event);
-        }
+        transportState().triggerEvent(event);
       }
     });
   }
@@ -270,6 +268,13 @@ public abstract class AbstractServerStream extends AbstractStream
     }
 
 
+
+    public final void triggerEvent(Object event) {
+      if (listenerClosed) {
+        return;
+      }
+      listener().triggerEvent(event);
+    }
 
     @Override
     protected ServerStreamListener listener() {

--- a/core/src/main/java/io/grpc/internal/AbstractServerStream.java
+++ b/core/src/main/java/io/grpc/internal/AbstractServerStream.java
@@ -174,6 +174,18 @@ public abstract class AbstractServerStream extends AbstractStream
   }
 
   @Override
+  public final void triggerEvent(final Object event) {
+    transportState().runOnTransportThread(new Runnable() {
+      @Override
+      public void run() {
+        if (transportState().listener != null) {
+          transportState().listener.triggerEvent(event);
+        }
+      }
+    });
+  }
+
+  @Override
   public StatsTraceContext statsTraceContext() {
     return statsTraceCtx;
   }

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -256,7 +256,10 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
 
   @Override
   public void triggerEvent(Object event) {
-    stream.triggerEvent(event);
+    try (TaskCloseable ignore = PerfMark.traceTask("ServerCall.triggerEvent")) {
+      PerfMark.attachTag(tag);
+      stream.triggerEvent(event);
+    }
   }
 
   @Override
@@ -403,10 +406,13 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
 
     @Override
     public void triggerEvent(Object event) {
-      if (call.cancelled) {
-        return;
+      try (TaskCloseable ignore = PerfMark.traceTask("ServerStreamListener.triggerEvent")) {
+        PerfMark.attachTag(call.tag);
+        if (call.cancelled) {
+          return;
+        }
+        listener.onEvent(event);
       }
-      listener.onEvent(event);
     }
   }
 }

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -256,6 +256,9 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
 
   @Override
   public void triggerEvent(Object event) {
+    if (closeCalled) {
+      return;
+    }
     try (TaskCloseable ignore = PerfMark.traceTask("ServerCall.triggerEvent")) {
       PerfMark.attachTag(tag);
       stream.triggerEvent(event);

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -255,6 +255,11 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
   }
 
   @Override
+  public void triggerEvent(Object event) {
+    stream.triggerEvent(event);
+  }
+
+  @Override
   public SecurityLevel getSecurityLevel() {
     final Attributes attributes = getAttributes();
     if (attributes == null) {
@@ -394,6 +399,14 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
         }
         listener.onReady();
       }
+    }
+
+    @Override
+    public void triggerEvent(Object event) {
+      if (call.cancelled) {
+        return;
+      }
+      listener.onEvent(event);
     }
   }
 }

--- a/core/src/main/java/io/grpc/internal/ServerCallImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerCallImpl.java
@@ -256,9 +256,6 @@ final class ServerCallImpl<ReqT, RespT> extends ServerCall<ReqT, RespT> {
 
   @Override
   public void triggerEvent(Object event) {
-    if (closeCalled) {
-      return;
-    }
     try (TaskCloseable ignore = PerfMark.traceTask("ServerCall.triggerEvent")) {
       PerfMark.attachTag(tag);
       stream.triggerEvent(event);

--- a/core/src/main/java/io/grpc/internal/ServerImpl.java
+++ b/core/src/main/java/io/grpc/internal/ServerImpl.java
@@ -781,6 +781,9 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
 
     @Override
     public void onReady() {}
+
+    @Override
+    public void triggerEvent(Object event) {}
   }
 
   /**
@@ -958,6 +961,34 @@ public final class ServerImpl extends io.grpc.Server implements InternalInstrume
         }
 
         callExecutor.execute(new OnReady());
+      }
+    }
+
+    @Override
+    public void triggerEvent(final Object event) {
+      try (TaskCloseable ignore = PerfMark.traceTask("ServerStreamListener.triggerEvent")) {
+        PerfMark.attachTag(tag);
+        final Link link = PerfMark.linkOut();
+
+        final class TriggerEvent extends ContextRunnable {
+          TriggerEvent() {
+            super(context);
+          }
+
+          @Override
+          public void runInContext() {
+            try (TaskCloseable ignore = PerfMark.traceTask("ServerCallListener(app).onEvent")) {
+              PerfMark.attachTag(tag);
+              PerfMark.linkIn(link);
+              getListener().triggerEvent(event);
+            } catch (Throwable t) {
+              internalClose(t);
+              throw t;
+            }
+          }
+        }
+
+        callExecutor.execute(new TriggerEvent());
       }
     }
   }

--- a/core/src/main/java/io/grpc/internal/ServerStream.java
+++ b/core/src/main/java/io/grpc/internal/ServerStream.java
@@ -88,6 +88,12 @@ public interface ServerStream extends Stream {
   void setListener(ServerStreamListener serverStreamListener);
 
   /**
+   * Triggers a custom event. Implementations must ensure this is propagated to the
+   * listener on the transport thread.
+   */
+  void triggerEvent(Object event);
+
+  /**
    * The context for recording stats and traces for this stream.
    */
   StatsTraceContext statsTraceContext();

--- a/core/src/main/java/io/grpc/internal/ServerStreamListener.java
+++ b/core/src/main/java/io/grpc/internal/ServerStreamListener.java
@@ -42,4 +42,9 @@ public interface ServerStreamListener extends StreamListener {
    * @param status details about the remote closure
    */
   void closed(Status status);
+
+  /**
+   * Propagates a custom event to the listener. Must be called on the transport thread.
+   */
+  void triggerEvent(Object event);
 }

--- a/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
@@ -391,6 +391,9 @@ public class AbstractServerStreamTest {
 
     @Override
     public void closed(Status status) {}
+
+    @Override
+    public void triggerEvent(Object event) {}
   }
 
   private static class AbstractServerStreamBase extends AbstractServerStream {

--- a/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
+++ b/core/src/test/java/io/grpc/internal/AbstractServerStreamTest.java
@@ -362,6 +362,31 @@ public class AbstractServerStreamTest {
   }
 
   @Test
+  public void triggerEvent_propagatesToListener() {
+    ServerStreamListener listener = mock(ServerStreamListener.class);
+    stream.transportState().setListener(listener);
+
+    Object event = new Object();
+    stream.triggerEvent(event);
+
+    verify(listener).triggerEvent(event);
+  }
+
+  @Test
+  public void triggerEvent_ignoredAfterClose() {
+    ServerStreamListener listener = mock(ServerStreamListener.class);
+    stream.transportState().setListener(listener);
+
+    stream.close(Status.OK, new Metadata());
+    stream.transportState().complete();
+
+    Object event = new Object();
+    stream.triggerEvent(event);
+
+    verify(listener, never()).triggerEvent(any());
+  }
+
+  @Test
   public void changeOnReadyThreshold() {
     stream.setListener(new ServerStreamListenerBase());
     stream.transportState().onStreamAllocated();

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -493,6 +493,32 @@ public class ServerCallImplTest {
     assertThat(e).hasMessageThat().isEqualTo("unexpected exception");
   }
 
+  @Test
+  public void triggerEvent_propagatesToStream() {
+    Object event = new Object();
+    call.triggerEvent(event);
+    verify(stream).triggerEvent(event);
+  }
+
+  @Test
+  public void streamListener_triggerEvent() {
+    ServerStreamListenerImpl<Long> streamListener =
+        new ServerCallImpl.ServerStreamListenerImpl<>(call, callListener, context);
+    Object event = new Object();
+    streamListener.triggerEvent(event);
+    verify(callListener).onEvent(event);
+  }
+
+  @Test
+  public void streamListener_triggerEvent_cancelled() {
+    ServerStreamListenerImpl<Long> streamListener =
+        new ServerCallImpl.ServerStreamListenerImpl<>(call, callListener, context);
+    Object event = new Object();
+    streamListener.closed(Status.CANCELLED);
+    streamListener.triggerEvent(event);
+    verify(callListener, never()).onEvent(event);
+  }
+
   private static class LongMarshaller implements Marshaller<Long> {
     @Override
     public InputStream stream(Long value) {

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -501,6 +501,14 @@ public class ServerCallImplTest {
   }
 
   @Test
+  public void triggerEvent_afterClose_noop() {
+    call.close(Status.OK, new Metadata());
+    Object event = new Object();
+    call.triggerEvent(event);
+    verify(stream, never()).triggerEvent(event);
+  }
+
+  @Test
   public void streamListener_triggerEvent() {
     ServerStreamListenerImpl<Long> streamListener =
         new ServerCallImpl.ServerStreamListenerImpl<>(call, callListener, context);

--- a/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerCallImplTest.java
@@ -501,12 +501,13 @@ public class ServerCallImplTest {
   }
 
   @Test
-  public void triggerEvent_afterClose_noop() {
+  public void triggerEvent_afterClose_propagatesToStream() {
     call.close(Status.OK, new Metadata());
     Object event = new Object();
     call.triggerEvent(event);
-    verify(stream, never()).triggerEvent(event);
+    verify(stream).triggerEvent(event);
   }
+
 
   @Test
   public void streamListener_triggerEvent() {

--- a/core/src/test/java/io/grpc/internal/ServerImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ServerImplTest.java
@@ -1690,6 +1690,52 @@ public class ServerImplTest {
   }
 
   @Test
+  public void triggerEvent_delegatesToListener() {
+    JumpToApplicationThreadServerStreamListener listener
+        = new JumpToApplicationThreadServerStreamListener(
+            executor.getScheduledExecutorService(),
+            executor.getScheduledExecutorService(),
+            stream,
+            Context.ROOT.withCancellation(),
+            PerfMark.createTag());
+    ServerStreamListener mockListener = mock(ServerStreamListener.class);
+    listener.setListener(mockListener);
+
+    Object event = new Object();
+    listener.triggerEvent(event);
+
+    verify(mockListener, never()).triggerEvent(any());
+
+    executor.runDueTasks();
+    verify(mockListener).triggerEvent(event);
+  }
+
+  @Test
+  public void triggerEvent_errorCancelsCall() {
+    JumpToApplicationThreadServerStreamListener listener
+        = new JumpToApplicationThreadServerStreamListener(
+            executor.getScheduledExecutorService(),
+            executor.getScheduledExecutorService(),
+            stream,
+            Context.ROOT.withCancellation(),
+            PerfMark.createTag());
+    ServerStreamListener mockListener = mock(ServerStreamListener.class);
+    listener.setListener(mockListener);
+
+    TestError expectedT = new TestError();
+    doThrow(expectedT).when(mockListener).triggerEvent(any());
+
+    listener.triggerEvent(new Object());
+    try {
+      executor.runDueTasks();
+      fail("Expected exception");
+    } catch (TestError t) {
+      assertSame(expectedT, t);
+      ensureServerStateNotLeaked();
+    }
+  }
+
+  @Test
   public void binaryLogInstalled() throws Exception {
     final SettableFuture<Boolean> intercepted = SettableFuture.create();
     final ServerInterceptor interceptor = new ServerInterceptor() {

--- a/core/src/testFixtures/java/io/grpc/internal/AbstractTransportTest.java
+++ b/core/src/testFixtures/java/io/grpc/internal/AbstractTransportTest.java
@@ -2117,6 +2117,36 @@ public abstract class AbstractTransportTest {
     clientStream.cancel(Status.CANCELLED);
   }
 
+  @Test
+  public void serverStream_triggerEvent_afterClose() throws Exception {
+    server.start(serverListener);
+    client = newClientTransport(server);
+    startTransport(client, mockClientTransportListener);
+    MockServerTransportListener serverTransportListener
+        = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    serverTransport = serverTransportListener.transport;
+
+    ClientStream clientStream = client.newStream(
+        methodDescriptor, new Metadata(), callOptions, noopTracers);
+    ClientStreamListenerBase clientStreamListener = new ClientStreamListenerBase();
+    clientStream.start(clientStreamListener);
+
+    StreamCreation serverStreamCreation
+        = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    ServerStream serverStream = serverStreamCreation.stream;
+    ServerStreamListenerBase serverStreamListener = serverStreamCreation.listener;
+
+    // Close the stream from client side
+    clientStream.cancel(Status.CANCELLED);
+
+    Object event = new Object();
+    serverStream.triggerEvent(event);
+
+    // Verify listener did NOT receive the event
+    Object receivedEvent = serverStreamListener.eventQueue.poll(100, TimeUnit.MILLISECONDS);
+    assertNull(receivedEvent);
+  }
+
   /**
    * Helper that simply does an RPC. It can be used similar to a sleep for negative testing: to give
    * time for actions _not_ to happen. Since it is based on doing an actual RPC with actual

--- a/core/src/testFixtures/java/io/grpc/internal/AbstractTransportTest.java
+++ b/core/src/testFixtures/java/io/grpc/internal/AbstractTransportTest.java
@@ -2139,6 +2139,8 @@ public abstract class AbstractTransportTest {
     // Close the stream from client side
     clientStream.cancel(Status.CANCELLED);
 
+    serverStreamListener.awaitClose(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
     Object event = new Object();
     serverStream.triggerEvent(event);
 

--- a/core/src/testFixtures/java/io/grpc/internal/AbstractTransportTest.java
+++ b/core/src/testFixtures/java/io/grpc/internal/AbstractTransportTest.java
@@ -2088,6 +2088,35 @@ public abstract class AbstractTransportTest {
     assertNull(metadata.get(tellTaleKey));
   }
 
+  @Test
+  public void serverStream_triggerEvent() throws Exception {
+    server.start(serverListener);
+    client = newClientTransport(server);
+    startTransport(client, mockClientTransportListener);
+    MockServerTransportListener serverTransportListener
+        = serverListener.takeListenerOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    serverTransport = serverTransportListener.transport;
+
+    ClientStream clientStream = client.newStream(
+        methodDescriptor, new Metadata(), callOptions, noopTracers);
+    ClientStreamListenerBase clientStreamListener = new ClientStreamListenerBase();
+    clientStream.start(clientStreamListener);
+
+    StreamCreation serverStreamCreation
+        = serverTransportListener.takeStreamOrFail(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    ServerStream serverStream = serverStreamCreation.stream;
+    ServerStreamListenerBase serverStreamListener = serverStreamCreation.listener;
+
+    Object event = new Object();
+    serverStream.triggerEvent(event);
+
+    Object receivedEvent = serverStreamListener.eventQueue.poll(TIMEOUT_MS, TimeUnit.MILLISECONDS);
+    assertEquals(event, receivedEvent);
+
+    // Cleanup
+    clientStream.cancel(Status.CANCELLED);
+  }
+
   /**
    * Helper that simply does an RPC. It can be used similar to a sleep for negative testing: to give
    * time for actions _not_ to happen. Since it is based on doing an actual RPC with actual

--- a/core/src/testFixtures/java/io/grpc/internal/AbstractTransportTest.java
+++ b/core/src/testFixtures/java/io/grpc/internal/AbstractTransportTest.java
@@ -2114,7 +2114,7 @@ public abstract class AbstractTransportTest {
     assertEquals(event, receivedEvent);
 
     // Cleanup
-    clientStream.cancel(Status.CANCELLED);
+    serverStream.close(Status.OK, new Metadata());
   }
 
   @Test

--- a/core/src/testFixtures/java/io/grpc/internal/MockServerTransportListener.java
+++ b/core/src/testFixtures/java/io/grpc/internal/MockServerTransportListener.java
@@ -45,8 +45,8 @@ public class MockServerTransportListener implements ServerTransportListener {
   @Override
   public void streamCreated(ServerStream stream, String method, Metadata headers) {
     ServerStreamListenerBase listener = new ServerStreamListenerBase();
-    streams.add(new StreamCreation(stream, method, headers, listener));
     stream.setListener(listener);
+    streams.add(new StreamCreation(stream, method, headers, listener));
   }
 
   @Override

--- a/core/src/testFixtures/java/io/grpc/internal/ServerStreamListenerBase.java
+++ b/core/src/testFixtures/java/io/grpc/internal/ServerStreamListenerBase.java
@@ -89,11 +89,21 @@ public class ServerStreamListenerBase implements ServerStreamListener {
     halfClosedLatch.countDown();
   }
 
+  public final BlockingQueue<Object> eventQueue = new LinkedBlockingQueue<>();
+
   @Override
   public void closed(Status status) {
     if (this.status.isDone()) {
       fail("closed invoked more than once");
     }
     this.status.set(status);
+  }
+
+  @Override
+  public void triggerEvent(Object event) {
+    if (this.status.isDone()) {
+      fail("triggerEvent invoked after closed");
+    }
+    eventQueue.add(event);
   }
 }

--- a/inprocess/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/inprocess/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -739,7 +739,7 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
 
       void triggerServerEvent(final Object event) {
         synchronized (this) {
-          if (!closed && serverStreamListener != null) {
+          if (!closed) {
             syncContext.executeLater(new Runnable() {
               @Override
               public void run() {

--- a/inprocess/src/main/java/io/grpc/inprocess/InProcessTransport.java
+++ b/inprocess/src/main/java/io/grpc/inprocess/InProcessTransport.java
@@ -430,6 +430,11 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
       }
 
       @Override
+      public void triggerEvent(Object event) {
+        clientStream.triggerServerEvent(event);
+      }
+
+      @Override
       public void request(int numMessages) {
         boolean onReady = clientStream.serverRequested(numMessages);
         if (onReady) {
@@ -730,6 +735,20 @@ final class InProcessTransport implements ServerTransport, ConnectionClientTrans
 
       private synchronized void setListener(ServerStreamListener listener) {
         this.serverStreamListener = listener;
+      }
+
+      void triggerServerEvent(final Object event) {
+        synchronized (this) {
+          if (!closed && serverStreamListener != null) {
+            syncContext.executeLater(new Runnable() {
+              @Override
+              public void run() {
+                serverStreamListener.triggerEvent(event);
+              }
+            });
+          }
+        }
+        syncContext.drain();
       }
 
       @Override

--- a/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
+++ b/netty/src/test/java/io/grpc/netty/NettyClientTransportTest.java
@@ -1343,6 +1343,10 @@ public class NettyClientTransportTest {
     @Override
     public void closed(Status status) {
     }
+
+    @Override
+    public void triggerEvent(Object event) {
+    }
   }
 
   private final class EchoServerListener implements ServerListener {

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpServerTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpServerTransportTest.java
@@ -1519,6 +1519,10 @@ public class OkHttpServerTransportTest {
     public void onReady() {
     }
 
+    @Override
+    public void triggerEvent(Object event) {
+    }
+
     static String getContent(InputStream message) throws IOException {
       try {
         return new String(ByteStreams.toByteArray(message), UTF_8);

--- a/opentelemetry/src/main/java/io/grpc/opentelemetry/OpenTelemetryTracingModule.java
+++ b/opentelemetry/src/main/java/io/grpc/opentelemetry/OpenTelemetryTracingModule.java
@@ -452,6 +452,13 @@ final class OpenTelemetryTracingModule {
         delegate().onReady();
       }
     }
+
+    @Override
+    public void onEvent(Object event) {
+      try (Scope scope = context.makeCurrent()) {
+        delegate().onEvent(event);
+      }
+    }
   }
 
   @VisibleForTesting

--- a/opentelemetry/src/test/java/io/grpc/opentelemetry/OpenTelemetryTracingModuleTest.java
+++ b/opentelemetry/src/test/java/io/grpc/opentelemetry/OpenTelemetryTracingModuleTest.java
@@ -948,6 +948,11 @@ public class OpenTelemetryTracingModuleTest {
       public void onComplete() {
         callbackSpan.set(Span.fromContext(Context.current()));
       }
+
+      @Override
+      public void onEvent(Object event) {
+        callbackSpan.set(Span.fromContext(Context.current()));
+      }
     };
     ServerInterceptor interceptor = tracingModule.getServerSpanPropagationInterceptor();
     @SuppressWarnings("unchecked")
@@ -966,6 +971,8 @@ public class OpenTelemetryTracingModuleTest {
     listener.onHalfClose();
     assertEquals(callbackSpan.get(), Span.getInvalid());
     listener.onComplete();
+    assertEquals(callbackSpan.get(), Span.getInvalid());
+    listener.onEvent(new Object());
     assertEquals(callbackSpan.get(), Span.getInvalid());
 
     Span parentSpan = tracerRule.spanBuilder("parent-span").startSpan();
@@ -988,6 +995,9 @@ public class OpenTelemetryTracingModuleTest {
       assertEquals(callbackSpan.get().getSpanContext().getTraceId(),
           parentSpan.getSpanContext().getTraceId());
       listener.onComplete();
+      assertEquals(callbackSpan.get().getSpanContext().getTraceId(),
+          parentSpan.getSpanContext().getTraceId());
+      listener.onEvent(new Object());
       assertEquals(callbackSpan.get().getSpanContext().getTraceId(),
           parentSpan.getSpanContext().getTraceId());
     } finally {

--- a/util/src/main/java/io/grpc/util/TransmitStatusRuntimeExceptionInterceptor.java
+++ b/util/src/main/java/io/grpc/util/TransmitStatusRuntimeExceptionInterceptor.java
@@ -104,6 +104,15 @@ public final class TransmitStatusRuntimeExceptionInterceptor implements ServerIn
         }
       }
 
+      @Override
+      public void onEvent(Object event) {
+        try {
+          super.onEvent(event);
+        } catch (StatusRuntimeException e) {
+          closeWithException(e);
+        }
+      }
+
       private void closeWithException(StatusRuntimeException t) {
         Metadata metadata = t.getTrailers();
         if (metadata == null) {
@@ -275,6 +284,16 @@ public final class TransmitStatusRuntimeExceptionInterceptor implements ServerIn
       } catch (ExecutionException e) {
         throw new RuntimeException(ERROR_MSG, e);
       }
+    }
+
+    @Override
+    public void triggerEvent(final Object event) {
+      serializingExecutor.execute(new Runnable() {
+        @Override
+        public void run() {
+          SerializingServerCall.super.triggerEvent(event);
+        }
+      });
     }
   }
 }

--- a/util/src/test/java/io/grpc/util/UtilServerInterceptorsTest.java
+++ b/util/src/test/java/io/grpc/util/UtilServerInterceptorsTest.java
@@ -31,7 +31,10 @@ import io.grpc.ServiceDescriptor;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.testing.TestMethodDescriptors;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -183,6 +186,7 @@ public class UtilServerInterceptorsTest {
         getSoleMethod(intercepted).getServerCallHandler().startCall(call, headers);
     callDoubleSreListener.onMessage(null); // the only close with our exception
     callDoubleSreListener.onHalfClose(); // should not trigger a close
+    callDoubleSreListener.onEvent(new Object()); // should not trigger a close
 
     // this listener closes the call when it is initialized with startCall
     listener = new VoidCallListener() {
@@ -195,13 +199,116 @@ public class UtilServerInterceptorsTest {
       public void onHalfClose() {
         throw exception;
       }
+
+      @Override
+      public void onEvent(Object event) {
+        throw exception;
+      }
     };
 
     ServerCall.Listener<Void> callClosedListener =
         getSoleMethod(intercepted).getServerCallHandler().startCall(call, headers);
     // call is already closed, does not match exception
     callClosedListener.onHalfClose(); // should not trigger a close
+    callClosedListener.onEvent(new Object()); // should not trigger a close
     assertEquals(1, call.numCloses);
+  }
+
+  @Test
+  public void statusRuntimeExceptionTransmitter_onEvent_transmitsStatusAndTrailers() {
+    final Status expectedStatus = Status.RESOURCE_EXHAUSTED.withDescription("rate limited");
+    final Metadata expectedMetadata = new Metadata();
+    Metadata.Key<String> key =
+        Metadata.Key.of("custom-trailer", Metadata.ASCII_STRING_MARSHALLER);
+    expectedMetadata.put(key, "val");
+
+    final java.util.concurrent.atomic.AtomicReference<Status> closedStatus =
+        new java.util.concurrent.atomic.AtomicReference<>();
+    final java.util.concurrent.atomic.AtomicReference<Metadata> closedTrailers =
+        new java.util.concurrent.atomic.AtomicReference<>();
+
+    FakeServerCall<Void, Void> call =
+        new FakeServerCall<Void, Void>(expectedStatus, expectedMetadata) {
+          @Override
+          public void close(Status status, Metadata trailers) {
+            closedStatus.set(status);
+            closedTrailers.set(trailers);
+            super.close(status, trailers);
+          }
+        };
+
+    final StatusRuntimeException exception =
+        new StatusRuntimeException(expectedStatus, expectedMetadata);
+
+    listener = new VoidCallListener() {
+      @Override
+      public void onEvent(Object event) {
+        throw exception;
+      }
+    };
+
+    ServerServiceDefinition intercepted = ServerInterceptors.intercept(
+        serviceDefinition,
+        Arrays.asList(TransmitStatusRuntimeExceptionInterceptor.instance()));
+
+    // When onEvent throws StatusRuntimeException, it should close the call with status and trailers
+    getSoleMethod(intercepted).getServerCallHandler().startCall(call, headers).onEvent("event");
+
+    assertEquals(1, call.numCloses);
+    assertEquals(expectedStatus, closedStatus.get());
+    assertEquals("val", closedTrailers.get().get(key));
+  }
+
+  @Test
+  public void statusRuntimeExceptionTransmitter_serializingServerCall_serializesTriggerEvent() {
+    final List<String> executionOrder = Collections.synchronizedList(new ArrayList<String>());
+    FakeServerCall<Void, Void> call = new FakeServerCall<Void, Void>(Status.OK, new Metadata()) {
+      @Override
+      public void sendHeaders(Metadata headers) {
+        executionOrder.add("sendHeaders");
+      }
+
+      @Override
+      public void triggerEvent(Object event) {
+        executionOrder.add("triggerEvent:" + event);
+      }
+
+      @Override
+      public void sendMessage(Void message) {
+        executionOrder.add("sendMessage");
+      }
+
+      @Override
+      public void close(Status status, Metadata trailers) {
+        executionOrder.add("close");
+      }
+    };
+
+    final java.util.concurrent.atomic.AtomicReference<ServerCall<Void, Void>> interceptedCall =
+        new java.util.concurrent.atomic.AtomicReference<>();
+    listener = new VoidCallListener() {
+      @Override
+      public void onCall(ServerCall<Void, Void> call, Metadata headers) {
+        interceptedCall.set(call);
+      }
+    };
+
+    ServerServiceDefinition intercepted = ServerInterceptors.intercept(
+        serviceDefinition,
+        Arrays.asList(TransmitStatusRuntimeExceptionInterceptor.instance()));
+    getSoleMethod(intercepted).getServerCallHandler().startCall(call, headers);
+
+    ServerCall<Void, Void> sc = interceptedCall.get();
+    sc.sendHeaders(new Metadata());
+    sc.triggerEvent("event1");
+    sc.sendMessage(null);
+    sc.triggerEvent("event2");
+    sc.close(Status.OK, new Metadata());
+
+    assertEquals(
+        Arrays.asList(
+            "sendHeaders", "triggerEvent:event1", "sendMessage", "triggerEvent:event2", "close"),
+        executionOrder);
   }
 
   private static class FakeServerCall<ReqT, RespT> extends NoopServerCall<ReqT, RespT> {

--- a/util/src/test/java/io/grpc/util/UtilServerInterceptorsTest.java
+++ b/util/src/test/java/io/grpc/util/UtilServerInterceptorsTest.java
@@ -104,6 +104,11 @@ public class UtilServerInterceptorsTest {
       public void onReady() {
         throw exception;
       }
+
+      @Override
+      public void onEvent(Object event) {
+        throw exception;
+      }
     };
 
     ServerServiceDefinition intercepted = ServerInterceptors.intercept(
@@ -116,7 +121,36 @@ public class UtilServerInterceptorsTest {
     getSoleMethod(intercepted).getServerCallHandler().startCall(call, headers).onComplete();
     getSoleMethod(intercepted).getServerCallHandler().startCall(call, headers).onHalfClose();
     getSoleMethod(intercepted).getServerCallHandler().startCall(call, headers).onReady();
-    assertEquals(5, call.numCloses);
+    getSoleMethod(intercepted).getServerCallHandler().startCall(call, headers)
+        .onEvent(new Object());
+    assertEquals(6, call.numCloses);
+  }
+
+  @Test
+  public void statusRuntimeExceptionTransmitter_serializingServerCall_triggerEvent() {
+    final java.util.concurrent.atomic.AtomicReference<Object> eventRef =
+        new java.util.concurrent.atomic.AtomicReference<>();
+    FakeServerCall<Void, Void> call = new FakeServerCall<Void, Void>(Status.OK, new Metadata()) {
+      @Override
+      public void triggerEvent(Object event) {
+        eventRef.set(event);
+      }
+    };
+    final java.util.concurrent.atomic.AtomicReference<ServerCall<Void, Void>> interceptedCall =
+        new java.util.concurrent.atomic.AtomicReference<>();
+    listener = new VoidCallListener() {
+      @Override
+      public void onCall(ServerCall<Void, Void> call, Metadata headers) {
+        interceptedCall.set(call);
+      }
+    };
+    ServerServiceDefinition intercepted = ServerInterceptors.intercept(
+        serviceDefinition,
+        Arrays.asList(TransmitStatusRuntimeExceptionInterceptor.instance()));
+    getSoleMethod(intercepted).getServerCallHandler().startCall(call, headers);
+    Object testEvent = new Object();
+    interceptedCall.get().triggerEvent(testEvent);
+    assertEquals(testEvent, eventRef.get());
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/ExternalProcessorClientInterceptorTest.java
+++ b/xds/src/test/java/io/grpc/xds/ExternalProcessorClientInterceptorTest.java
@@ -14301,6 +14301,7 @@ public class ExternalProcessorClientInterceptorTest {
   @Test
   public void clientInterceptor_contextPropagatedToStartCall() throws Exception {
     String uniqueExtProcServerName = InProcessServerBuilder.generateName();
+    final CountDownLatch extProcCompletedLatch = new CountDownLatch(1);
     ExternalProcessorGrpc.ExternalProcessorImplBase extProcImpl = 
         new ExternalProcessorGrpc.ExternalProcessorImplBase() {
           @Override
@@ -14321,11 +14322,14 @@ public class ExternalProcessorClientInterceptorTest {
               }
 
               @Override
-              public void onError(Throwable t) {}
+              public void onError(Throwable t) {
+                extProcCompletedLatch.countDown();
+              }
 
               @Override
               public void onCompleted() {
                 responseObserver.onCompleted();
+                extProcCompletedLatch.countDown();
               }
             };
           }
@@ -14390,6 +14394,13 @@ public class ExternalProcessorClientInterceptorTest {
 
     final AtomicReference<ClientCall<String, String>> proxyCallRef = new AtomicReference<>();
     ExecutorService callExecutor = Executors.newSingleThreadExecutor();
+    final CountDownLatch callClosedLatch = new CountDownLatch(1);
+    ClientCall.Listener<String> callListener = new ClientCall.Listener<String>() {
+      @Override
+      public void onClose(Status status, Metadata trailers) {
+        callClosedLatch.countDown();
+      }
+    };
     try {
       testContext.run(() -> {
         ClientCall<String, String> proxyCall = interceptCall(
@@ -14398,7 +14409,7 @@ public class ExternalProcessorClientInterceptorTest {
             DEFAULT_CALL_OPTIONS.withExecutor(callExecutor),
             dataPlaneChannel);
         proxyCallRef.set(proxyCall);
-        proxyCall.start(new ClientCall.Listener<String>() {}, new Metadata());
+        proxyCall.start(callListener, new Metadata());
       });
 
       ClientCall<String, String> proxyCall = proxyCallRef.get();
@@ -14409,6 +14420,8 @@ public class ExternalProcessorClientInterceptorTest {
 
       assertThat(downstreamStartLatch.await(5, TimeUnit.SECONDS)).isTrue();
       assertThat(contextValueAtDownstreamStart.get()).isEqualTo("test-value");
+      assertThat(callClosedLatch.await(5, TimeUnit.SECONDS)).isTrue();
+      assertThat(extProcCompletedLatch.await(5, TimeUnit.SECONDS)).isTrue();
 
       proxyCall.cancel("cleanup", null);
     } finally {
@@ -14423,6 +14436,7 @@ public class ExternalProcessorClientInterceptorTest {
   @Test
   public void clientInterceptor_contextPropagatedToListenerCallbacks() throws Exception {
     String uniqueExtProcServerName = InProcessServerBuilder.generateName();
+    final CountDownLatch extProcCompletedLatch = new CountDownLatch(1);
     ExternalProcessorGrpc.ExternalProcessorImplBase extProcImpl = 
         new ExternalProcessorGrpc.ExternalProcessorImplBase() {
           @Override
@@ -14443,11 +14457,14 @@ public class ExternalProcessorClientInterceptorTest {
               }
 
               @Override
-              public void onError(Throwable t) {}
+              public void onError(Throwable t) {
+                extProcCompletedLatch.countDown();
+              }
 
               @Override
               public void onCompleted() {
                 responseObserver.onCompleted();
+                extProcCompletedLatch.countDown();
               }
             };
           }
@@ -14542,6 +14559,7 @@ public class ExternalProcessorClientInterceptorTest {
       proxyCall.halfClose();
 
       assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+      assertThat(extProcCompletedLatch.await(5, TimeUnit.SECONDS)).isTrue();
 
       assertThat(onHeadersContext.get()).isEqualTo("test-value");
       assertThat(onMessageContext.get()).isEqualTo("test-value");
@@ -14561,6 +14579,7 @@ public class ExternalProcessorClientInterceptorTest {
   @Test
   public void clientInterceptor_contextPropagatedToExtProcStub() throws Exception {
     String uniqueExtProcServerName = InProcessServerBuilder.generateName();
+    final CountDownLatch extProcClosedLatch = new CountDownLatch(1);
     ExternalProcessorGrpc.ExternalProcessorImplBase extProcImpl = 
         new ExternalProcessorGrpc.ExternalProcessorImplBase() {
           @Override
@@ -14571,10 +14590,14 @@ public class ExternalProcessorClientInterceptorTest {
               public void onNext(ProcessingRequest request) {}
 
               @Override
-              public void onError(Throwable t) {}
+              public void onError(Throwable t) {
+                extProcClosedLatch.countDown();
+              }
 
               @Override
-              public void onCompleted() {}
+              public void onCompleted() {
+                extProcClosedLatch.countDown();
+              }
             };
           }
         };
@@ -14623,6 +14646,13 @@ public class ExternalProcessorClientInterceptorTest {
 
     final AtomicReference<ClientCall<String, String>> proxyCallRef = new AtomicReference<>();
     ExecutorService callExecutor = Executors.newSingleThreadExecutor();
+    final CountDownLatch callClosedLatch = new CountDownLatch(1);
+    ClientCall.Listener<String> callListener = new ClientCall.Listener<String>() {
+      @Override
+      public void onClose(Status status, Metadata trailers) {
+        callClosedLatch.countDown();
+      }
+    };
     try {
       testContext.run(() -> {
         ClientCall<String, String> proxyCall = interceptCall(
@@ -14631,7 +14661,7 @@ public class ExternalProcessorClientInterceptorTest {
             DEFAULT_CALL_OPTIONS.withExecutor(callExecutor),
             dataPlaneChannel);
         proxyCallRef.set(proxyCall);
-        proxyCall.start(new ClientCall.Listener<String>() {}, new Metadata());
+        proxyCall.start(callListener, new Metadata());
       });
 
       ClientCall<String, String> proxyCall = proxyCallRef.get();
@@ -14640,6 +14670,8 @@ public class ExternalProcessorClientInterceptorTest {
       assertThat(contextAtExtProcCall.get()).isEqualTo("test-value");
 
       proxyCall.cancel("cleanup", null);
+      assertThat(callClosedLatch.await(5, TimeUnit.SECONDS)).isTrue();
+      assertThat(extProcClosedLatch.await(5, TimeUnit.SECONDS)).isTrue();
     } finally {
       channelManager.close();
       shutdownAndAwaitTermination(extProcServerExecutor);


### PR DESCRIPTION
This adds triggerEvent/onEvent APIs to `ServerCall` and `ServerCall.Listener` routing them through `ServerStream` transport.

Addresses #7868 for server interceptors.