### PR TITLE
stub: drain pending reads on cancel to release their buffers

### DIFF
--- a/stub/src/main/java/io/grpc/stub/BlockingClientCall.java
+++ b/stub/src/main/java/io/grpc/stub/BlockingClientCall.java
@@ -241,7 +241,8 @@ public final class BlockingClientCall<ReqT, RespT> {
 
   /**
    * Cancel stream and stop any further writes.  Note that some reads that are in flight may still
-   * happen after the cancel.
+   * happen after the cancel.  Reads that have been received but not yet delivered are processed
+   * when cancelling, releasing their resources.
    *
    * @param message if not {@code null}, will appear as the description of the CANCELLED status
    * @param cause if not {@code null}, will appear as the cause of the CANCELLED status
@@ -249,6 +250,10 @@ public final class BlockingClientCall<ReqT, RespT> {
   public void cancel(String message, Throwable cause) {
     writeClosed = true;
     call.cancel(message, cause);
+    // Reads queued by the transport hold buffers that are only released when their delivery task
+    // runs and observes the cancelled stream.  Nothing else will drain the executor once the user
+    // abandons the call, so the queued tasks must be processed here.
+    executor.drain();
   }
 
   /**
@@ -276,6 +281,11 @@ public final class BlockingClientCall<ReqT, RespT> {
     executor.drain();
     CloseState state = closeState.get();
     return (state == null) ? null : state.status;
+  }
+
+  @VisibleForTesting
+  ThreadSafeThreadlessExecutor getExecutor() {
+    return executor;
   }
 
   /**

--- a/stub/src/test/java/io/grpc/stub/BlockingClientCallTest.java
+++ b/stub/src/test/java/io/grpc/stub/BlockingClientCallTest.java
@@ -222,6 +222,23 @@ public class BlockingClientCallTest {
   }
 
   @Test
+  public void testCancelDrainsPendingReads() throws Exception {
+    biDiStream = ClientCalls.blockingBidiStreamingCall(channel, BIDI_STREAMING_METHOD,
+        CallOptions.DEFAULT);
+
+    // The server delivering a message queues a read-delivery task in the call executor, which
+    // only runs when the user reads/writes or the call is cancelled
+    testMethod.sendValueToClient(60);
+    assertThat(biDiStream.getExecutor()).isNotEmpty();
+
+    biDiStream.cancel("done reading", null);
+
+    // The queued read task must be processed by cancel() itself; when orphaned it holds the
+    // message's transport buffers, which leak (see #12355)
+    assertThat(biDiStream.getExecutor()).isEmpty();
+  }
+
+  @Test
   public void testIsActivityReady() throws Exception {
     biDiStream = ClientCalls.blockingBidiStreamingCall(channel,  BIDI_STREAMING_METHOD,
         CallOptions.DEFAULT);


### PR DESCRIPTION
AI disclosure: this change was prepared with AI coding agents, reviewed and revised line by line by me.

## What
Drain the call executor in `BlockingClientCall.cancel()` so read-delivery tasks already queued by the transport are processed instead of orphaned.

## Why
`cancel()` is the documented way to abandon a v2 blocking call.  It stopped all reads and writes but never drained the executor, so a read that had been received but not yet delivered kept its delivery task queued forever.  The task holds the message's transport buffers, which are only released when the task runs and observes the cancelled stream (the delivery path closes the producer when the call has an error status).  Cancelling with an undelivered read therefore leaks the transport's `ByteBuf`s, as reported in #12355.

## How
`cancel()` now calls `executor.drain()` after `call.cancel(...)`.  Each queued task then runs either the closed-stream discard path, which releases its buffers, or, if the cancel has not fully propagated yet, delivers the message into the buffer, consistent with the existing "some reads that are in flight may still happen after the cancel" behavior.

*Limitation:* abandoning a call without `cancel()` still leaves queued tasks undrained, matching the long-standing v1 iterator caveat ("the iterator can result in leaks if not completely consumed").

## Root cause
The executor of a v2 blocking call is driven only by the user's read/write calls.  `cancel()` was the one exit that stopped driving it, so tasks queued before the cancel were never run.

## Testing
- New `BlockingClientCallTest#testCancelDrainsPendingReads`: fails without the change (executor queue non-empty after cancel), passes with it.
- Issue reproducer (manualflowcontrol example server + v2 blocking client doing write/read/write/sleep 1s/cancel, 10 iterations, `-Dio.netty.leakDetection.level=paranoid -Dio.netty.leakDetection.targetRecords=100`): master reports 1 `LEAK: ByteBuf.release() was not called`; this change reports none, stable across 3 runs.

## Verification of the original issue
Same reproducer as the issue, run on master and on this branch:
- master: `SEVERE: LEAK: ByteBuf.release() was not called before it's garbage-collected`, with the leaked buffer's access records showing the deframed message held by the queued delivery task.
- this change: no leak reports, client exits cleanly.

Fixes #12355

