### PR TITLE
core: handle closed transport factory in InternalSubchannel without panic

### DIFF
--- a/core/src/main/java/io/grpc/internal/InternalSubchannel.java
+++ b/core/src/main/java/io/grpc/internal/InternalSubchannel.java
@@ -273,10 +273,20 @@ final class InternalSubchannel implements InternalInstrumented<ChannelStats>, Tr
     TransportLogger transportLogger = new TransportLogger();
     // In case the transport logs in the constructor, use the subchannel logId
     transportLogger.logId = getLogId();
-    ConnectionClientTransport transport =
-        new CallTracingTransport(
-            transportFactory
-                .newClientTransport(address, options, transportLogger), callsTracer);
+    ConnectionClientTransport rawTransport;
+    try {
+      rawTransport =
+          transportFactory.newClientTransport(address, options, transportLogger);
+    } catch (IllegalStateException e) {
+      channelLogger.log(
+          ChannelLogLevel.WARNING, "Transport factory is closed, shutting down subchannel", e);
+      shutdown(
+          Status.UNAVAILABLE
+              .withDescription("Transport factory is closed")
+              .withCause(e));
+      return;
+    }
+    ConnectionClientTransport transport = new CallTracingTransport(rawTransport, callsTracer);
     transportLogger.logId = transport.getLogId();
     channelz.addClientSocket(transport);
     pendingTransport = transport;

--- a/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
+++ b/core/src/test/java/io/grpc/internal/InternalSubchannelTest.java
@@ -1671,6 +1671,21 @@ public class InternalSubchannelTest {
     );
   }
 
+  @Test
+  public void transportFactoryClosed_shutsDownSubchannelSafely() {
+    SocketAddress addr = mock(SocketAddress.class);
+    createInternalSubchannel(addr);
+    assertEquals(IDLE, internalSubchannel.getState());
+
+    when(mockTransportFactory.newClientTransport(any(), any(), any()))
+        .thenThrow(new IllegalStateException("The transport factory is closed."));
+
+    assertNull(internalSubchannel.obtainActiveTransport());
+    assertExactCallbackInvokes(
+        "onStateChange:CONNECTING", "onStateChange:SHUTDOWN", "onTerminated");
+    assertEquals(SHUTDOWN, internalSubchannel.getState());
+  }
+
   private void assertNoCallbackInvoke() {
     while (fakeExecutor.runDueTasks() > 0) {}
     assertEquals(0, callbackInvokes.size());


### PR DESCRIPTION
Catch `IllegalStateException` when starting a new transport against a closed transport factory and shut down the subchannel safely instead of letting it escape into the `SynchronizationContext` and causing a channel panic.

[Internal yaqs](http://yaqs/840333647365013504) 
[Related CL](http://CL/956595914)