### PR TITLE
okhttp: Move connection window update before stream termination logic

### DIFF
--- a/okhttp/src/main/java/io/grpc/okhttp/OkHttpServerTransport.java
+++ b/okhttp/src/main/java/io/grpc/okhttp/OkHttpServerTransport.java
@@ -864,6 +864,19 @@ final class OkHttpServerTransport implements ServerTransport,
       // concerned with the window being exceeded at this point.
       in.require(length);
 
+      // connection window update
+      // The connection window must be updated even if the stream is in an errored state.
+      // See RFC 9113, section 6.9
+      connectionUnacknowledgedBytesRead += paddedLength;
+      if (connectionUnacknowledgedBytesRead
+          >= config.flowControlWindow * Utils.DEFAULT_WINDOW_UPDATE_RATIO) {
+        synchronized (lock) {
+          frameWriter.windowUpdate(0, connectionUnacknowledgedBytesRead);
+          frameWriter.flush();
+        }
+        connectionUnacknowledgedBytesRead = 0;
+      }
+
       synchronized (lock) {
         StreamState stream = streams.get(streamId);
         if (stream == null) {
@@ -886,17 +899,6 @@ final class OkHttpServerTransport implements ServerTransport,
         Buffer buf = new Buffer();
         buf.write(in.getBuffer(), length);
         stream.inboundDataReceived(buf, length, paddedLength - length, inFinished);
-      }
-
-      // connection window update
-      connectionUnacknowledgedBytesRead += paddedLength;
-      if (connectionUnacknowledgedBytesRead
-          >= config.flowControlWindow * Utils.DEFAULT_WINDOW_UPDATE_RATIO) {
-        synchronized (lock) {
-          frameWriter.windowUpdate(0, connectionUnacknowledgedBytesRead);
-          frameWriter.flush();
-        }
-        connectionUnacknowledgedBytesRead = 0;
       }
     }
 

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpServerTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpServerTransportTest.java
@@ -1067,6 +1067,7 @@ public class OkHttpServerTransportTest {
     writeDataDirectly(clientWriterSink, FLAG_PADDED | FLAG_END_STREAM, 1, message, 100);
     clientFrameWriter.flush();
     assertThat(clientFrameReader.nextFrame(clientFramesRead)).isTrue();
+    // Receive window update for the padded data size before stream reset
     verify(clientFramesRead).windowUpdate(0, expectedConsumed + 100);
     assertThat(clientFrameReader.nextFrame(clientFramesRead)).isTrue();
     verify(clientFramesRead).rstStream(eq(1), eq(ErrorCode.FLOW_CONTROL_ERROR));

--- a/okhttp/src/test/java/io/grpc/okhttp/OkHttpServerTransportTest.java
+++ b/okhttp/src/test/java/io/grpc/okhttp/OkHttpServerTransportTest.java
@@ -1067,6 +1067,8 @@ public class OkHttpServerTransportTest {
     writeDataDirectly(clientWriterSink, FLAG_PADDED | FLAG_END_STREAM, 1, message, 100);
     clientFrameWriter.flush();
     assertThat(clientFrameReader.nextFrame(clientFramesRead)).isTrue();
+    verify(clientFramesRead).windowUpdate(0, expectedConsumed + 100);
+    assertThat(clientFrameReader.nextFrame(clientFramesRead)).isTrue();
     verify(clientFramesRead).rstStream(eq(1), eq(ErrorCode.FLOW_CONTROL_ERROR));
     clientFrameWriter.rstStream(3, ErrorCode.CANCEL);
     pingPong();


### PR DESCRIPTION
By RFC 9113, section 6.9, receivers must take frames into account for flow control even if they're errored.

This change moves the stream error response logic after connection window updates