### PR TITLE
servlet: Register response trailers before stream writes

### DIFF
--- a/servlet/src/main/java/io/grpc/servlet/ServletServerStream.java
+++ b/servlet/src/main/java/io/grpc/servlet/ServletServerStream.java
@@ -82,6 +82,8 @@ final class ServletServerStream extends AbstractServerStream {
     this.resp = (HttpServletResponse) asyncCtx.getResponse();
     this.writer = new AsyncServletOutputStreamWriter(
         asyncCtx, transportState, logId);
+    // Register before the peer can reset the stream and cause the container to commit the response.
+    resp.setTrailerFields(sink.trailerSupplier);
     resp.getOutputStream().setWriteListener(new GrpcWriteListener());
   }
 
@@ -231,7 +233,6 @@ final class ServletServerStream extends AbstractServerStream {
     @Override
     public void writeHeaders(Metadata headers, boolean flush) {
       writeHeadersToServletResponse(headers);
-      resp.setTrailerFields(trailerSupplier);
       try {
         writer.flush();
       } catch (IOException e) {


### PR DESCRIPTION
## Summary

- register the servlet response trailer supplier when the server stream is created
- avoid registering trailers from `writeHeaders()`, after a client RST_STREAM may already have caused Jetty to commit the response
- preserve the existing trailer population and write behavior

This removes the race where `HttpServletResponse.setTrailerFields()` throws `IllegalStateException: Committed`.

## Testing

- `./gradlew :grpc-servlet:jettyTest -PskipCodegen=true -PskipAndroid=true` (80 tests, 19 skipped)
- `./gradlew :grpc-servlet:tomcat9Test -PskipCodegen=true -PskipAndroid=true` (78 tests, 29 skipped)
- `./gradlew :grpc-servlet:undertowTest -PskipCodegen=true -PskipAndroid=true` (78 tests, 23 skipped)
- `./gradlew :grpc-servlet:checkstyleMain -PskipCodegen=true -PskipAndroid=true`

Fixes #12777