### PR TITLE
SECURITY.md: correct Netty and tcnative versions for 1.81.x-1.84.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -400,7 +400,10 @@ grpc-netty version | netty-handler version | netty-tcnative-boringssl-static ver
 1.75.x-1.76.x      | 4.1.124.Final         | 2.0.72.Final
 1.77.x-1.78.x      | 4.1.127.Final         | 2.0.74.Final
 1.79.x-1.80.x      | 4.1.130.Final         | 2.0.74.Final
-1.81.x-            | 4.2.16.Final          | 2.0.81.Final
+1.81.x             | 4.1.132.Final         | 2.0.75.Final
+1.82.x             | 4.1.133.Final         | 2.0.75.Final
+1.83.x             | 4.2.15.Final          | 2.0.75.Final
+1.84.x-            | 4.2.16.Final          | 2.0.81.Final
 
 _(grpc-netty-shaded avoids issues with keeping these versions in sync.)_
 


### PR DESCRIPTION
In #12969, updating the `1.81.x-` row in place inadvertently overwrote the entries for past releases. Because a few updates #12805 and #12856 were missed in `SECURITY.md`, releases `1.82.x` and `1.83.x` were omitted.

This PR restores the accurate Netty and netty-tcnative version mappings for each release:
- `1.81.x`: Netty `4.1.132.Final` / netty-tcnative `2.0.75.Final` (#12738)
- `1.82.x`: Netty `4.1.133.Final` / netty-tcnative `2.0.75.Final` (#12805)
- `1.83.x`: Netty `4.2.15.Final` / netty-tcnative `2.0.75.Final` (#12856)
- `1.84.x-`: Netty `4.2.16.Final` / netty-tcnative `2.0.81.Final` (#12969)

Resolves https://github.com/grpc/grpc-java/pull/12969#discussion_r3857095197
