### PR TITLE
netty: make hostname verification configurable

### DIFF
--- a/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
+++ b/netty/src/main/java/io/grpc/netty/GrpcSslContexts.java
@@ -47,6 +47,7 @@ import java.util.logging.Logger;
 @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1784")
 public class GrpcSslContexts {
   private static final Logger logger = Logger.getLogger(GrpcSslContexts.class.getName());
+  static final String DEFAULT_ENDPOINT_IDENTIFICATION_ALGORITHM = "HTTPS";
 
   private GrpcSslContexts() {}
 
@@ -88,6 +89,11 @@ public class GrpcSslContexts {
 
   /**
    * Creates an SslContextBuilder with ciphers and APN appropriate for gRPC.
+   *
+   * <p>HTTPS endpoint identification is enabled by default. Clients that authenticate a non-DNS
+   * identity may explicitly disable it with {@link
+   * SslContextBuilder#endpointIdentificationAlgorithm(String) endpointIdentificationAlgorithm("")},
+   * but must perform alternative identity verification.
    *
    * @see SslContextBuilder#forClient()
    * @see #configure(SslContextBuilder)
@@ -140,7 +146,8 @@ public class GrpcSslContexts {
 
   /**
    * Set ciphers and APN appropriate for gRPC. Precisely what is set is permitted to change, so if
-   * an application requires particular settings it should override the options set here.
+   * an application requires particular settings it should override the options set here. For
+   * client builders, HTTPS endpoint identification is enabled by default.
    */
   @CanIgnoreReturnValue
   public static SslContextBuilder configure(SslContextBuilder builder) {
@@ -149,7 +156,8 @@ public class GrpcSslContexts {
 
   /**
    * Set ciphers and APN appropriate for gRPC. Precisely what is set is permitted to change, so if
-   * an application requires particular settings it should override the options set here.
+   * an application requires particular settings it should override the options set here. For
+   * client builders, HTTPS endpoint identification is enabled by default.
    */
   @ExperimentalApi("https://github.com/grpc/grpc-java/issues/1784")
   @CanIgnoreReturnValue
@@ -173,7 +181,8 @@ public class GrpcSslContexts {
         return builder
             .sslProvider(SslProvider.OPENSSL)
             .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
-            .applicationProtocolConfig(apc);
+            .applicationProtocolConfig(apc)
+            .endpointIdentificationAlgorithm(DEFAULT_ENDPOINT_IDENTIFICATION_ALGORITHM);
       }
       default:
         throw new IllegalArgumentException("Unsupported provider: " + provider);
@@ -182,7 +191,8 @@ public class GrpcSslContexts {
 
   /**
    * Set ciphers and APN appropriate for gRPC. Precisely what is set is permitted to change, so if
-   * an application requires particular settings it should override the options set here.
+   * an application requires particular settings it should override the options set here. For
+   * client builders, HTTPS endpoint identification is enabled by default.
    */
   @CanIgnoreReturnValue
   public static SslContextBuilder configure(SslContextBuilder builder, Provider jdkProvider) {
@@ -220,7 +230,8 @@ public class GrpcSslContexts {
         .sslProvider(SslProvider.JDK)
         .ciphers(Http2SecurityUtil.CIPHERS, SupportedCipherSuiteFilter.INSTANCE)
         .applicationProtocolConfig(apc)
-        .sslContextProvider(jdkProvider);
+        .sslContextProvider(jdkProvider)
+        .endpointIdentificationAlgorithm(DEFAULT_ENDPOINT_IDENTIFICATION_ALGORITHM);
   }
 
   /**

--- a/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
+++ b/netty/src/main/java/io/grpc/netty/ProtocolNegotiators.java
@@ -680,8 +680,11 @@ final class ProtocolNegotiators {
         sslEngine = sslContext.newEngine(ctx.alloc());
       }
       SSLParameters sslParams = sslEngine.getSSLParameters();
-      sslParams.setEndpointIdentificationAlgorithm("HTTPS");
-      sslEngine.setSSLParameters(sslParams);
+      if (sslParams.getEndpointIdentificationAlgorithm() == null) {
+        sslParams.setEndpointIdentificationAlgorithm(
+            GrpcSslContexts.DEFAULT_ENDPOINT_IDENTIFICATION_ALGORITHM);
+        sslEngine.setSSLParameters(sslParams);
+      }
       ctx.pipeline().addBefore(ctx.name(), /* name= */ null, this.executor != null
           ? new SslHandler(sslEngine, false, this.executor)
           : new SslHandler(sslEngine, false));

--- a/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
+++ b/netty/src/test/java/io/grpc/netty/ProtocolNegotiatorsTest.java
@@ -111,6 +111,7 @@ import io.netty.handler.codec.http2.Http2Settings;
 import io.netty.handler.proxy.ProxyConnectException;
 import io.netty.handler.ssl.ApplicationProtocolConfig;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
 import java.io.File;
@@ -934,6 +935,47 @@ public class ProtocolNegotiatorsTest {
 
     ChannelHandlerContext grpcHandlerCtx = pipeline.context(grpcHandler);
     assertNotNull(grpcHandlerCtx);
+  }
+
+  @Test
+  public void grpcSslContextsConfigure_enablesEndpointIdentification() throws Exception {
+    SslContext clientSslContext = GrpcSslContexts.configure(
+        SslContextBuilder.forClient().endpointIdentificationAlgorithm(null)).build();
+
+    SSLEngine sslEngine = clientSslContext.newEngine(channel.alloc(), "localhost", 443);
+
+    assertThat(sslEngine.getSSLParameters().getEndpointIdentificationAlgorithm())
+        .isEqualTo("HTTPS");
+  }
+
+  @Test
+  public void clientTlsHandler_nullEndpointIdentificationUsesHttps() throws Exception {
+    SslContext clientSslContext = GrpcSslContexts.forClient()
+        .endpointIdentificationAlgorithm(null)
+        .build();
+    ClientTlsHandler handler = new ClientTlsHandler(grpcHandler, clientSslContext,
+        "authority", null, noopLogger, Optional.absent(),
+        getClientTlsProtocolNegotiator(), null);
+
+    pipeline.addLast(handler);
+
+    assertThat(pipeline.get(SslHandler.class).engine().getSSLParameters()
+        .getEndpointIdentificationAlgorithm()).isEqualTo("HTTPS");
+  }
+
+  @Test
+  public void clientTlsHandler_emptyEndpointIdentificationRemainsDisabled() throws Exception {
+    SslContext clientSslContext = GrpcSslContexts.forClient()
+        .endpointIdentificationAlgorithm("")
+        .build();
+    ClientTlsHandler handler = new ClientTlsHandler(grpcHandler, clientSslContext,
+        "authority", null, noopLogger, Optional.absent(),
+        getClientTlsProtocolNegotiator(), null);
+
+    pipeline.addLast(handler);
+
+    assertThat(pipeline.get(SslHandler.class).engine().getSSLParameters()
+        .getEndpointIdentificationAlgorithm()).isEmpty();
   }
 
   @Test

--- a/netty/src/test/java/io/grpc/netty/TlsTest.java
+++ b/netty/src/test/java/io/grpc/netty/TlsTest.java
@@ -238,6 +238,43 @@ public class TlsTest {
   }
 
   /**
+   * Test that a client can explicitly disable hostname verification when it authenticates the
+   * server using a non-DNS identity.
+   */
+  @Test
+  public void clientCanDisableHostnameVerification() throws Exception {
+    // Create & start a server.
+    File serverCertFile = TestUtils.loadCert("server1.pem");
+    File serverPrivateKeyFile = TestUtils.loadCert("server1.key");
+    X509Certificate[] serverTrustedCaCerts = {
+        TestUtils.loadX509Cert("ca.pem")
+    };
+    server = serverBuilder(0, serverCertFile, serverPrivateKeyFile, serverTrustedCaCerts)
+        .addService(new SimpleServiceImpl())
+        .build()
+        .start();
+
+    // Use a mismatched authority, but explicitly disable DNS hostname verification.
+    File clientCertChainFile = TestUtils.loadCert("client.pem");
+    File clientPrivateKeyFile = TestUtils.loadCert("client.key");
+    X509Certificate[] clientTrustedCaCerts = {
+        TestUtils.loadX509Cert("ca.pem")
+    };
+    channel = NettyChannelBuilder.forAddress("localhost", server.getPort())
+        .overrideAuthority("i.am.a.bad.hostname")
+        .negotiationType(NegotiationType.TLS)
+        .sslContext(clientContextBuilder
+            .endpointIdentificationAlgorithm("")
+            .keyManager(clientCertChainFile, clientPrivateKeyFile)
+            .trustManager(clientTrustedCaCerts)
+            .build())
+        .build();
+    SimpleServiceGrpc.SimpleServiceBlockingStub client = SimpleServiceGrpc.newBlockingStub(channel);
+
+    client.unaryRpc(SimpleRequest.getDefaultInstance());
+  }
+
+  /**
    * Tests that a server configured to require client authentication refuses to accept connections
    * from a client that has an untrusted certificate.
    */

--- a/xds/src/main/java/io/grpc/xds/internal/security/certprovider/CertProviderClientSslContextProvider.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/certprovider/CertProviderClientSslContextProvider.java
@@ -76,7 +76,9 @@ final class CertProviderClientSslContextProvider extends CertProviderSslContextP
     }
 
     SslContextBuilder sslContextBuilder =
-        GrpcSslContexts.forClient().trustManager(trustManagerFactory);
+        GrpcSslContexts.forClient()
+            .endpointIdentificationAlgorithm("")
+            .trustManager(trustManagerFactory);
     if (isMtls()) {
       sslContextBuilder.keyManager(savedKey, savedCertChain);
     }

--- a/xds/src/main/java/io/grpc/xds/internal/security/trust/XdsX509TrustManager.java
+++ b/xds/src/main/java/io/grpc/xds/internal/security/trust/XdsX509TrustManager.java
@@ -263,10 +263,6 @@ final class XdsX509TrustManager extends X509ExtendedTrustManager implements X509
     if (socket instanceof SSLSocket) {
       SSLSocket sslSocket = (SSLSocket) socket;
       SSLParameters sslParams = sslSocket.getSSLParameters();
-      if (sslParams != null) {
-        sslParams.setEndpointIdentificationAlgorithm("");
-        sslSocket.setSSLParameters(sslParams);
-      }
       sniMatchers = getAutoSniSanMatchers(sslParams);
     }
     if (sniMatchers.isEmpty() && certContext != null) {
@@ -284,8 +280,6 @@ final class XdsX509TrustManager extends X509ExtendedTrustManager implements X509
     List<StringMatcher> sniMatchers = null;
     SSLParameters sslParams = sslEngine.getSSLParameters();
     if (sslParams != null) {
-      sslParams.setEndpointIdentificationAlgorithm("");
-      sslEngine.setSSLParameters(sslParams);
       sniMatchers = getAutoSniSanMatchers(sslParams);
     }
     if (sniMatchers.isEmpty() && certContext != null) {

--- a/xds/src/test/java/io/grpc/xds/internal/security/certprovider/CertProviderClientSslContextProviderTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/certprovider/CertProviderClientSslContextProviderTest.java
@@ -38,6 +38,7 @@ import io.grpc.xds.client.Bootstrapper;
 import io.grpc.xds.client.CommonBootstrapperTestUtils;
 import io.grpc.xds.internal.security.CommonTlsContextTestsUtil;
 import io.grpc.xds.internal.security.CommonTlsContextTestsUtil.TestCallback;
+import io.netty.buffer.UnpooledByteBufAllocator;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
@@ -393,6 +394,10 @@ public class CertProviderClientSslContextProviderTest {
         CommonTlsContextTestsUtil.getValueThruCallback(provider);
 
     doChecksOnSslContext(false, testCallback.updatedSslContext, /* expectedApnProtos= */ null);
+    assertThat(testCallback.updatedSslContext.getKey()
+        .newEngine(UnpooledByteBufAllocator.DEFAULT)
+        .getSSLParameters()
+        .getEndpointIdentificationAlgorithm()).isEmpty();
   }
 
   @Test

--- a/xds/src/test/java/io/grpc/xds/internal/security/trust/XdsX509TrustManagerTest.java
+++ b/xds/src/test/java/io/grpc/xds/internal/security/trust/XdsX509TrustManagerTest.java
@@ -574,6 +574,23 @@ public class XdsX509TrustManagerTest {
   }
 
   @Test
+  public void checkServerTrustedSslEngine_doesNotModifyEndpointIdentificationAlgorithm()
+      throws CertificateException, IOException {
+    trustManager = new XdsX509TrustManager(null, mockDelegate, false);
+    SSLParameters sslParams = new SSLParameters();
+    sslParams.setEndpointIdentificationAlgorithm("HTTPS");
+    TestSslEngine sslEngine = mock(TestSslEngine.class, CALLS_REAL_METHODS);
+    sslEngine.setSSLParameters(sslParams);
+    X509Certificate[] serverCerts =
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
+
+    trustManager.checkServerTrusted(serverCerts, "ECDHE_ECDSA", sslEngine);
+
+    assertThat(sslEngine.getSSLParameters().getEndpointIdentificationAlgorithm())
+        .isEqualTo("HTTPS");
+  }
+
+  @Test
   public void checkServerTrustedSslEngineSpiffeTrustMap_missing_spiffe_id()
       throws CertificateException, IOException, CertStoreException {
     TestSslEngine sslEngine = buildTrustManagerAndGetSslEngine();
@@ -665,6 +682,23 @@ public class XdsX509TrustManagerTest {
     verify(sslSocket, times(1)).isConnected();
     verify(sslSocket, atLeastOnce()).getHandshakeSession();
     assertThat(sslSocket.getSSLParameters().getEndpointIdentificationAlgorithm()).isEmpty();
+  }
+
+  @Test
+  public void checkServerTrustedSslSocket_doesNotModifyEndpointIdentificationAlgorithm()
+      throws CertificateException, IOException {
+    trustManager = new XdsX509TrustManager(null, mockDelegate, false);
+    SSLParameters sslParams = new SSLParameters();
+    sslParams.setEndpointIdentificationAlgorithm("HTTPS");
+    TestSslSocket sslSocket = mock(TestSslSocket.class, CALLS_REAL_METHODS);
+    sslSocket.setSSLParameters(sslParams);
+    X509Certificate[] serverCerts =
+        CertificateUtils.toX509Certificates(TlsTesting.loadCert(SERVER_1_PEM_FILE));
+
+    trustManager.checkServerTrusted(serverCerts, "ECDHE_ECDSA", sslSocket);
+
+    assertThat(sslSocket.getSSLParameters().getEndpointIdentificationAlgorithm())
+        .isEqualTo("HTTPS");
   }
 
   @Test
@@ -785,7 +819,7 @@ public class XdsX509TrustManagerTest {
     when(mockSession.getProtocol()).thenReturn("TLSv1.2");
     when(mockSession.getPeerHost()).thenReturn("peer-host-from-mock");
     SSLParameters sslParams = new SSLParameters();
-    sslParams.setEndpointIdentificationAlgorithm("HTTPS");
+    sslParams.setEndpointIdentificationAlgorithm("");
     return sslParams;
   }
 


### PR DESCRIPTION
Fixes #12343.

This configures HTTPS endpoint identification in GrpcSslContexts and updates ClientTlsHandler to preserve an explicit empty-string opt-out. A null algorithm still falls back to HTTPS, retaining hostname verification for custom contexts that do not select an algorithm.

The public Javadoc warns callers that disabling DNS hostname verification requires alternative identity verification.

Tests:
- GrpcSslContexts and ClientTlsHandler regression tests cover the default, null fallback, and empty-string opt-out.
- TlsTest verifies a real mismatched-hostname handshake succeeds only with the explicit opt-out; OpenSSL and JDK passed locally, while unavailable Conscrypt was skipped by its existing assumption.
- Javadoc, Checkstyle, AnimalSniffer, ProtocolNegotiatorsTest (55 tests), and TlsTest (18 tests; 6 environment skips) passed.
- The full grpc-netty check ran 647 tests. Two unrelated NettyServerTest cases timed out locally; multiPortConnections reproduced unchanged on base commit 5fda0c7.