### PR TITLE
core: Handle ProxySelector IllegalArgumentException

### DIFF
--- a/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
+++ b/core/src/main/java/io/grpc/internal/ProxyDetectorImpl.java
@@ -206,7 +206,15 @@ class ProxyDetectorImpl implements ProxyDetector {
       return null;
     }
 
-    List<Proxy> proxies = proxySelector.select(uri);
+    List<Proxy> proxies;
+    try {
+      proxies = proxySelector.select(uri);
+    } catch (IllegalArgumentException e) {
+      throw new IOException(
+          "ProxySelector " + proxySelector.getClass().getName()
+              + " threw an exception while selecting a proxy",
+          e);
+    }
     // ProxySelector.select(URI) is contractually required to return a non-null, non-empty list.
     // Surface the offending implementation's class name so a broken ProxySelector can be fixed.
     if (proxies == null || proxies.isEmpty()) {

--- a/core/src/test/java/io/grpc/internal/ProxyDetectorImplTest.java
+++ b/core/src/test/java/io/grpc/internal/ProxyDetectorImplTest.java
@@ -214,4 +214,19 @@ public class ProxyDetectorImplTest {
     assertTrue(e.getMessage(), e.getMessage().contains("null"));
     assertTrue(e.getMessage(), e.getMessage().contains(proxySelector.getClass().getName()));
   }
+
+  @Test
+  public void throwsWhenProxySelectorThrowsIllegalArgumentException() throws Exception {
+    IllegalArgumentException cause =
+        new IllegalArgumentException("port out of range: 899858473");
+    when(proxySelector.select(any(URI.class))).thenThrow(cause);
+
+    IOException exception =
+        assertThrows(IOException.class, () -> proxyDetector.proxyFor(destination));
+
+    assertEquals(cause, exception.getCause());
+    assertTrue(
+        exception.getMessage(),
+        exception.getMessage().contains(proxySelector.getClass().getName()));
+  }
 }


### PR DESCRIPTION
Fixes #13052.

Android’s `DefaultProxySelector.select()` may throw `IllegalArgumentException` when the system proxy configuration contains an invalid port. This unchecked exception currently escapes the DNS resolver task and can terminate the process.

This change catches the exception at the `ProxySelector.select()` call and wraps it in an `IOException`. The original cause is preserved, and the exception message identifies the `ProxySelector` implementation.

`DnsNameResolver` already handles an `IOException` from proxy detection as an `UNAVAILABLE` name-resolution result. This allows the resolver to fail cleanly instead of letting the unchecked exception escape.

This intentionally avoids silently falling back to a direct connection. It follows the fail-cleanly approach used for invalid `ProxySelector` results in #12793 and avoids bypassing a configured proxy.

**Testing**

1. Added a regression test verifying that the exception is wrapped, the original cause is preserved, and the `ProxySelector` implementation is identified.
2. Ran `.\gradlew.bat :grpc-core:test --tests "io.grpc.internal.ProxyDetectorImplTest"`
3. All 11 tests passed on Windows with Temurin JDK 17.
