### PR TITLE
xDS: Support retries in RawMessageClientInterceptor and conditionally add it to the filter chain

### DIFF
--- a/xds/src/main/java/io/grpc/xds/ExternalProcessorClientInterceptor.java
+++ b/xds/src/main/java/io/grpc/xds/ExternalProcessorClientInterceptor.java
@@ -231,14 +231,10 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
           MetadataUtils.newAttachHeadersInterceptor(extraHeaders));
     }
 
-    // The filter chain is preceded by RawMessageClientInterceptor, so ReqT and RespT are
-    // InputStream.
-    MethodDescriptor<InputStream, InputStream> rawMethod =
-        (MethodDescriptor<InputStream, InputStream>) (MethodDescriptor<?, ?>) method;
-    ClientCall<InputStream, InputStream> rawCall =
-        new SimpleForwardingClientCall<InputStream, InputStream>(
-            (ClientCall<InputStream, InputStream>) (ClientCall<?, ?>)
-                next.newCall(method, callOptions)) {
+    // The filter chain is preceded by RawMessageClientInterceptor when payload access is
+    // required, in which case ReqT and RespT are InputStream.
+    ClientCall<ReqT, RespT> rawCall =
+        new SimpleForwardingClientCall<ReqT, RespT>(next.newCall(method, callOptions)) {
           private final AtomicBoolean cancelled = new AtomicBoolean(false);
 
           @Override
@@ -250,15 +246,15 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
         };
 
     // Create a local subclass instance to buffer outbound actions
-    DataPlaneDelayedCall<InputStream, InputStream> delayedCall =
+    DataPlaneDelayedCall<ReqT, RespT> delayedCall =
         new DataPlaneDelayedCall<>(
             serializingExecutor, scheduler, callOptions.getDeadline());
 
-    DataPlaneClientCall dataPlaneCall = new DataPlaneClientCall(
+    DataPlaneClientCall<ReqT, RespT> dataPlaneCall = new DataPlaneClientCall<>(
         delayedCall, rawCall, extProcStub, filterConfig, filterConfig.getMutationRulesConfig(),
-        scheduler, rawMethod, next, metricsRecorder, next.authority());
+        scheduler, method, next, metricsRecorder, next.authority());
 
-    return (ClientCall<ReqT, RespT>) (ClientCall<?, ?>) dataPlaneCall;
+    return dataPlaneCall;
   }
 
   // --- SHARED UTILITY METHODS ---
@@ -277,13 +273,13 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
    * Handles the bidirectional stream with the External Processor.
    * Buffers the actual RPC start until the Ext Proc header response is received.
    */
-  private static class DataPlaneClientCall 
-      extends SimpleForwardingClientCall<InputStream, InputStream> {
+  private static class DataPlaneClientCall<ReqT, RespT>
+      extends SimpleForwardingClientCall<ReqT, RespT> {
 
     private final ExternalProcessorGrpc.ExternalProcessorStub stub;
     private final ExternalProcessorFilterConfig config;
-    private final ClientCall<InputStream, InputStream> rawCall;
-    private final DataPlaneDelayedCall<InputStream, InputStream> delayedCall;
+    private final ClientCall<ReqT, RespT> rawCall;
+    private final DataPlaneDelayedCall<ReqT, RespT> delayedCall;
     private final ScheduledExecutorService scheduler;
     final Object streamLock = new Object();
     @Nullable private volatile EventType expectedRequestResponse;
@@ -291,9 +287,9 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
     @Nullable private volatile ClientCallStreamObserver<ProcessingRequest>
         extProcClientCallRequestObserver;
     @GuardedBy("streamLock")
-    private final Queue<InputStream> pendingDrainingMessages =
+    private final Queue<ReqT> pendingDrainingMessages =
         new ConcurrentLinkedQueue<>();
-    @Nullable private volatile DataPlaneListener wrappedListener;
+    @Nullable private volatile DataPlaneListener<RespT> wrappedListener;
     private final HeaderMutationFilter mutationFilter;
     private final HeaderMutator mutator = HeaderMutator.create();
     private final AtomicInteger pendingRequests = new AtomicInteger(0);
@@ -372,8 +368,8 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
     final AtomicBoolean bodyMessageSentToExtProc = new AtomicBoolean(false);
 
     protected DataPlaneClientCall(
-        DataPlaneDelayedCall<InputStream, InputStream> delayedCall,
-        ClientCall<InputStream, InputStream> rawCall,
+        DataPlaneDelayedCall<ReqT, RespT> delayedCall,
+        ClientCall<ReqT, RespT> rawCall,
         ExternalProcessorGrpc.ExternalProcessorStub stub,
         ExternalProcessorFilterConfig config,
         Optional<HeaderMutationRulesConfig> mutationRulesConfig,
@@ -465,11 +461,11 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
     }
 
     @Override
-    public void start(Listener<InputStream> responseListener, Metadata headers) {
+    public void start(Listener<RespT> responseListener, Metadata headers) {
       this.callContext = Context.current();
       clientHeadersStartNanos = System.nanoTime();
       this.requestHeaders = headers;
-      this.wrappedListener = new DataPlaneListener(responseListener, this);
+      this.wrappedListener = new DataPlaneListener<>(responseListener, this);
 
       // DelayedClientCall.start will buffer the listener and headers until setCall is called.
       super.start(wrappedListener, headers);
@@ -977,8 +973,9 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
       }
     }
 
+    @SuppressWarnings("unchecked")
     @Override
-    public void sendMessage(InputStream message) {
+    public void sendMessage(ReqT message) {
       if (requestSideClosed.get()) {
         // External processor already closed the request stream. Discard further messages.
         return;
@@ -1002,8 +999,8 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
             return;
           }
           try {
-            ByteString copiedBody = ByteString.readFrom(message);
-            pendingDrainingMessages.add(new KnownLengthInputStream(copiedBody));
+            ByteString copiedBody = ByteString.readFrom((InputStream) message);
+            pendingDrainingMessages.add((ReqT) new KnownLengthInputStream(copiedBody));
           } catch (IOException e) {
             cancelDownstream("Failed to copy outbound message for buffering", e);
           }
@@ -1017,7 +1014,7 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
 
         // Mode is GRPC
         try {
-          ByteString bodyByteString = outboundStreamToByteString(message);
+          ByteString bodyByteString = outboundStreamToByteString((InputStream) message);
           if (config.getObservabilityMode()) {
             sendToExtProc(ProcessingRequest.newBuilder()
                 .setRequestBody(HttpBody.newBuilder()
@@ -1026,7 +1023,7 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
                     .build())
                 .build());
             bodyMessageSentToExtProc.set(true);
-            super.sendMessage(new KnownLengthInputStream(bodyByteString));
+            super.sendMessage((ReqT) new KnownLengthInputStream(bodyByteString));
           } else {
             if (downstreamToSidestreamWindow <= 0 || !pendingRequestBodyMessages.isEmpty()) {
               pendingRequestBodyMessages.add(bodyByteString);
@@ -1159,6 +1156,7 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
       cancelDownstream(message, cause);
     }
 
+    @SuppressWarnings("unchecked")
     private void handleRequestBodyResponse(BodyResponse bodyResponse) {
       if (bodyResponse.hasResponse() && bodyResponse.getResponse().hasBodyMutation()) {
         BodyMutation mutation = bodyResponse.getResponse().getBodyMutation();
@@ -1180,7 +1178,7 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
               }
             }
             if (sendImmediately) {
-              super.sendMessage(new KnownLengthInputStream(body));
+              super.sendMessage((ReqT) new KnownLengthInputStream(body));
               trySendAccumulatedWindowUpdates();
             }
           }
@@ -1200,7 +1198,7 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
     }
 
     private void handleResponseBodyResponse(
-        BodyResponse bodyResponse, DataPlaneListener listener) {
+        BodyResponse bodyResponse, DataPlaneListener<RespT> listener) {
       if (bodyResponse.hasResponse() && bodyResponse.getResponse().hasBodyMutation()) {
         BodyMutation mutation = bodyResponse.getResponse().getBodyMutation();
         if (mutation.hasStreamedResponse()) {
@@ -1215,7 +1213,7 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
       }
     }
 
-    private void deliverResponseBody(ByteString body, DataPlaneListener listener) {
+    private void deliverResponseBody(ByteString body, DataPlaneListener<RespT> listener) {
       boolean shouldDeliver = false;
       synchronized (streamLock) {
         if (downstreamRequestsPending > 0) {
@@ -1267,7 +1265,7 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
 
     // Used to immediately flush any mutated response chunks that we already received and buffered
     // before the stream failed, ensuring the application receives them in the correct order
-    void drainPendingMutatedResponseBodiesDirect(DataPlaneListener listener) {
+    void drainPendingMutatedResponseBodiesDirect(DataPlaneListener<RespT> listener) {
       List<ByteString> toDeliver = new ArrayList<>();
       synchronized (streamLock) {
         ByteString body;
@@ -1280,6 +1278,7 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
       }
     }
 
+    @SuppressWarnings("unchecked")
     void drainPendingUpstreamBodyMessages() {
       while (true) {
         ByteString body = null;
@@ -1297,7 +1296,7 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
         if (body == null) {
           break;
         }
-        super.sendMessage(new KnownLengthInputStream(body));
+        super.sendMessage((ReqT) new KnownLengthInputStream(body));
         trySendAccumulatedWindowUpdates();
         if (triggerHalfClose) {
           if (requestSideClosed.compareAndSet(false, true)) {
@@ -1307,7 +1306,8 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
       }
     }
 
-    private void handleImmediateResponse(ImmediateResponse immediate, DataPlaneListener listener)
+    private void handleImmediateResponse(
+        ImmediateResponse immediate, DataPlaneListener<RespT> listener)
         throws HeaderMutationDisallowedException {
       Status status = Status.fromCodeValue(immediate.getGrpcStatus().getStatus());
       if (!immediate.getDetails().isEmpty()) {
@@ -1335,6 +1335,7 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
       closeExtProcStream();
     }
 
+    @SuppressWarnings("unchecked")
     private void drainPendingDrainingMessages() {
       while (true) {
         Object msg = null; // Can be ByteString or InputStream
@@ -1378,14 +1379,14 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
         }
 
         if (isMutated) {
-          super.sendMessage(new KnownLengthInputStream((ByteString) msg));
+          super.sendMessage((ReqT) new KnownLengthInputStream((ByteString) msg));
         } else {
-          super.sendMessage((InputStream) msg);
+          super.sendMessage((ReqT) msg);
         }
       }
     }
 
-    private void handleFailOpen(DataPlaneListener listener) {
+    private void handleFailOpen(DataPlaneListener<RespT> listener) {
       if (!activateCall()) {
         drainPendingRequests();
       }
@@ -1452,11 +1453,11 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
     }
   }
 
-  private static class DataPlaneListener extends SimpleForwardingClientCallListener<InputStream> {
-    private final DataPlaneClientCall dataPlaneClientCall;
+  private static class DataPlaneListener<RespT> extends SimpleForwardingClientCallListener<RespT> {
+    private final DataPlaneClientCall<?, RespT> dataPlaneClientCall;
     // Path 3: Upstream response bodies queued because upstream to sidestream window not available,
     // response headers not cleared by ext_proc or ext_proc stream draining
-    private final Queue<InputStream> savedMessages = new ConcurrentLinkedQueue<>();
+    private final Queue<RespT> savedMessages = new ConcurrentLinkedQueue<>();
     private boolean inboundPassThrough = false;
     @Nullable private volatile Metadata savedHeaders;
     @Nullable private volatile Metadata savedTrailers;
@@ -1466,8 +1467,8 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
     private final AtomicBoolean trailersOnly = new AtomicBoolean(false);
 
     protected DataPlaneListener(
-        ClientCall.Listener<InputStream> delegate,
-        DataPlaneClientCall dataPlaneClientCall) {
+        ClientCall.Listener<RespT> delegate,
+        DataPlaneClientCall<?, RespT> dataPlaneClientCall) {
       super(delegate);
       this.dataPlaneClientCall = dataPlaneClientCall;
     }
@@ -1529,22 +1530,36 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
       }
     }
 
+    @SuppressWarnings("unchecked")
     @Override
-    public void onMessage(InputStream message) {
+    public void onMessage(RespT message) {
       synchronized (dataPlaneClientCall.streamLock) {
         if (inboundPassThrough) {
           dataPlaneClientCall.getCallContext().run(() -> delegate().onMessage(message));
           return;
         }
 
-        boolean checkDrain = dataPlaneClientCall.getExtProcStreamState().get().isDraining()
-            && dataPlaneClientCall.getCurrentProcessingMode().getResponseBodyMode()
-                == ProcessingMode.BodySendMode.GRPC;
+        if (dataPlaneClientCall.getCurrentProcessingMode().getResponseBodyMode()
+            != ProcessingMode.BodySendMode.GRPC) {
+          if (savedHeaders != null) {
+            savedMessages.add(message);
+            return;
+          }
+          if (dataPlaneClientCall.getPassThroughMode().get()
+              || dataPlaneClientCall.getExtProcStreamState().get().isCompleted()) {
+            dataPlaneClientCall.getCallContext().run(() -> delegate().onMessage(message));
+            return;
+          }
+          dataPlaneClientCall.getCallContext().run(() -> delegate().onMessage(message));
+          return;
+        }
+
+        boolean checkDrain = dataPlaneClientCall.getExtProcStreamState().get().isDraining();
 
         if (savedHeaders != null || checkDrain) {
           try {
-            ByteString copiedBody = ByteString.readFrom(message);
-            savedMessages.add(new KnownLengthInputStream(copiedBody));
+            ByteString copiedBody = ByteString.readFrom((InputStream) message);
+            savedMessages.add((RespT) new KnownLengthInputStream(copiedBody));
           } catch (IOException e) {
             dataPlaneClientCall.cancelDownstream("Failed to copy inbound message for buffering", e);
           }
@@ -1556,24 +1571,22 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
           return;
         }
 
-        if (dataPlaneClientCall.getExtProcStreamState().get().isCompleted()
-            || dataPlaneClientCall.getCurrentProcessingMode().getResponseBodyMode()
-                != ProcessingMode.BodySendMode.GRPC) {
+        if (dataPlaneClientCall.getExtProcStreamState().get().isCompleted()) {
           dataPlaneClientCall.getCallContext().run(() -> delegate().onMessage(message));
           return;
         }
 
         try {
-          ByteString bodyByteString = ByteString.readFrom(message);
+          ByteString bodyByteString = ByteString.readFrom((InputStream) message);
           // TODO: Consider having separate classes handling normal mode and observability mode
           if (dataPlaneClientCall.getConfig().getObservabilityMode()) {
             sendResponseBodyToExtProc(bodyByteString, false);
             dataPlaneClientCall.bodyMessageSentToExtProc.set(true);
             dataPlaneClientCall.getCallContext().run(
-                () -> delegate().onMessage(bodyByteString.newInput()));
+                () -> delegate().onMessage((RespT) bodyByteString.newInput()));
           } else {
             if (dataPlaneClientCall.upstreamToSidestreamWindow <= 0 || !savedMessages.isEmpty()) {
-              savedMessages.add(new KnownLengthInputStream(bodyByteString));
+              savedMessages.add((RespT) new KnownLengthInputStream(bodyByteString));
             } else {
               dataPlaneClientCall.upstreamToSidestreamWindow -= bodyByteString.size();
               sendResponseBodyToExtProc(bodyByteString, false);
@@ -1592,10 +1605,10 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
         while (dataPlaneClientCall.isSidecarReady()
             && dataPlaneClientCall.upstreamToSidestreamWindow > 0
             && !savedMessages.isEmpty()) {
-          InputStream msg = savedMessages.poll();
+          RespT msg = savedMessages.poll();
           if (msg != null) {
             try {
-              ByteString bodyByteString = ByteString.readFrom(msg);
+              ByteString bodyByteString = ByteString.readFrom((InputStream) msg);
               dataPlaneClientCall.upstreamToSidestreamWindow -= bodyByteString.size();
               sendResponseBodyToExtProc(bodyByteString, false);
               dataPlaneClientCall.bodyMessageSentToExtProc.set(true);
@@ -1666,7 +1679,7 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
         synchronized (dataPlaneClientCall.streamLock) {
           savedHeaders = null;
           if (!dataPlaneClientCall.getExtProcStreamState().get().isDraining()) {
-            InputStream msg;
+            RespT msg;
             while ((msg = savedMessages.poll()) != null) {
               onMessage(msg);
             }
@@ -1707,12 +1720,13 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
       dataPlaneClientCall.getCallContext().run(() -> delegate().onClose(status, trailers));
     }
 
+    @SuppressWarnings("unchecked")
     void onExternalBody(ByteString body) {
       // If needed, downstream reading can be made more optimal by creating a wrapped
       // Inputstream wraps the underlying bytestring and that implements HasByteBuffer,
       // Detachable, KnownLength
       dataPlaneClientCall.getCallContext().run(
-          () -> delegate().onMessage(body.newInput()));
+          () -> delegate().onMessage((RespT) body.newInput()));
     }
 
     void unblockAfterStreamComplete() {
@@ -1728,9 +1742,9 @@ final class ExternalProcessorClientInterceptor implements ClientInterceptor {
 
     private void proceedWithSavedMessages() {
       synchronized (dataPlaneClientCall.streamLock) {
-        InputStream msg;
+        RespT msg;
         while ((msg = savedMessages.poll()) != null) {
-          final InputStream finalMsg = msg;
+          final RespT finalMsg = msg;
           dataPlaneClientCall.getCallContext().run(() -> delegate().onMessage(finalMsg));
         }
         inboundPassThrough = true;

--- a/xds/src/main/java/io/grpc/xds/ExternalProcessorFilter.java
+++ b/xds/src/main/java/io/grpc/xds/ExternalProcessorFilter.java
@@ -134,6 +134,20 @@ public class ExternalProcessorFilter implements Filter {
         extProcFilterConfig, cachedChannelManager, scheduler, context);
   }
 
+  @Override
+  public boolean requiresPayloadAccess(
+      FilterConfig filterConfig, @Nullable FilterConfig overrideConfig) {
+    ExternalProcessorFilterConfig extProcFilterConfig =
+        (ExternalProcessorFilterConfig) filterConfig;
+    if (overrideConfig != null) {
+      extProcFilterConfig = mergeConfigs(extProcFilterConfig,
+          (ExternalProcessorFilterOverrideConfig) overrideConfig);
+    }
+    ProcessingMode mode = extProcFilterConfig.getExternalProcessor().getProcessingMode();
+    return mode.getRequestBodyMode() != ProcessingMode.BodySendMode.NONE
+        || mode.getResponseBodyMode() != ProcessingMode.BodySendMode.NONE;
+  }
+
   private static ExternalProcessorFilterConfig mergeConfigs(
       ExternalProcessorFilterConfig extProcFilterConfig,
       ExternalProcessorFilterOverrideConfig extProcFilterConfigOverride) {

--- a/xds/src/main/java/io/grpc/xds/Filter.java
+++ b/xds/src/main/java/io/grpc/xds/Filter.java
@@ -125,6 +125,18 @@ interface Filter extends Closeable {
   }
 
   /**
+   * Returns true if this filter requires access to the request or response message payloads for
+   * the given configuration.
+   *
+   * <p>When true, interceptors that provide raw message payload access (e.g. {@code
+   * RawMessageClientInterceptor}) will be installed in the client interceptor chain.
+   */
+  default boolean requiresPayloadAccess(
+      FilterConfig config, @Nullable FilterConfig overrideConfig) {
+    return false;
+  }
+
+  /**
    * Releases filter resources like shared resources and remote connections.
    *
    * <p>See {@link Provider#newInstance()} for details on filter instance creation.

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.util.Durations;
 import io.grpc.Attributes;
 import io.grpc.CallOptions;
@@ -35,6 +36,7 @@ import io.grpc.ChannelConfigurator;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
+import io.grpc.Drainable;
 import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
 import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
 import io.grpc.InternalConfigSelector;
@@ -69,6 +71,8 @@ import io.grpc.xds.client.XdsClient;
 import io.grpc.xds.client.XdsInitializationException;
 import io.grpc.xds.client.XdsLogger;
 import io.grpc.xds.client.XdsLogger.XdsLogLevel;
+import io.grpc.xds.internal.extproc.KnownLengthInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -1134,6 +1138,9 @@ final class XdsNameResolver extends NameResolver {
         new MethodDescriptor.Marshaller<InputStream>() {
           @Override
           public InputStream stream(InputStream value) {
+            if (value instanceof KnownLengthInputStream) {
+              return new KnownLengthInputStream(((KnownLengthInputStream) value).getByteString());
+            }
             return value;
           }
 
@@ -1192,7 +1199,31 @@ final class XdsNameResolver extends NameResolver {
 
         @Override
         public void sendMessage(ReqT message) {
-          rawCall.sendMessage(method.getRequestMarshaller().stream(message));
+          InputStream stream = method.getRequestMarshaller().stream(message);
+          ByteString byteString;
+          try {
+            if (stream instanceof Drainable) {
+              int size = stream.available();
+              ByteString.Output output =
+                  size > 0 ? ByteString.newOutput(size) : ByteString.newOutput();
+              ((Drainable) stream).drainTo(output);
+              byteString = output.toByteString();
+            } else {
+              byteString = ByteString.readFrom(stream);
+            }
+          } catch (IOException e) {
+            throw Status.INTERNAL
+                .withDescription("Failed to read message for raw message interceptor")
+                .withCause(e)
+                .asRuntimeException();
+          } finally {
+            try {
+              stream.close();
+            } catch (IOException ignored) {
+              // ignore
+            }
+          }
+          rawCall.sendMessage(new KnownLengthInputStream(byteString));
         }
 
         @Override

--- a/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
+++ b/xds/src/main/java/io/grpc/xds/XdsNameResolver.java
@@ -893,6 +893,7 @@ final class XdsNameResolver extends NameResolver {
         selectedOverrideConfigs.putAll(weightedCluster.filterConfigOverrides());
       }
 
+      boolean anyFilterRequiresPayload = false;
       ImmutableList.Builder<ClientInterceptor> filterInterceptors = ImmutableList.builder();
       for (NamedFilterConfig namedFilter : filterConfigs) {
         String name = namedFilter.name;
@@ -907,12 +908,14 @@ final class XdsNameResolver extends NameResolver {
 
         if (interceptor != null) {
           filterInterceptors.add(interceptor);
+          if (filter.requiresPayloadAccess(config, overrideConfig)) {
+            anyFilterRequiresPayload = true;
+          }
         }
       }
 
       ImmutableList.Builder<ClientInterceptor> withRawMessage = ImmutableList.builder();
-      if (GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_CLIENT", false)
-          || GrpcUtil.getFlag("GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_SERVER", false)) {
+      if (anyFilterRequiresPayload) {
         withRawMessage.add(new RawMessageClientInterceptor());
       }
       withRawMessage.addAll(filterInterceptors.build());
@@ -1138,6 +1141,10 @@ final class XdsNameResolver extends NameResolver {
         new MethodDescriptor.Marshaller<InputStream>() {
           @Override
           public InputStream stream(InputStream value) {
+            // For retry attempts, RetriableStream calls stream(value) once per attempt.
+            // Returning a fresh KnownLengthInputStream wrapping the immutable ByteString ensures
+            // each retry attempt reads from the beginning of the payload rather than an already
+            // drained stream.
             if (value instanceof KnownLengthInputStream) {
               return new KnownLengthInputStream(((KnownLengthInputStream) value).getByteString());
             }

--- a/xds/src/main/java/io/grpc/xds/internal/extproc/KnownLengthInputStream.java
+++ b/xds/src/main/java/io/grpc/xds/internal/extproc/KnownLengthInputStream.java
@@ -25,10 +25,16 @@ import java.io.InputStream;
  * An {@link InputStream} backed by a {@link ByteString} that implements {@link KnownLength}.
  */
 public final class KnownLengthInputStream extends InputStream implements KnownLength {
+  private final ByteString byteString;
   private final InputStream delegate;
 
   public KnownLengthInputStream(ByteString byteString) {
+    this.byteString = byteString;
     this.delegate = byteString.newInput();
+  }
+
+  public ByteString getByteString() {
+    return byteString;
   }
 
   @Override

--- a/xds/src/test/java/io/grpc/xds/ExternalProcessorFilterTest.java
+++ b/xds/src/test/java/io/grpc/xds/ExternalProcessorFilterTest.java
@@ -24,6 +24,7 @@ import io.envoyproxy.envoy.extensions.filters.http.ext_proc.v3.ExtProcOverrides;
 import io.envoyproxy.envoy.extensions.filters.http.ext_proc.v3.ExtProcPerRoute;
 import io.envoyproxy.envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor;
 import io.envoyproxy.envoy.extensions.filters.http.ext_proc.v3.ProcessingMode;
+import io.grpc.MetricRecorder;
 import io.grpc.NameResolver;
 import io.grpc.NameResolverProvider;
 import io.grpc.NameResolverRegistry;
@@ -340,5 +341,116 @@ public class ExternalProcessorFilterTest {
         provider.parseFilterConfigOverride(Any.pack(structMessage), filterContext);
 
     assertThat(result.errorDetail).contains("Invalid proto:");
+  }
+
+  @Test
+  public void requiresPayloadAccess_defaultProcessingMode_returnsFalse() throws Exception {
+    ExternalProcessor proto = createBaseProto(extProcServerName).build();
+    ExternalProcessorFilterConfig config =
+        provider.parseFilterConfig(Any.pack(proto), filterContext).config;
+
+    try (ExternalProcessorFilter filter = provider.newInstance(
+        Filter.FilterContext.create("test-filter", new MetricRecorder() {}))) {
+      assertThat(filter.requiresPayloadAccess(config, null)).isFalse();
+    }
+  }
+
+  @Test
+  public void requiresPayloadAccess_explicitNone_returnsFalse() throws Exception {
+    ExternalProcessor proto = createBaseProto(extProcServerName)
+        .setProcessingMode(ProcessingMode.newBuilder()
+            .setRequestBodyMode(ProcessingMode.BodySendMode.NONE)
+            .setResponseBodyMode(ProcessingMode.BodySendMode.NONE)
+            .build())
+        .build();
+    ExternalProcessorFilterConfig config =
+        provider.parseFilterConfig(Any.pack(proto), filterContext).config;
+
+    try (ExternalProcessorFilter filter = provider.newInstance(
+        Filter.FilterContext.create("test-filter", new MetricRecorder() {}))) {
+      assertThat(filter.requiresPayloadAccess(config, null)).isFalse();
+    }
+  }
+
+  @Test
+  public void requiresPayloadAccess_requestBodyGrpc_returnsTrue() throws Exception {
+    ExternalProcessor proto = createBaseProto(extProcServerName)
+        .setProcessingMode(ProcessingMode.newBuilder()
+            .setRequestBodyMode(ProcessingMode.BodySendMode.GRPC)
+            .build())
+        .build();
+    ExternalProcessorFilterConfig config =
+        provider.parseFilterConfig(Any.pack(proto), filterContext).config;
+
+    try (ExternalProcessorFilter filter = provider.newInstance(
+        Filter.FilterContext.create("test-filter", new MetricRecorder() {}))) {
+      assertThat(filter.requiresPayloadAccess(config, null)).isTrue();
+    }
+  }
+
+  @Test
+  public void requiresPayloadAccess_responseBodyGrpc_returnsTrue() throws Exception {
+    ExternalProcessor proto = createBaseProto(extProcServerName)
+        .setProcessingMode(ProcessingMode.newBuilder()
+            .setResponseBodyMode(ProcessingMode.BodySendMode.GRPC)
+            .setResponseTrailerMode(ProcessingMode.HeaderSendMode.SEND)
+            .build())
+        .build();
+    ExternalProcessorFilterConfig config =
+        provider.parseFilterConfig(Any.pack(proto), filterContext).config;
+
+    try (ExternalProcessorFilter filter = provider.newInstance(
+        Filter.FilterContext.create("test-filter", new MetricRecorder() {}))) {
+      assertThat(filter.requiresPayloadAccess(config, null)).isTrue();
+    }
+  }
+
+  @Test
+  public void requiresPayloadAccess_overrideTurnsOnPayloadAccess_returnsTrue() throws Exception {
+    ExternalProcessor proto = createBaseProto(extProcServerName).build();
+    ExternalProcessorFilterConfig config =
+        provider.parseFilterConfig(Any.pack(proto), filterContext).config;
+
+    ExtProcPerRoute perRoute = ExtProcPerRoute.newBuilder()
+        .setOverrides(ExtProcOverrides.newBuilder()
+            .setProcessingMode(ProcessingMode.newBuilder()
+                .setRequestBodyMode(ProcessingMode.BodySendMode.GRPC)
+                .build())
+            .build())
+        .build();
+    ExternalProcessorFilterOverrideConfig overrideConfig =
+        provider.parseFilterConfigOverride(Any.pack(perRoute), filterContext).config;
+
+    try (ExternalProcessorFilter filter = provider.newInstance(
+        Filter.FilterContext.create("test-filter", new MetricRecorder() {}))) {
+      assertThat(filter.requiresPayloadAccess(config, overrideConfig)).isTrue();
+    }
+  }
+
+  @Test
+  public void requiresPayloadAccess_overrideTurnsOffPayloadAccess_returnsFalse() throws Exception {
+    ExternalProcessor proto = createBaseProto(extProcServerName)
+        .setProcessingMode(ProcessingMode.newBuilder()
+            .setRequestBodyMode(ProcessingMode.BodySendMode.GRPC)
+            .build())
+        .build();
+    ExternalProcessorFilterConfig config =
+        provider.parseFilterConfig(Any.pack(proto), filterContext).config;
+
+    ExtProcPerRoute perRoute = ExtProcPerRoute.newBuilder()
+        .setOverrides(ExtProcOverrides.newBuilder()
+            .setProcessingMode(ProcessingMode.newBuilder()
+                .setRequestBodyMode(ProcessingMode.BodySendMode.NONE)
+                .setResponseBodyMode(ProcessingMode.BodySendMode.NONE)
+                .build())
+            .build())
+        .build();
+    ExternalProcessorFilterOverrideConfig overrideConfig =
+        provider.parseFilterConfigOverride(Any.pack(perRoute), filterContext).config;
+
+    try (ExternalProcessorFilter filter = provider.newInstance(
+        Filter.FilterContext.create("test-filter", new MetricRecorder() {}))) {
+      assertThat(filter.requiresPayloadAccess(config, overrideConfig)).isFalse();
+    }
   }
 }

--- a/xds/src/test/java/io/grpc/xds/StatefulFilter.java
+++ b/xds/src/test/java/io/grpc/xds/StatefulFilter.java
@@ -21,10 +21,16 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Message;
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.MethodDescriptor;
 import io.grpc.ServerInterceptor;
 import java.util.ConcurrentModificationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
@@ -38,10 +44,22 @@ class StatefulFilter implements Filter {
   private final AtomicBoolean shutdown = new AtomicBoolean();
 
   final int idx;
+  private final boolean requiresPayloadAccess;
   @Nullable volatile String lastCfg = null;
 
   public StatefulFilter(int idx) {
+    this(idx, false);
+  }
+
+  public StatefulFilter(int idx, boolean requiresPayloadAccess) {
     this.idx = idx;
+    this.requiresPayloadAccess = requiresPayloadAccess;
+  }
+
+  @Override
+  public boolean requiresPayloadAccess(
+      FilterConfig config, @Nullable FilterConfig overrideConfig) {
+    return requiresPayloadAccess;
   }
 
   public boolean isShutdown() {
@@ -67,6 +85,21 @@ class StatefulFilter implements Filter {
     return null;
   }
 
+  @Nullable
+  @Override
+  public ClientInterceptor buildClientInterceptor(
+      FilterConfig config,
+      @Nullable FilterConfig overrideConfig,
+      ScheduledExecutorService scheduler) {
+    return new ClientInterceptor() {
+      @Override
+      public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+          MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+        return next.newCall(method, callOptions);
+      }
+    };
+  }
+
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder().append("StatefulFilter{")
@@ -80,16 +113,26 @@ class StatefulFilter implements Filter {
   static final class Provider implements Filter.Provider {
 
     private final String typeUrl;
+    private final boolean requiresPayloadAccess;
     private final ConcurrentMap<Integer, StatefulFilter> instances = new ConcurrentHashMap<>();
 
     volatile int counter;
 
     Provider() {
-      this(DEFAULT_TYPE_URL);
+      this(DEFAULT_TYPE_URL, false);
+    }
+
+    Provider(boolean requiresPayloadAccess) {
+      this(DEFAULT_TYPE_URL, requiresPayloadAccess);
     }
 
     Provider(String typeUrl) {
+      this(typeUrl, false);
+    }
+
+    Provider(String typeUrl, boolean requiresPayloadAccess) {
       this.typeUrl = typeUrl;
+      this.requiresPayloadAccess = requiresPayloadAccess;
     }
 
     @Override
@@ -109,7 +152,7 @@ class StatefulFilter implements Filter {
 
     @Override
     public synchronized StatefulFilter newInstance(FilterContext context) {
-      StatefulFilter filter = new StatefulFilter(counter++);
+      StatefulFilter filter = new StatefulFilter(counter++, requiresPayloadAccess);
       instances.put(filter.idx, filter);
       return filter;
     }

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -1713,7 +1713,12 @@ public class XdsNameResolverTest {
   }
 
   private StatefulFilter.Provider filterStateTestSetupResolver() {
-    StatefulFilter.Provider statefulFilterProvider = new StatefulFilter.Provider();
+    return filterStateTestSetupResolver(false);
+  }
+
+  private StatefulFilter.Provider filterStateTestSetupResolver(boolean requiresPayloadAccess) {
+    StatefulFilter.Provider statefulFilterProvider =
+        new StatefulFilter.Provider(requiresPayloadAccess);
     FilterRegistry filterRegistry = FilterRegistry.newRegistry()
         .register(statefulFilterProvider, ROUTER_FILTER_PROVIDER);
     resolver = new XdsNameResolver(targetUri, null, AUTHORITY, null, serviceConfigParser,
@@ -3165,79 +3170,30 @@ public class XdsNameResolverTest {
   }
 
   @Test
-  public void rawMessageClientInterceptor_flagFalse() {
-    String origClientProp = System.getProperty("GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_CLIENT");
-    String origServerProp = System.getProperty("GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_SERVER");
-    System.setProperty("GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_CLIENT", "false");
-    System.setProperty("GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_SERVER", "false");
-    try {
-      filterStateTestSetupResolver();
-      FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
-      VirtualHost vhost = filterStateTestVhost();
+  public void rawMessageClientInterceptor_filterDoesNotRequirePayloadAccess() {
+    filterStateTestSetupResolver(false);
+    FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
+    VirtualHost vhost = filterStateTestVhost();
 
-      xdsClient.deliverLdsUpdateWithFilters(vhost, filterStateTestConfigs(STATEFUL_1));
-      createAndDeliverClusterUpdates(xdsClient, cluster1);
+    xdsClient.deliverLdsUpdateWithFilters(vhost, filterStateTestConfigs(STATEFUL_1));
+    createAndDeliverClusterUpdates(xdsClient, cluster1);
 
-      // When flags are false, RawMessageClientInterceptor is not added.
-      assertClusterResolutionResult(call1, cluster1);
-      assertThat(testCall.methodDescriptor).isSameInstanceAs(call1.methodDescriptor);
-    } finally {
-      restoreProperty("GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_CLIENT", origClientProp);
-      restoreProperty("GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_SERVER", origServerProp);
-    }
+    // When filter does not require payload access, RawMessageClientInterceptor is not added.
+    assertClusterResolutionResult(call1, cluster1);
+    assertThat(testCall.methodDescriptor).isSameInstanceAs(call1.methodDescriptor);
   }
 
   @Test
-  public void rawMessageClientInterceptor_flagTrue() {
-    String origClientProp = System.getProperty("GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_CLIENT");
-    String origServerProp = System.getProperty("GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_SERVER");
+  public void rawMessageClientInterceptor_filterRequiresPayloadAccess() {
+    filterStateTestSetupResolver(true);
+    FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
+    VirtualHost vhost = filterStateTestVhost();
 
-    // When GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_CLIENT is true, RawMessageClientInterceptor is added.
-    System.setProperty("GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_CLIENT", "true");
-    System.setProperty("GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_SERVER", "false");
-    try {
-      filterStateTestSetupResolver();
-      FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
-      VirtualHost vhost = filterStateTestVhost();
+    xdsClient.deliverLdsUpdateWithFilters(vhost, filterStateTestConfigs(STATEFUL_1));
+    createAndDeliverClusterUpdates(xdsClient, cluster1);
 
-      xdsClient.deliverLdsUpdateWithFilters(vhost, filterStateTestConfigs(STATEFUL_1));
-      createAndDeliverClusterUpdates(xdsClient, cluster1);
-
-      assertClusterResolutionResult(call1, cluster1);
-      assertThat(testCall.methodDescriptor).isNotSameInstanceAs(call1.methodDescriptor);
-    } finally {
-      restoreProperty("GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_CLIENT", origClientProp);
-      restoreProperty("GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_SERVER", origServerProp);
-    }
-
-    resolver.shutdown();
-    reset(mockListener);
-    when(mockListener.onResult2(any())).thenReturn(Status.OK);
-
-    // When GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_SERVER is true, RawMessageClientInterceptor is added.
-    System.setProperty("GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_CLIENT", "false");
-    System.setProperty("GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_SERVER", "true");
-    try {
-      filterStateTestSetupResolver();
-      FakeXdsClient xdsClient = (FakeXdsClient) resolver.getXdsClient();
-      VirtualHost vhost = filterStateTestVhost();
-
-      xdsClient.deliverLdsUpdateWithFilters(vhost, filterStateTestConfigs(STATEFUL_1));
-      createAndDeliverClusterUpdates(xdsClient, cluster1);
-
-      assertClusterResolutionResult(call1, cluster1);
-      assertThat(testCall.methodDescriptor).isNotSameInstanceAs(call1.methodDescriptor);
-    } finally {
-      restoreProperty("GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_CLIENT", origClientProp);
-      restoreProperty("GRPC_EXPERIMENTAL_XDS_EXT_PROC_ON_SERVER", origServerProp);
-    }
-  }
-
-  private static void restoreProperty(String key, @Nullable String value) {
-    if (value == null) {
-      System.clearProperty(key);
-    } else {
-      System.setProperty(key, value);
-    }
+    // When a filter requires payload access, RawMessageClientInterceptor is added.
+    assertClusterResolutionResult(call1, cluster1);
+    assertThat(testCall.methodDescriptor).isNotSameInstanceAs(call1.methodDescriptor);
   }
 }

--- a/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
+++ b/xds/src/test/java/io/grpc/xds/XdsNameResolverTest.java
@@ -129,6 +129,7 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
 import org.junit.After;
@@ -3098,6 +3099,69 @@ public class XdsNameResolverTest {
     String response = ClientCalls.blockingUnaryCall(
         channel, METHOD_SAY_HELLO, CallOptions.DEFAULT, "World");
     assertThat(response).isEqualTo("Hello World");
+  }
+
+  @Test
+  public void rawMessageClientInterceptor_retriesPreservePayload() throws Exception {
+    String serverName = InProcessServerBuilder.generateName();
+    AtomicInteger attempts = new AtomicInteger();
+    List<String> receivedMessages = new ArrayList<>();
+    ServerServiceDefinition serviceDef = ServerServiceDefinition.builder("test.TestService")
+        .addMethod(METHOD_SAY_HELLO, new ServerCallHandler<String, String>() {
+          @Override
+          public ServerCall.Listener<String> startCall(
+              ServerCall<String, String> call, Metadata headers) {
+            call.request(1);
+            return new ServerCall.Listener<String>() {
+              @Override
+              public void onMessage(String message) {
+                receivedMessages.add(message);
+                if (attempts.incrementAndGet() == 1) {
+                  call.close(Status.UNAVAILABLE.withDescription("transient error"), new Metadata());
+                } else {
+                  call.sendHeaders(new Metadata());
+                  call.sendMessage("Hello " + message);
+                  call.close(Status.OK, new Metadata());
+                }
+              }
+            };
+          }
+        }).build();
+
+    grpcCleanup.register(InProcessServerBuilder.forName(serverName)
+        .directExecutor()
+        .addService(serviceDef)
+        .build()
+        .start());
+
+    Map<String, Object> retryPolicy = new HashMap<>();
+    retryPolicy.put("maxAttempts", 2D);
+    retryPolicy.put("initialBackoff", "0.01s");
+    retryPolicy.put("maxBackoff", "0.1s");
+    retryPolicy.put("backoffMultiplier", 1D);
+    retryPolicy.put("retryableStatusCodes", ImmutableList.of("UNAVAILABLE"));
+
+    Map<String, Object> methodConfig = new HashMap<>();
+    Map<String, Object> name = new HashMap<>();
+    name.put("service", "test.TestService");
+    methodConfig.put("name", ImmutableList.of(name));
+    methodConfig.put("retryPolicy", retryPolicy);
+
+    Map<String, Object> serviceConfig = new HashMap<>();
+    serviceConfig.put("methodConfig", ImmutableList.of(methodConfig));
+
+    Channel channel = grpcCleanup.register(InProcessChannelBuilder.forName(serverName)
+        .directExecutor()
+        .enableRetry()
+        .defaultServiceConfig(serviceConfig)
+        .intercept(new XdsNameResolver.RawMessageClientInterceptor())
+        .build());
+
+    String response = ClientCalls.blockingUnaryCall(
+        channel, METHOD_SAY_HELLO, CallOptions.DEFAULT, "World");
+    assertThat(response).isEqualTo("Hello World");
+    assertThat(attempts.get()).isEqualTo(2);
+    assertThat(receivedMessages).containsExactly("World", "World");
   }
 
   @Test


### PR DESCRIPTION
### 1. Supporting retries
Previously, `RawMessageClientInterceptor.sendMessage()` forwarded a single-use
InputStream directly to `rawCall.sendMessage()`. When retries were triggered by
RetriableStream, attempt 1 drained the InputStream to EOF. Subsequent retry
attempts would then serialize the already-drained stream, sending an empty (0-byte)
request payload.

Fix this by:
1. Buffering the request stream into an immutable `ByteString` (using `Drainable`
   when supported) in `RawMessageClientInterceptor.sendMessage()` and wrapping it
   in a `KnownLengthInputStream`.
2. Exposing `getByteString()` on `KnownLengthInputStream`.
3. Having `RAW_MARSHALLER.stream()` return a fresh `KnownLengthInputStream` wrapping
   the underlying `ByteString` on each attempt, allowing retries to read the payload
   from byte 0.

### 2. Conditional addition of `RawMessageClientInterceptor` 

Also we need to only install `RawMessageClientInterceptor` when a filter requires payload access to avoid the performance hit for non ext_proc cases. As suggested in the [grfc discussion](https://github.com/grpc/proposal/pull/484#discussion_r3960018060), introduce `Filter.requiresPayloadAccess(config, overrideConfig)` to allow filters to declare whether they need access to message payloads. Update `ExternalProcessorFilter`   to implement this method, returning false when body send mode is NONE for both request and response. Update `XdsNameResolver` to only install `RawMessageClientInterceptor` when at least one configured filter requires payload access. Generalize `ExternalProcessorClientInterceptor` to support generic request/response types when payload interception is not needed.

#### Generalizing `ExternalProcessorClientInterceptor` to Support Pass-through Types

`ExternalProcessorClientInterceptor` previously hardcoded `ClientCall<InputStream, InputStream>` and `SimpleForwardingClientCallListener<InputStream>`, assuming `RawMessageClientInterceptor` was always present earlier in the chain to convert application messages to `InputStream`.

Now that `RawMessageClientInterceptor` is omitted when body send mode is `NONE`, `ExternalProcessorClientInterceptor` directly handles the application's request and response types (`ReqT`, `RespT`). `DataPlaneClientCall` and `DataPlaneListener` were generalized to `<ReqT, RespT>` to avoid compiler-generated synthetic bridge casts to `InputStream`, which would otherwise result in a runtime `ClassCastException` when sending or receiving application messages.

Fixes #13010